### PR TITLE
End to end test

### DIFF
--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -1,0 +1,32 @@
+name: Build charm
+
+on: 
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  get-runner-image:
+    name: Get runner image
+    uses: canonical/operator-workflows/.github/workflows/get_runner_image.yaml@main
+  build-charm:
+    name: Build the charm
+    needs: get-runner-image
+    runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Enable network in LXD
+        run: sudo iptables -I DOCKER-USER  -j ACCEPT
+      - name: Add user to lxd group
+        run: sudo adduser runner lxd
+      - name: Initialize LXD
+        run: sudo -u runner lxd init --auto
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+      - name: Pack charm
+        run: sudo -u runner charmcraft pack
+      - uses: actions/upload-artifact@v3
+        with:
+          name: github-runner-charm
+          path: github-runner_*.charm
+          retention-days: 5

--- a/.github/workflows/build_charm.yaml
+++ b/.github/workflows/build_charm.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Enable network in LXD
-        run: sudo iptables -I DOCKER-USER  -j ACCEPT
+        run: sudo iptables -I DOCKER-USER -j ACCEPT
       - name: Add user to lxd group
         run: sudo adduser runner lxd
       - name: Initialize LXD

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
     steps:
       - uses: actions/checkout@v3
+      - name: Initialize LXD
+        run: sudo lxd init --auto
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
       - name: Pack charm

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -7,8 +7,17 @@ on:
 
 jobs:
   e2e-test:
-    name: end to end test
+    name: basic end to end test
     runs-on: [self-hosted, linux, x64, e2e-runner]
+    steps:
+      - name: Echo hello world
+        run: echo "hello world"
+  e2e-respawn-test:
+    name: respawning runner end to end test
+    runs-on: [self-hosted, linux, x64, e2e-runner]
+    strategy:
+      matrix:
+        runner: [1, 2]
     steps:
       - name: Echo hello world
         run: echo "hello world"

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -15,12 +15,14 @@ jobs:
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
     steps:
       - uses: actions/checkout@v3
+      - name: Add user to lxd group
+        run: sudo adduser runner lxd
       - name: Initialize LXD
         run: sudo lxd init --auto
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
       - name: Pack charm
-        run: charmcraft pack
+        run: sudo -u runner charmcraft pack
       - uses: actions/upload-artifact@v3
         with:
           name: github-runner-charm

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -10,7 +10,7 @@ jobs:
     name: end to end test
     runs-on: [self-hosted, linux, x64, e2e-runner]
     strategy:
-      # Two tests are schedule to test if the charm is able to spawn new runners.
+      # Two tests are scheduled to test if the charm is able to spawn new runners.
       matrix:
         runner: [1, 2]
     steps:

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -3,6 +3,7 @@ name: End to end tests
 on: 
   pull_request:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   # Add a job for triggering the build, deploy, and configure the charm.

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -29,10 +29,6 @@ jobs:
         with:
           name: github-runner-charm
           path: github-runner_*.charm
-      - uses: mxschmitt/action-tmate@v3
-        if: ${{ failure() }}
-        with:
-          limit-access-to-actor: true
   e2e-test:
     name: end to end test
     runs-on: [self-hosted, linux, x64, demo-runner]

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -21,4 +21,3 @@ jobs:
     steps:
       - name: Echo hello world
         run: echo "hello world"
- 

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -14,8 +14,9 @@ jobs:
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
     steps:
       - uses: actions/checkout@v3
-      - name: Initialize LXD
-        run: sudo lxd init --auto
+      - uses: mxschmitt/action-tmate@v3
+      - name: Add user to lxd group
+        run: sudo adduser ubuntu lxd
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
       - name: Pack charm

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -25,7 +25,7 @@ jobs:
           name: github-runner-charm
           path: github-runner_*.charm
       - uses: mxschmitt/action-tmate@v3
-        if: $
+        if: ${{ failure() }}
         with:
           limit-access-to-actor: true
       

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
     steps:
       - uses: actions/checkout@v3
-      - uses: mxschmitt/action-tmate@v3
       - name: Add user to lxd group
         run: sudo adduser ubuntu lxd
       - name: Install charmcraft
@@ -25,4 +24,8 @@ jobs:
         with:
           name: github-runner-charm
           path: github-runner_*.charm
+      - uses: mxschmitt/action-tmate@v3
+        if: $
+        with:
+          limit-access-to-actor: true
       

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -5,31 +5,11 @@ on:
   workflow_call:
 
 jobs:
-  get-runner-image:
-    name: Get runner image
-    uses: canonical/operator-workflows/.github/workflows/get_runner_image.yaml@main
-  build-charm:
-    name: Build the charm
-    needs: get-runner-image
-    runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
+  # Add a job for triggering the build, deploy, and configure the charm.
+  hello-world-test:
+    name: hello world test
+    runs-on: [self-hosted, linux, x64, demo-runner]
     steps:
-      - uses: actions/checkout@v3
-      - name: Add runner user to lxd group
-        run: sudo adduser runner lxd
-      - name: Switch user to apply group change
-        run: sudo su runner
-      - name: Initialize LXD
-        run: sudo lxd init --auto
-      - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
-      - name: Pack charm
-        run: charmcraft pack
-      - uses: actions/upload-artifact@v3
-        with:
-          name: github-runner-charm
-          path: github-runner_*.charm
-      - uses: mxschmitt/action-tmate@v3
-        if: ${{ failure() }}
-        with:
-          limit-access-to-actor: true
-      
+      - name: Echo hello world
+        run: echo "hello world"
+ 

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -14,8 +14,12 @@ jobs:
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
     steps:
       - uses: actions/checkout@v3
-      - name: Add user to lxd group
-        run: sudo adduser ubuntu lxd
+      - name: Add runner user to lxd group
+        run: sudo adduser runner lxd
+      - name: Switch user to apply group change
+        run: sudo su runner
+      - name: Initialize LXD
+        run: sudo lxd init --auto
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
       - name: Pack charm

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -6,9 +6,31 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Add a job for triggering the build, deploy, and configure the charm.
-  hello-world-test:
-    name: hello world test
+  get-runner-image:
+    name: Get runner image
+    uses: canonical/operator-workflows/.github/workflows/get_runner_image.yaml@main
+  build-charm:
+    name: Build the charm
+    needs: get-runner-image
+    runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Initialize LXD
+        run: sudo lxd init --auto
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+      - name: Pack charm
+        run: charmcraft pack
+      - uses: actions/upload-artifact@v3
+        with:
+          name: github-runner-charm
+          path: github-runner_*.charm
+      - uses: mxschmitt/action-tmate@v3
+        if: ${{ failure() }}
+        with:
+          limit-access-to-actor: true
+  e2e-test:
+    name: end to end test
     runs-on: [self-hosted, linux, x64, demo-runner]
     steps:
       - name: Echo hello world

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -1,0 +1,25 @@
+name: End to end tests
+
+on: 
+  pull_request:
+  workflow_call:
+
+jobs:
+  get-runner-image:
+    name: Get runner image
+    uses: canonical/operator-workflows/.github/workflows/get_runner_image.yaml@main
+  build-charm:
+    name: Build the charm
+    needs: get-runner-image
+    runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+      - name: Pack charm
+        run: charmcraft pack
+      - uses: actions/upload-artifact@v3
+        with:
+          name: github-runner-charm
+          path: github-runner_*.charm
+      

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -15,10 +15,12 @@ jobs:
     runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
     steps:
       - uses: actions/checkout@v3
+      - name: Enable network in LXD
+        run: sudo iptables -I DOCKER-USER  -j ACCEPT
       - name: Add user to lxd group
         run: sudo adduser runner lxd
       - name: Initialize LXD
-        run: sudo lxd init --auto
+        run: sudo -u runner lxd init --auto
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
       - name: Pack charm

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -6,32 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  get-runner-image:
-    name: Get runner image
-    uses: canonical/operator-workflows/.github/workflows/get_runner_image.yaml@main
-  build-charm:
-    name: Build the charm
-    needs: get-runner-image
-    runs-on: ${{ needs.get-runner-image.outputs.runs-on }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Enable network in LXD
-        run: sudo iptables -I DOCKER-USER  -j ACCEPT
-      - name: Add user to lxd group
-        run: sudo adduser runner lxd
-      - name: Initialize LXD
-        run: sudo -u runner lxd init --auto
-      - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
-      - name: Pack charm
-        run: sudo -u runner charmcraft pack
-      - uses: actions/upload-artifact@v3
-        with:
-          name: github-runner-charm
-          path: github-runner_*.charm
   e2e-test:
     name: end to end test
-    runs-on: [self-hosted, linux, x64, demo-runner]
+    runs-on: [self-hosted, linux, x64, e2e-runner]
     steps:
       - name: Echo hello world
         run: echo "hello world"

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -7,15 +7,10 @@ on:
 
 jobs:
   e2e-test:
-    name: basic end to end test
-    runs-on: [self-hosted, linux, x64, e2e-runner]
-    steps:
-      - name: Echo hello world
-        run: echo "hello world"
-  e2e-respawn-test:
-    name: respawning runner end to end test
+    name: end to end test
     runs-on: [self-hosted, linux, x64, e2e-runner]
     strategy:
+      # Two tests are schedule to test if the charm is able to spawn new runners.
       matrix:
         runner: [1, 2]
     steps:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,5 +14,3 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "22.04"
-    - name: "ubuntu"
-      channel: "20.04"

--- a/config.yaml
+++ b/config.yaml
@@ -10,12 +10,6 @@ options:
       default: ""
       description:
         The GitHub Personal Access Token for registering the self-hosted runners.
-  containers:
-      type: int
-      default: 0
-      description: >
-        The number of container runners. This charm will spawn or destroy container
-        runners to match this setting.
   virtual-machines:
       type: int
       default: 0
@@ -49,14 +43,3 @@ options:
       default: 60
       description: >
         Minutes between each check for new versions of the runner binary.
-  virt-type:
-      type: string
-      default: "container"
-      description: >
-        DEPRECATED: both `containers` and `virtual-machines` are supported at the same time
-        Virtualization type for runners, either container or virtual-machine.
-  quantity:
-      type: int
-      default: 0
-      description: >
-        DEPRECATED: use `containers` and `virtual-machines` Quantity of runners to maintain.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,4 +19,3 @@ description: >
 
 series:
     - jammy
-    - focal

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ requests
 jinja2
 ghapi
 pylxd
-# Newer version does not work with default OpenSSL version on focal/jammy.
+# Newer version does not work with default OpenSSL version on jammy.
 cryptography <= 38.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ requests
 jinja2
 ghapi
 pylxd
-# Newer version does not work with default OpenSSL version on focal.
+# Newer version does not work with default OpenSSL version on focal/jammy.
 cryptography <= 38.0.4

--- a/script/deploy_runner.sh
+++ b/script/deploy_runner.sh
@@ -14,7 +14,7 @@ DOWNLOAD_LOCATION=$(curl \
   "https://api.github.com/repos/canonical/github-runner-operator/actions/artifacts/{$GITHUB_RUNNER_ARTIFACT_ID}/zip" \
   | grep location)
 # Parse out the URL from the format "Location: URL\r".
-LOCATION_ARRAY=($DOWNLOAD_LOCATION)
+read -ra LOCATION_ARRAY <<< "$DOWNLOAD_LOCATION"
 URL=$(echo "${LOCATION_ARRAY[1]}" | tr -d '\r')
 
 # Download the github runner charm.

--- a/script/deploy_runner.sh
+++ b/script/deploy_runner.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+rm -f github_runner.zip
+
+# Request a download URL for the artifact.
+echo "Requesting github runner charm download link..."
+DOWNLOAD_LOCATION=$(curl \
+  --head \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}"\
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/canonical/github-runner-operator/actions/artifacts/{$GITHUB_RUNNER_ARTIFACT_ID}/zip" \
+  | grep location)
+# Parse out the URL from the format "Location: URL\r".
+LOCATION_ARRAY=($DOWNLOAD_LOCATION)
+URL=$(echo "${LOCATION_ARRAY[1]}" | tr -d '\r')
+
+# Download the github runner charm.
+echo "Downloading github runner charm..."
+curl -o github_runner.zip "$URL"
+
+# Decompress the zip.
+echo "Decompressing github runner charm..."
+unzip -p github_runner.zip > github-runner.charm
+rm github_runner.zip
+
+# Deploy the charm.
+juju deploy ./github-runner.charm --series=jammy e2e-runner
+juju config e2e-runner token="$GITHUB_TOKEN" path=canonical/github-runner-operator virtual-machines=1

--- a/script/remove_runner.sh
+++ b/script/remove_runner.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+juju remove-application e2e-runner --force

--- a/script/remove_runner.sh
+++ b/script/remove_runner.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-juju remove-application e2e-runner --force
+juju remove-application e2e-runner --force --destroy-storage --no-wait

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,7 +17,6 @@ from ops.charm import (
     ConfigChangedEvent,
     InstallEvent,
     StopEvent,
-    UpdateStatusEvent,
     UpgradeCharmEvent,
 )
 from ops.framework import EventBase, StoredState
@@ -134,7 +133,6 @@ class GithubRunnerCharm(CharmBase):
         self.on.define_event("update_runner_bin", UpdateRunnerBinEvent)
 
         self.framework.observe(self.on.install, self._on_install)
-        self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.reconcile_runners, self._on_reconcile_runners)
@@ -223,33 +221,6 @@ class GithubRunnerCharm(CharmBase):
                 self.unit.status = MaintenanceStatus(f"Failed to start runners: {err}")
         else:
             self.unit.status = BlockedStatus("Missing token or org/repo path config")
-
-    def _on_update_status(self, _event: UpdateStatusEvent) -> None:
-        """Handle the update status of charm.
-
-        Args:
-            event: Event of charm update status.
-        """
-        vm_num = self.config["virtual-machines"]
-
-        runner_manager = self._get_runner_manager()
-        if not runner_manager:
-            self.unit.status = BlockedStatus("Missing token or org/repo path config")
-            return
-
-        runner_info = runner_manager.get_github_info()
-
-        vm_count = 0
-        for info in runner_info:
-            if info.status == GitHubRunnerStatus.ONLINE:
-                vm_count += 1
-
-        logger.info("Expected runner count: %i, Online runner count: %i", vm_num, vm_count)
-
-        if vm_num != vm_count:
-            self.unit.status = MaintenanceStatus("Waiting runners number to be reconciled")
-        else:
-            self.unit.status = ActiveStatus()
 
     @catch_unexpected_charm_errors
     def _on_upgrade_charm(self, _event: UpgradeCharmEvent) -> None:
@@ -342,7 +313,7 @@ class GithubRunnerCharm(CharmBase):
             event: Event of reconciling the runner state.
         """
         if not RunnerManager.runner_bin_path.is_file():
-            logger.warn("Unable to reconcile due to missing runner binary")
+            logger.warning("Unable to reconcile due to missing runner binary")
             return
 
         runner_manager = self._get_runner_manager()

--- a/src/charm.py
+++ b/src/charm.py
@@ -244,6 +244,8 @@ class GithubRunnerCharm(CharmBase):
             if info.status == GitHubRunnerStatus.ONLINE:
                 vm_count += 1
 
+        logger.info("Expected runner count: %i, Online runner count: %i", vm_num, vm_count)
+
         if vm_num != vm_count:
             self.unit.status = MaintenanceStatus("Waiting runners number to be reconciled")
         else:

--- a/src/charm.py
+++ b/src/charm.py
@@ -200,7 +200,7 @@ class GithubRunnerCharm(CharmBase):
 
         runner_manager = self._get_runner_manager()
         if runner_manager:
-            self.unit.status = MaintenanceStatus("Installing runner binary")
+            self.unit.status = MaintenanceStatus("Downloading runner binary")
             try:
                 runner_info = runner_manager.get_latest_runner_bin_url()
                 logger.info(

--- a/src/charm.py
+++ b/src/charm.py
@@ -216,6 +216,7 @@ class GithubRunnerCharm(CharmBase):
             self.unit.status = MaintenanceStatus("Starting runners")
             try:
                 self._reconcile_runners(runner_manager)
+                self.unit.status = ActiveStatus()
             except RunnerError as err:
                 logger.exception("Failed to start runners")
                 self.unit.status = MaintenanceStatus(f"Failed to start runners: {err}")

--- a/src/charm.py
+++ b/src/charm.py
@@ -341,8 +341,13 @@ class GithubRunnerCharm(CharmBase):
         Args:
             event: Event of reconciling the runner state.
         """
+        if not RunnerManager.runner_bin_path.is_file():
+            logger.warn("Unable to reconcile due to missing runner binary")
+            return
+
         runner_manager = self._get_runner_manager()
-        if not runner_manager or runner_manager.runner_bin_path is None:
+        if not runner_manager:
+            self.unit.status = BlockedStatus("Missing token or org/repo path config")
             return
         self.unit.status = MaintenanceStatus("Reconciling runners")
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -277,7 +277,6 @@ class GithubRunnerCharm(CharmBase):
         runner_manager = self._get_runner_manager()
         if not runner_manager:
             return
-        old_status = self.unit.status
         try:
             self.unit.status = MaintenanceStatus("Checking for runner updates")
             runner_info = runner_manager.get_latest_runner_bin_url()
@@ -305,7 +304,7 @@ class GithubRunnerCharm(CharmBase):
             runner_manager.flush(flush_busy=False)
             self._reconcile_runners(runner_manager)
 
-        self.unit.status = old_status
+        self.unit.status = ActiveStatus()
 
     @catch_unexpected_charm_errors
     def _on_reconcile_runners(self, _event: ReconcileRunnersEvent) -> None:

--- a/src/github_type.py
+++ b/src/github_type.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TypedDict
+from typing import List, TypedDict
 
 from typing_extensions import NotRequired
 
@@ -30,7 +30,7 @@ class RunnerApplication(TypedDict, total=False):
     sha256_checksum: NotRequired[str]
 
 
-RunnerApplicationList = list[RunnerApplication]
+RunnerApplicationList = List[RunnerApplication]
 
 
 class SelfHostedRunnerLabel(TypedDict, total=False):

--- a/src/runner.py
+++ b/src/runner.py
@@ -115,7 +115,7 @@ class Runner:
     runner_application = Path("/opt/github-runner")
     env_file = runner_application / ".env"
     config_script = runner_application / "config.sh"
-    runner_script = runner_application / "start.sh"
+    run_script = runner_application / "run.sh"
 
     def __init__(
         self,
@@ -450,12 +450,15 @@ class Runner:
 
         logger.info("Starting runner %s", self.config.name)
 
-        # Put a script to run the GitHub self-hosted runner in the instance and run it.
-        contents = self._clients.jinja.get_template("start.j2").render()
-        self.instance.files.put(self.runner_script, contents, mode="0755")
-        self._execute(["/usr/bin/sudo", "chown", "ubuntu:ubuntu", str(self.runner_script)])
-        self._execute(["/usr/bin/sudo", "chmod", "u+x", str(self.runner_script)])
-        self._execute(["/usr/bin/sudo", "-u", "ubuntu", str(self.runner_script)])
+        self._execute(
+            [
+                "/usr/bin/sudo",
+                "-u",
+                "ubuntu",
+                str(self.run_script),
+            ],
+            cwd=str(self.runner_application),
+        )
 
         logger.info("Started runner %s", self.config.name)
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -246,7 +246,7 @@ class Runner:
             "source": {
                 "type": "image",
                 "mode": "pull",
-                "server": "https://cloud-images.ubuntu.com/jammy",
+                "server": "https://cloud-images.ubuntu.com/daily",
                 "protocol": "simplestreams",
                 "alias": image,
             },

--- a/src/runner.py
+++ b/src/runner.py
@@ -115,7 +115,7 @@ class Runner:
     runner_application = Path("/opt/github-runner")
     env_file = runner_application / ".env"
     config_script = runner_application / "config.sh"
-    run_script = runner_application / "run.sh"
+    runner_script = runner_application / "start.sh"
 
     def __init__(
         self,
@@ -450,15 +450,12 @@ class Runner:
 
         logger.info("Starting runner %s", self.config.name)
 
-        self._execute(
-            [
-                "/usr/bin/sudo",
-                "-u",
-                "ubuntu",
-                str(self.run_script),
-            ],
-            cwd=str(self.runner_application),
-        )
+        # Put a script to run the GitHub self-hosted runner in the instance and run it.
+        contents = self._clients.jinja.get_template("start.j2").render()
+        self.instance.files.put(self.runner_script, contents, mode="0755")
+        self._execute(["/usr/bin/sudo", "chown", "ubuntu:ubuntu", str(self.runner_script)])
+        self._execute(["/usr/bin/sudo", "chmod", "u+x", str(self.runner_script)])
+        self._execute(["/usr/bin/sudo", "-u", "ubuntu", str(self.runner_script)])
 
         logger.info("Started runner %s", self.config.name)
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -200,14 +200,10 @@ class Runner:
                 self.instance.stop(wait=True, timeout=60)
             except LXDAPIException:
                 logger.exception("Unable to gracefully stop runner within timeout.")
-                if self.instance is not None:
+                try:
                     self.instance.stop(force=True)
-
-            with suppress(LXDAPIException):
-                # Ephemeral containers should auto-delete when stopped;
-                # this is just a fall-back.
-                if self.instance is not None:
-                    self.instance.delete(wait=True)
+                except LXDAPIException:
+                    raise RunnerRemoveError(f"Unable to remove {self.config.name}") from err
         else:
             # We somehow have a non-running instance which should have been
             # ephemeral. Try to delete it and allow any errors doing so to

--- a/src/runner.py
+++ b/src/runner.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import logging
 import time
-from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import CalledProcessError  # nosec B404
@@ -202,7 +201,7 @@ class Runner:
                 logger.exception("Unable to gracefully stop runner within timeout.")
                 try:
                     self.instance.stop(force=True)
-                except LXDAPIException:
+                except LXDAPIException as err:
                     raise RunnerRemoveError(f"Unable to remove {self.config.name}") from err
         else:
             # We somehow have a non-running instance which should have been

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import tarfile
 import tempfile
 import urllib.request
@@ -86,6 +87,17 @@ class RunnerManager:
         self.config = runner_manager_config
         self.image = image
         self.proxies = proxies
+
+        # Setting the env var to this process and any child process spawned.
+        if "no_proxy" in self.proxies:
+            os.environ["NO_PROXY"] = self.proxies["no_proxy"]
+            os.environ["no_proxy"] = self.proxies["no_proxy"]
+        if "http" in self.proxies:
+            os.environ["HTTP_PROXY"] = self.proxies["http"]
+            os.environ["http_proxy"] = self.proxies["http"]
+        if "https" in self.proxies:
+            os.environ["HTTPS_PROXY"] = self.proxies["https"]
+            os.environ["https_proxy"] = self.proxies["https"]
 
         self.runner_bin_path: Optional[Path] = None
 

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -73,7 +73,7 @@ class RunnerManager:
         self,
         app_name: str,
         runner_manager_config: RunnerManagerConfig,
-        image: str = "focal",
+        image: str = "jammy",
         proxies: ProxySetting = ProxySetting(),
     ) -> None:
         """Construct RunnerManager object for creating and managing runners.

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import os
 import tarfile
 import urllib.request
 import uuid
@@ -34,7 +33,7 @@ from github_type import (
 )
 from runner import Runner, RunnerClients, RunnerConfig, RunnerStatus
 from runner_type import GitHubOrg, GitHubPath, GitHubRepo, ProxySetting, VirtualMachineResources
-from utilities import retry
+from utilities import retry, set_env_var
 
 logger = logging.getLogger(__name__)
 
@@ -91,14 +90,11 @@ class RunnerManager:
 
         # Setting the env var to this process and any child process spawned.
         if "no_proxy" in self.proxies:
-            os.environ["NO_PROXY"] = self.proxies["no_proxy"]
-            os.environ["no_proxy"] = self.proxies["no_proxy"]
+            set_env_var("NO_PROXY", self.proxies["no_proxy"])
         if "http" in self.proxies:
-            os.environ["HTTP_PROXY"] = self.proxies["http"]
-            os.environ["http_proxy"] = self.proxies["http"]
+            set_env_var("HTTP_PROXY", self.proxies["http"])
         if "https" in self.proxies:
-            os.environ["HTTPS_PROXY"] = self.proxies["https"]
-            os.environ["https_proxy"] = self.proxies["https"]
+            set_env_var("HTTPS_PROXY", self.proxies["https"])
 
         self.session = requests.Session()
         adapter = requests.adapters.HTTPAdapter(

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -252,6 +252,14 @@ class RunnerManager:
         online_runners = [
             runner for runner in runners if runner.status.exist and runner.status.online
         ]
+
+        logger.info(
+            "Expected runner count: %i, Online runner count: %i, Offline runner count: %i",
+            quantity,
+            len(online_runners),
+            len(offline_runners),
+        )
+
         delta = quantity - len(online_runners)
         if delta > 0:
             if RunnerManager.runner_bin_path is None:

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -68,7 +68,7 @@ class RunnerInfo:
 class RunnerManager:
     """Manage a group of runners according to configuration."""
 
-    runner_bin_path = Path("opt/github-runner-app")
+    runner_bin_path = Path("/opt/github-runner-app")
 
     def __init__(
         self,

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -132,7 +132,7 @@ class RunnerManager:
                 owner=self.config.path.owner, repo=self.config.path.repo
             )
         if isinstance(self.config.path, GitHubOrg):
-            runner_bins = self._clients.github.actions.list_runner_application_for_org(
+            runner_bins = self._clients.github.actions.list_runner_applications_for_org(
                 org=self.config.path.org
             )
 

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -128,9 +128,22 @@ def get_env_var(env_var: str) -> Optional[str]:
     Looks for all upper-case and all low-case of the `env_var`.
 
     Args:
-        env_var: Name of environment variable.
+        env_var: Name of the environment variable.
 
     Returns:
         Value of the environment variable. None if not found.
     """
     return os.environ.get(env_var.upper(), os.environ.get(env_var.lower(), None))
+
+
+def set_env_var(env_var: str, value: str) -> None:
+    """Set the environment variable value.
+
+    Set the all upper case and all low case of the `env_var`.
+
+    Args:
+        env_var: Name of the environment variable.
+        value: Value to set environment variable to.
+    """
+    os.environ[env_var.upper()] = value
+    os.environ[env_var.lower()] = value

--- a/templates/start.j2
+++ b/templates/start.j2
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-(/opt/github-runner/run.sh; sudo systemctl halt -i) &>/dev/null &

--- a/templates/start.j2
+++ b/templates/start.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+(/opt/github-runner/run.sh; sudo systemctl halt -i) &>/dev/null &

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -79,7 +79,7 @@ class MockPylxdInstance:
 
     def stop(self, wait: bool = True, timeout: int = 60):
         self.status = "Stopped"
-        # Ephemeral virtual machine should delete on stop.
+        # Ephemeral virtual machine should be deleted on stop.
         self.deleted = True
 
     def delete(self, wait: bool = True, timeout: int = 60):

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -150,7 +150,7 @@ class MockGhapiActions:
     def list_runner_applications_for_repo(self, owner: str, repo: str):
         return self._list_runner_applications()
 
-    def list_runner_application_for_org(self, org: str):
+    def list_runner_applications_for_org(self, org: str):
         return self._list_runner_applications()
 
     def create_registration_token_for_repo(self, owner: str, repo: str):

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -79,6 +79,8 @@ class MockPylxdInstance:
 
     def stop(self, wait: bool = True, timeout: int = 60):
         self.status = "Stopped"
+        # Ephemeral virtual machine should delete on stop.
+        self.deleted = True
 
     def delete(self, wait: bool = True, timeout: int = 60):
         self.deleted = True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,6 +3,7 @@
 
 """Test cases for GithubRunnerCharm."""
 
+import os
 import unittest
 import urllib.error
 from subprocess import CalledProcessError  # nosec B404
@@ -40,8 +41,34 @@ def mock_get_latest_runner_bin_url():
     return mock
 
 
+def mock_get_github_info():
+    return [
+        RunnerInfo("test runner 0", GitHubRunnerStatus.ONLINE),
+        RunnerInfo("test runner 1", GitHubRunnerStatus.ONLINE),
+        RunnerInfo("test runner 2", GitHubRunnerStatus.OFFLINE),
+        RunnerInfo("test runner 3", GitHubRunnerStatus.OFFLINE),
+        RunnerInfo("test runner 4", "unknown"),
+    ]
+
+
 class TestCharm(unittest.TestCase):
     """Test cases for GithubRunnerCharm."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUJU_CHARM_HTTPS_PROXY": "mock_https_proxy",
+            "JUJU_CHARM_HTTP_PROXY": "mock_http_proxy",
+            "JUJU_CHARM_NO_PROXY": "mock_no_proxy",
+        },
+    )
+    def test_proxy_setting(self):
+        harness = Harness(GithubRunnerCharm)
+        harness.begin()
+
+        assert harness.charm.proxies["https"] == "mock_https_proxy"
+        assert harness.charm.proxies["http"] == "mock_http_proxy"
+        assert harness.charm.proxies["no_proxy"] == "mock_no_proxy"
 
     @patch("pathlib.Path.write_text")
     @patch("subprocess.run")
@@ -101,8 +128,8 @@ class TestCharm(unittest.TestCase):
         harness.update_config({"path": "mockorg/repo", "token": "mocktoken"})
         harness.begin()
 
-        # update to 10 containers
-        harness.update_config({"containers": 10, "virtual-machines": 0})
+        # update to 0 virtual machines
+        harness.update_config({"virtual-machines": 0})
         harness.charm.on.reconcile_runners.emit()
         rm.assert_called_with(
             "github-runner",
@@ -113,7 +140,7 @@ class TestCharm(unittest.TestCase):
         mock_rm.reset_mock()
 
         # update to 10 VMs with 4 cpu and 7GiB memory
-        harness.update_config({"containers": 0, "virtual-machines": 10, "vm-cpu": 4})
+        harness.update_config({"virtual-machines": 10, "vm-cpu": 4})
         harness.charm.on.reconcile_runners.emit()
         rm.assert_called_with(
             "github-runner",
@@ -169,7 +196,7 @@ class TestCharm(unittest.TestCase):
 
         # Base case: no error thrown.
         harness.charm.on.install.emit()
-        assert harness.charm.unit.status == ActiveStatus()
+        assert harness.charm.unit.status == MaintenanceStatus("Starting runners")
 
         harness.charm._reconcile_runners = raise_runner_error
         harness.charm.on.install.emit()
@@ -222,15 +249,6 @@ class TestCharm(unittest.TestCase):
     @patch("pathlib.Path.write_text")
     @patch("subprocess.run")
     def test_check_runners_action(self, run, wt, rm):
-        def mock_get_github_info():
-            return [
-                RunnerInfo("test runner 0", GitHubRunnerStatus.ONLINE),
-                RunnerInfo("test runner 1", GitHubRunnerStatus.ONLINE),
-                RunnerInfo("test runner 2", GitHubRunnerStatus.OFFLINE),
-                RunnerInfo("test runner 3", GitHubRunnerStatus.OFFLINE),
-                RunnerInfo("test runner 4", "unknown"),
-            ]
-
         rm.return_value = mock_rm = MagicMock()
         mock_event = MagicMock()
 
@@ -280,3 +298,26 @@ class TestCharm(unittest.TestCase):
         harness.charm._on_flush_runners_action(mock_event)
         mock_event.fail.assert_called()
         mock_event.reset_mock()
+
+    @patch("charm.RunnerManager")
+    @patch("pathlib.Path.write_text")
+    @patch("subprocess.run")
+    def test_on_update_status(self, run, wt, rm):
+        rm.return_value = mock_rm = MagicMock()
+        mock_rm.get_github_info = mock_get_github_info
+
+        harness = Harness(GithubRunnerCharm)
+        harness.begin()
+
+        harness.charm.on.update_status.emit()
+        assert harness.charm.unit.status == BlockedStatus("Missing token or org/repo path config")
+
+        harness.update_config({"path": "mockorg/repo", "token": "mocktoken"})
+        harness.charm.on.update_status.emit()
+        assert harness.charm.unit.status == MaintenanceStatus(
+            "Waiting runners number to be reconciled"
+        )
+
+        harness.update_config({"virtual-machines": 2})
+        harness.charm.on.update_status.emit()
+        assert harness.charm.unit.status == ActiveStatus()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ import urllib.error
 from subprocess import CalledProcessError  # nosec B404
 from unittest.mock import MagicMock, call, patch
 
-from ops.model import BlockedStatus, MaintenanceStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
 
 from charm import GithubRunnerCharm
@@ -196,7 +196,7 @@ class TestCharm(unittest.TestCase):
 
         # Base case: no error thrown.
         harness.charm.on.install.emit()
-        assert harness.charm.unit.status == MaintenanceStatus("Starting runners")
+        assert harness.charm.unit.status == ActiveStatus()
 
         harness.charm._reconcile_runners = raise_runner_error
         harness.charm.on.install.emit()

--- a/tests/unit/test_runner_manager.py
+++ b/tests/unit/test_runner_manager.py
@@ -26,12 +26,13 @@ from tests.unit.mock import TEST_BINARY
         ),
     ],
 )
-def runner_manager_fixture(request, tmp_path):
+def runner_manager_fixture(request, tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "runner_manager.RunnerManager.runner_bin_path", Path(tmp_path / "mock_runner_binary")
+    )
     runner_manager = RunnerManager(
         "test app", RunnerManagerConfig(request.param[0], "mock token"), proxies=request.param[1]
     )
-    # Fake having a binary by setting to non-None value.
-    runner_manager.runner_bin_path = tmp_path / "test_binary"
     return runner_manager
 
 
@@ -78,7 +79,6 @@ def test_update_runner_bin(runner_manager: RunnerManager):
     runner_bin = runner_manager.get_latest_runner_bin_url(os_name="linux", arch_name="x64")
 
     runner_manager.update_runner_bin(runner_bin)
-    assert runner_manager.runner_bin_path is not None
 
 
 def test_reconcile_zero_count(runner_manager: RunnerManager):


### PR DESCRIPTION
- Implements a basic end to end test in which the charm is deployed, a runner is spawned, an GitHub workflow is ran. Part of the testing process will be manual for now, and can be automated later.
- Add bug fixes.
- Added some unit test for to pass coverage requirements.
- Add more logging for debugging.

Bug fixes includes:
- From testing, this method of setting proxy no longer works for ghapi library: https://github.com/fastai/ghapi/issues/50. Setting the env var for proxies are used instead. The env var should only affect the python process and child processes spawned.
- Change target series to jammy, to prevent dependency issues related to Rust binding of `cryptography` lib on focal.
- Use fixed file path for downloaded runner binary. Fix a missing binary problem, while avoid using `StoredState`.
- Fix a status related bug when executing `update-runner-bin` action.
- Fix typo related to GitHub organization API.