### PR TITLE
Temporary fix for missing tools in runners

### DIFF
--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -16,3 +16,10 @@ jobs:
     steps:
       - name: Echo hello world
         run: echo "hello world"
+  docker-test:
+    name: docker test
+    runs-on: [self-hosted, linux, x64, e2e-runner]
+    steps:
+      - name: Docker hello world
+        run: docker run hello-world
+    

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -9,20 +9,9 @@ jobs:
   e2e-test:
     name: end to end test
     runs-on: [self-hosted, linux, x64, e2e-runner]
-    strategy:
-      # Two tests are scheduled to test if the charm is able to spawn new runners.
-      matrix:
-        runner: [1, 2]
     steps:
       - name: Echo hello world
         run: echo "hello world"
-  docker-test:
-    name: docker test
-    needs: e2e-test
-    runs-on: [self-hosted, linux, x64, e2e-runner]
-    steps:
-      - name: Docker hello world
-        run: docker run hello-world
   pip-test:
     name: pip test
     needs: e2e-test
@@ -37,3 +26,10 @@ jobs:
     steps:
       - name: npm version
         run: npm --version
+  docker-test:
+    name: docker test
+    needs: e2e-test
+    runs-on: [self-hosted, linux, x64, e2e-runner]
+    steps:
+      - name: Docker hello world
+        run: sudo docker run hello-world

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -18,8 +18,22 @@ jobs:
         run: echo "hello world"
   docker-test:
     name: docker test
+    needs: e2e-test
     runs-on: [self-hosted, linux, x64, e2e-runner]
     steps:
       - name: Docker hello world
         run: docker run hello-world
-    
+  pip-test:
+    name: pip test
+    needs: e2e-test
+    runs-on: [self-hosted, linux, x64, e2e-runner]
+    steps:
+      - name: pip version
+        run: pip --version
+  npm-test:
+    name: npm test
+    needs: e2e-test
+    runs-on: [self-hosted, linux, x64, e2e-runner]
+    steps:
+      - name: npm version
+        run: npm --version

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -12,6 +12,13 @@ jobs:
     steps:
       - name: Echo hello world
         run: echo "hello world"
+  docker-test:
+    name: docker test
+    needs: e2e-test
+    runs-on: [self-hosted, linux, x64, e2e-runner]
+    steps:
+      - name: Docker version
+        run: docker --version
   pip-test:
     name: pip test
     needs: e2e-test
@@ -26,10 +33,3 @@ jobs:
     steps:
       - name: npm version
         run: npm --version
-  docker-test:
-    name: docker test
-    needs: e2e-test
-    runs-on: [self-hosted, linux, x64, e2e-runner]
-    steps:
-      - name: Docker hello world
-        run: sudo docker run hello-world

--- a/config.yaml
+++ b/config.yaml
@@ -20,20 +20,20 @@ options:
       type: int
       default: 2
       description: >
-        The number of CPUs used per virtual machine runner. Does not affect container runners.
+        The number of CPUs used per virtual machine runner.
   vm-memory:
     type: string
     default: 7GiB
     description: >
-        The memory size used per virtual machine runner. Does not affect container runners.
+        The memory size used per virtual machine runner.
   vm-disk:
     type: string
     default: 10GiB
     description: >
-        The root disk size used per virtual machine runner. Does not affect container runners.
+        The root disk size used per virtual machine runner.
   reconcile-interval:
       type: int
-      default: 5
+      default: 10
       description: >
         Minutes between each reconciliation between the current state and the target state of the
         runners. On reconciliation the charm polls the state of runners, such as, the number of

--- a/src/runner.py
+++ b/src/runner.py
@@ -357,8 +357,8 @@ class Runner:
         # TEMP: Install common tools used in GitHub Actions. This will be removed once virtual
         # machines are created from custom images/GitHub runner image.
         logger.info("Setting up installation of docker...")
-        self._execute(["/usr/bin/apt", "apt", "update"])
-        self._execute(["/usr/bin/apt", "apt", "ca-certificates", "curl", "gnupg", "lsb-release"])
+        self._execute(["/usr/bin/apt", "update"])
+        self._execute(["/usr/bin/apt", "install", "ca-certificates", "curl", "gnupg", "lsb-release"])
         self._execute(["/usr/bin/mkdir", "-m", "0755", "-p", "/etc/apt/keyrings"])
         self._execute(
             [
@@ -366,7 +366,7 @@ class Runner:
                 "-fsSL",
                 "https://download.docker.com/linux/ubuntu/gpg",
                 "|",
-                "gpg",
+                "/usr/bin/gpg",
                 "--dearmor",
                 "-o",
                 "/etc/apt/keyrings/docker.gpg",
@@ -386,7 +386,7 @@ class Runner:
                 "/dev/null",
             ]
         )
-        self._execute(["/usr/bin/apt", "apt", "update"])
+        self._execute(["/usr/bin/apt", "update"])
         logger.info("Installing docker...")
         self._execute(
             [

--- a/src/runner.py
+++ b/src/runner.py
@@ -405,8 +405,6 @@ class Runner:
                 "docker-compose-plugin",
             ]
         )
-        logger.info("Testing docker...")
-        self._execute(["/usr/bin/docker", "run", "hello-world"])
 
         logger.info("Installing Python 3 pip...")
         self._execute(["/usr/bin/apt", "install", "python3-pip"])

--- a/src/runner.py
+++ b/src/runner.py
@@ -467,8 +467,8 @@ class Runner:
     def _execute(self, cmd: list[str], cwd: Optional[str] = None, **kwargs) -> str:
         """Check execution of a command in a LXD instance.
 
-        The command is executed with `subprocess.run`, additional arguments can be pass into as
-        keyword arguments. The following arguments to `subprocess.run` should not be set
+        The command is executed with `subprocess.run`, additional arguments can be passed to it as
+        keyword arguments. The following arguments to `subprocess.run` should not be set:
         `capture_output`, `shell`, `check`. As those arguments are used by this function.
 
         Args:

--- a/src/runner.py
+++ b/src/runner.py
@@ -356,58 +356,12 @@ class Runner:
 
         # TEMP: Install common tools used in GitHub Actions. This will be removed once virtual
         # machines are created from custom images/GitHub runner image.
-        logger.info("Setting up installation of docker...")
         self._execute(["/usr/bin/apt", "update"])
-        self._execute(
-            ["/usr/bin/apt", "install", "-yq", "ca-certificates", "curl", "gnupg", "lsb-release"]
-        )
-        self._execute(["/usr/bin/mkdir", "-m", "0755", "-p", "/etc/apt/keyrings"])
-        gpg_key = self._execute(
-            [
-                "/usr/bin/curl",
-                "-fsSL",
-                "https://download.docker.com/linux/ubuntu/gpg",
-            ]
-        )
-        self._execute(
-            [
-                "/usr/bin/gpg",
-                "--dearmor",
-                "-o",
-                "/etc/apt/keyrings/docker.gpg",
-            ],
-            input=gpg_key,
-        )
-        self._execute(
-            [
-                "echo",
-                (
-                    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg"
-                    "] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-                ),
-                "|",
-                "/usr/bin/tee",
-                "/etc/apt/sources.list.d/docker.list",
-                ">",
-                "/dev/null",
-            ]
-        )
-        self._execute(["/usr/bin/apt", "update"])
-        logger.info("Installing docker...")
-        self._execute(
-            [
-                "/usr/bin/apt",
-                "install",
-                "-yq",
-                "docker-ce",
-                "docker-ce-cli",
-                "containerd.io",
-                "docker-buildx-plugin",
-                "docker-compose-plugin",
-            ]
-        )
 
-        logger.info("Install npm...")
+        logger.info("Installing docker...")
+        self._execute(["/usr/bin/apt", "install", "-yq", "docker.io"])
+
+        logger.info("Installing npm...")
         self._execute(["/usr/bin/apt", "install", "-yq", "npm"])
 
         logger.info("Installing Python 3 pip...")

--- a/src/runner.py
+++ b/src/runner.py
@@ -356,6 +356,7 @@ class Runner:
 
         # TEMP: Install common tools used in GitHub Actions. This will be removed once virtual
         # machines are created from custom images/GitHub runner image.
+        logger.info("Setting up installation of docker...")
         self._execute(["/usr/bin/apt", "apt", "update"])
         self._execute(["/usr/bin/apt", "apt", "ca-certificates", "curl", "gnupg", "lsb-release"])
         self._execute(["/usr/bin/mkdir", "-m", "0755", "-p", "/etc/apt/keyrings"])
@@ -386,6 +387,7 @@ class Runner:
             ]
         )
         self._execute(["/usr/bin/apt", "apt", "update"])
+        logger.info("Installing docker...")
         self._execute(
             [
                 "/usr/bin/apt",
@@ -397,9 +399,10 @@ class Runner:
                 "docker-compose-plugin",
             ]
         )
-        # Test docker.
+        logger.info("Testing docker...")
         self._execute(["/usr/bin/docker", "run", "hello-world"])
 
+        logger.info("Installing Python 3 pip...")
         self._execute(["/usr/bin/apt", "install", "python3-pip"])
 
         # The LXD instance is meant to run untrusted workload. Hardcoding the tmp directory should

--- a/src/runner.py
+++ b/src/runner.py
@@ -359,7 +359,7 @@ class Runner:
         logger.info("Setting up installation of docker...")
         self._execute(["/usr/bin/apt", "update"])
         self._execute(
-            ["/usr/bin/apt", "install", "ca-certificates", "curl", "gnupg", "lsb-release"]
+            ["/usr/bin/apt", "install", "-yq", "ca-certificates", "curl", "gnupg", "lsb-release"]
         )
         self._execute(["/usr/bin/mkdir", "-m", "0755", "-p", "/etc/apt/keyrings"])
         gpg_key = self._execute(
@@ -398,6 +398,7 @@ class Runner:
             [
                 "/usr/bin/apt",
                 "install",
+                "-yq",
                 "docker-ce",
                 "docker-ce-cli",
                 "containerd.io",
@@ -406,8 +407,11 @@ class Runner:
             ]
         )
 
+        logger.info("Install npm...")
+        self._execute(["/usr/bin/apt", "install", "-yq", "npm"])
+
         logger.info("Installing Python 3 pip...")
-        self._execute(["/usr/bin/apt", "install", "python3-pip"])
+        self._execute(["/usr/bin/apt", "install", "-yq", "python3-pip"])
 
         # The LXD instance is meant to run untrusted workload. Hardcoding the tmp directory should
         # be fine.

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -249,11 +249,22 @@ class RunnerManager:
             runner for runner in runners if runner.status.exist and runner.status.online
         ]
 
+        local_runners = {
+            instance.name: instance
+            # Pylint cannot find the `all` method.
+            for instance in self._clients.lxd.instances.all()  # pylint: disable=no-member
+            if instance.name.startswith(f"{self.app_name}-")
+        }
+
         logger.info(
-            "Expected runner count: %i, Online runner count: %i, Offline runner count: %i",
+            (
+                "Expected runner count: %i, Online runner count: %i, Offline runner count: %i, "
+                "LXD instance count: %i"
+            ),
             quantity,
             len(online_runners),
             len(offline_runners),
+            len(local_runners),
         )
 
         delta = quantity - len(online_runners)

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -93,18 +93,30 @@ def retry(  # pylint: disable=too-many-arguments
     return retry_decorator
 
 
-def execute_command(cmd: Sequence[str], check: bool = True) -> str:
+def execute_command(cmd: Sequence[str], check: bool = True, **kwargs) -> str:
     """Execute a command on a subprocess.
+
+    The command is executed with `subprocess.run`, additional arguments can be pass into as keyword
+    arguments. The following arguments to `subprocess.run` should not be set `capture_output`,
+    `shell`, `check`. As those arguments are used by this function.
 
     Args:
         cmd: Command in a list.
         check: Whether to throw error on non-zero exit code.
+        kwargs: Additional keyword arguments for the `subprocess.run` call.
 
     Returns:
         Output on stdout.
     """
     logger.info("Executing command %s", cmd)
-    result = subprocess.run(cmd, capture_output=True, shell=False, check=False)  # nosec B603
+    result = subprocess.run(  # nosec B603
+        cmd,
+        capture_output=True,
+        shell=False,
+        check=False,
+        # Disable type check due to the support for unpacking arguments in mypy is experimental.
+        **kwargs  # type: ignore
+    )
     logger.debug("Command %s returns: %s", cmd, result.stdout)
 
     if check:

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -96,9 +96,9 @@ def retry(  # pylint: disable=too-many-arguments
 def execute_command(cmd: Sequence[str], check: bool = True, **kwargs) -> str:
     """Execute a command on a subprocess.
 
-    The command is executed with `subprocess.run`, additional arguments can be pass into as keyword
-    arguments. The following arguments to `subprocess.run` should not be set `capture_output`,
-    `shell`, `check`. As those arguments are used by this function.
+    The command is executed with `subprocess.run`, additional arguments can be passed to it as
+    keyword arguments. The following arguments to `subprocess.run` should not be set:
+    `capture_output`, `shell`, `check`. As those arguments are used by this function.
 
     Args:
         cmd: Command in a list.

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,6 @@ commands =
 description = Run static analysis tests
 deps =
     bandit[toml]
-    toml
     -r{toxinidir}/requirements.txt
 commands =
     bandit -c {toxinidir}/pyproject.toml -r {[vars]src_path}

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ commands =
 [testenv:static]
 description = Run static analysis tests
 deps =
-    bandit
+    bandit[toml]
     toml
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
Self-hosted runners spawned by the GitHub runner charm does not have some common tooling users of GitHub Actions expects. This is due to the virtual machine hosting the self-hosted runners are created with the standard Ubuntu images.

Support for custom images based on [GitHub Actions Runner Images](https://github.com/actions/runner-images) is planned for the future and should be the permanent fix for this issue. In the mean time, installing the missing tools after starting up a virtual machine serves as a temporary fix.