### PR TITLE
Add proxy configuration for docker in runners

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -409,7 +409,7 @@ class Runner:
             env_contents = self._clients.jinja.get_template("env.j2").render(
                 proxies=self.config.proxies
             )
-            logger.debug("Proxy setting for the runner: {}", env_contents)
+            logger.debug("Proxy setting for the runner: %s", env_contents)
             self.instance.files.put(self.env_file, env_contents)
             self._execute(["/usr/bin/chown", "ubuntu:ubuntu", str(self.env_file)])
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -445,7 +445,7 @@ class Runner:
                 )
 
             self._execute(["systemctl", "daemon-reload"])
-            self._execute(["systemctl", "reload", "docker"])
+            self._execute(["systemctl", "restart", "docker"])
 
     @retry(tries=5, delay=30, local_logger=logger)
     def _register_runner(self, registration_token: str, labels: Sequence[str]) -> None:

--- a/src/runner.py
+++ b/src/runner.py
@@ -405,10 +405,12 @@ class Runner:
             return
 
         if self.config.proxies:
+            logger.info("Adding proxy setting to the runner.")
             env_contents = self._clients.jinja.get_template("env.j2").render(
                 proxies=self.config.proxies
             )
-            self.instance.files.put(self.env_file, env_contents, mode="0600")
+            logger.debug("Proxy setting for the runner: {}", env_contents)
+            self.instance.files.put(self.env_file, env_contents)
             self._execute(["/usr/bin/chown", "ubuntu:ubuntu", str(self.env_file)])
 
             docker_proxy_contents = self._clients.jinja.get_template(

--- a/src/runner.py
+++ b/src/runner.py
@@ -415,11 +415,15 @@ class Runner:
             self._execute(["/usr/bin/chown", "ubuntu:ubuntu", str(self.env_file)])
 
             # Verify the env file is written to runner.
-            exit_code, _, _ = self.instance.execute(["test", "-f", str(self.env_file)])
+            exit_code, _, stderr = self.instance.execute(["test", "-f", str(self.env_file)])
             if exit_code == 0:
                 logger.info("Loaded env file on runner instance %s.", self.config.name)
             else:
-                logger.error("Unable to load env file on runner instance %s", self.config.name)
+                logger.error(
+                    "Unable to load env file on runner instance %s due to: %s",
+                    self.config.name,
+                    stderr.read(),
+                )
                 raise RunnerFileLoadError(f"Failed to load env file on {self.config.name}")
 
             docker_proxy_contents = self._clients.jinja.get_template(
@@ -433,12 +437,14 @@ class Runner:
             self.instance.files.put(str(docker_service_proxy), docker_proxy_contents)
 
             # Verify the env file is written to runner.
-            exit_code, _, _ = self.instance.execute(["test", "-f", str(docker_service_proxy)])
+            exit_code, _, stderr = self.instance.execute(["test", "-f", str(docker_service_proxy)])
             if exit_code == 0:
                 logger.info("Loaded docker proxy file on runner instance %s.", self.config.name)
             else:
                 logger.error(
-                    "Unable to load docker proxy file on runner instance %s", self.config.name
+                    "Unable to load docker proxy file on runner instance %s due to: %s",
+                    self.config.name,
+                    stderr.read(),
                 )
                 raise RunnerFileLoadError(
                     f"Failed to load docker proxy file on {self.config.name}"

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -2,4 +2,3 @@ http_proxy={{proxies['http']}}
 https_proxy={{proxies['https']}}
 no_proxy={{proxies['no_proxy']}}
 LANG=C.UTF-8
-

--- a/templates/systemd-docker-proxy.j2
+++ b/templates/systemd-docker-proxy.j2
@@ -1,0 +1,4 @@
+[Service]
+Environment="HTTP_PROXY={{proxies['http']}}"
+Environment="HTTPS_PROXY={{proxies['https']}}"
+Environment="NO_PROXY={{proxies['no_proxy']}}"

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -94,16 +94,16 @@ class MockPylxdInstanceFiles:
     """Mock the behavior of a pylxd Instance files."""
 
     def __init__(self):
-        pass
+        self.files = {}
 
     def mk_dir(self, path, mode=None, uid=None, gid=None):
         pass
 
     def put(self, filepath, data, mode=None, uid=None, gid=None):
-        pass
+        self.files[str(filepath)] = data
 
     def get(self, filepath):
-        return ""
+        return self.files.get(str(filepath), None)
 
 
 class MockErrorResponse:

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -82,7 +82,18 @@ def test_create(
     """
 
     runner.create("test_image", vm_resources, binary_path, token)
-    assert len(pylxd.instances.all()) == 1
+
+    instances = pylxd.instances.all()
+    assert len(instances) == 1
+
+    if runner.config.proxies:
+        instance = instances[0]
+        systemd_docker_proxy = instance.files.get(
+            "/etc/systemd/system/docker.service.d/http-proxy.conf"
+        )
+        # Test the file has being written to.  This value does not contain the string as the
+        # jinja2.environment.Environment is mocked with MagicMock.
+        assert systemd_docker_proxy is not None
 
 
 def test_create_pylxd_fail(

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -88,11 +88,13 @@ def test_create(
 
     if runner.config.proxies:
         instance = instances[0]
+        env_proxy = instance.files.get("/opt/github-runner/.env")
         systemd_docker_proxy = instance.files.get(
             "/etc/systemd/system/docker.service.d/http-proxy.conf"
         )
         # Test the file has being written to.  This value does not contain the string as the
         # jinja2.environment.Environment is mocked with MagicMock.
+        assert env_proxy is not None
         assert systemd_docker_proxy is not None
 
 


### PR DESCRIPTION
For GitHub Actions that pulls docker images from docker hub or other registries, the docker within the runners needs to be configured with according to the proxy setting of the charm.