### PR TITLE
Delete LXD instance if LXD failed to remove ephemeral instance

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -7,6 +7,7 @@ parts:
     charm-python-packages:
       - setuptools  # for jinja2
     build-packages:
+      - git  # for installing git source of pylxd 
       - libffi-dev  # for cffi
       - libssl-dev  # for cryptography
       - rust-all  # for cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ ops
 requests
 jinja2
 ghapi
-pylxd @ git+https://github.com/lxc/pylxd@main
+pylxd @ git+https://github.com/lxc/pylxd
 # Newer version does not work with default OpenSSL version on jammy.
 cryptography <= 38.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ ops
 requests
 jinja2
 ghapi
-pylxd
+pylxd @ git+https://github.com/lxc/pylxd@main
 # Newer version does not work with default OpenSSL version on jammy.
 cryptography <= 38.0.4

--- a/src/runner.py
+++ b/src/runner.py
@@ -141,6 +141,18 @@ class Runner:
                         self.instance.stop(force=True)
                     except LxdError as err:
                         raise RunnerRemoveError(f"Unable to remove {self.config.name}") from err
+            else:
+                # Delete ephemeral instances that are in error status or stopped status that LXD
+                # failed to clean up.
+                logger.warning(
+                    "Found runner %s in status %s, forcing deletion",
+                    self.config.name,
+                    self.instance.status,
+                )
+                try:
+                    self.instance.delete(wait=True)
+                except LxdError as err:
+                    raise RunnerRemoveError(f"Unable to remove {self.config.name}") from err
 
         # The runner should cleanup itself.  Cleanup on GitHub in case of runner cleanup error.
         if isinstance(self.config.path, GitHubRepo):

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -52,10 +52,10 @@ def retry(  # pylint: disable=too-many-arguments
         """Decorate function with retry.
 
         Args:
-            fn (Callable[..., R]): The function to decorate.
+            fn: The function to decorate.
 
         Returns:
-            Callable[..., R]: The resulting function with retry added.
+            The resulting function with retry added.
         """
 
         @functools.wraps(func)


### PR DESCRIPTION
Fix a resource leak problem when LXD failed to remove an ephemeral instance on stop.

This PR includes:
- Delete LXD ephemeral instance that LXD failed to remove.
- Installs pylxd from source on GitHub to fix a bug in version on PyPI. [See this comment](https://github.com/lxc/pylxd/issues/538#issuecomment-1520142839).