### PR TITLE
Add delete method for lxd instance

### DIFF
--- a/src/lxd.py
+++ b/src/lxd.py
@@ -194,6 +194,20 @@ class LxdInstance:
         except pylxd.exceptions.LXDAPIException as err:
             raise LxdError(f"Unable to stop LXD instance {self.name}") from err
 
+    def delete(self, wait: bool = False) -> None:
+        """Delete the LXD instance.
+
+        Args:
+            wait: Whether to wait until the LXD instance stopped before returning.
+
+        Raises:
+            LxdException: Unable to delete the LXD instance.
+        """
+        try:
+            self._pylxd_instance.delete(wait)
+        except pylxd.exceptions.LXDAPIException as err:
+            raise LxdError(f"Unable to delete LXD instance {self.name}") from err
+
     def execute(self, cmd: list[str], cwd: Optional[str] = None) -> Tuple[int, IO, IO]:
         """Execute a command within the LXD instance.
 

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -238,21 +238,12 @@ class RunnerManager:
         """
         runners = self._get_runners()
 
-        # Clean up offline runners
-        offline_runners = [runner for runner in runners if not runner.status.online]
-        if offline_runners:
-            logger.info("Cleaning up offline runners.")
-
-            remove_token = self._get_github_remove_token()
-
-            for runner in offline_runners:
-                runner.remove(remove_token)
-                logger.info("Removed runner: %s", runner.config.name)
-
         # Add/Remove runners to match the target quantity
         online_runners = [
             runner for runner in runners if runner.status.exist and runner.status.online
         ]
+
+        offline_runners = [runner for runner in runners if not runner.status.online]
 
         local_runners = {
             instance.name: instance
@@ -272,7 +263,18 @@ class RunnerManager:
             len(local_runners),
         )
 
+        # Clean up offline runners
+        if offline_runners:
+            logger.info("Cleaning up offline runners.")
+
+            remove_token = self._get_github_remove_token()
+
+            for runner in offline_runners:
+                runner.remove(remove_token)
+                logger.info("Removed runner: %s", runner.config.name)
+
         delta = quantity - len(online_runners)
+        # Spawn new runners
         if delta > 0:
             if RunnerManager.runner_bin_path is None:
                 raise RunnerCreateError("Unable to create runner due to missing runner binary.")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,7 +10,6 @@ from tests.unit.mock import MockGhapiClient, MockLxdClient
 
 @pytest.fixture(autouse=True)
 def mocks(monkeypatch, tmp_path):
-    monkeypatch.setattr("lxd.pylxd.Client", MockLxdClient)
     monkeypatch.setattr("runner.time", unittest.mock.MagicMock())
     monkeypatch.setattr("runner_manager.GhApi", MockGhapiClient)
     monkeypatch.setattr("runner_manager.jinja2", unittest.mock.MagicMock())

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -29,7 +29,7 @@ TEST_BINARY = (
 
 
 class MockLxdClient:
-    """Mock the behavior of the pylxd client."""
+    """Mock the behavior of the lxd client."""
 
     def __init__(self):
         self.instances = MockLxdInstanceManager()
@@ -37,7 +37,7 @@ class MockLxdClient:
 
 
 class MockLxdInstanceManager:
-    """Mock the behavior of the pylxd Instances."""
+    """Mock the behavior of the lxd Instances."""
 
     def __init__(self):
         self.instances = {}
@@ -54,7 +54,7 @@ class MockLxdInstanceManager:
 
 
 class MockLxdProfileManager:
-    """Mock the behavior of the pylxd Profiles."""
+    """Mock the behavior of the lxd Profiles."""
 
     def __init__(self):
         self.profiles = set()
@@ -67,7 +67,7 @@ class MockLxdProfileManager:
 
 
 class MockLxdInstance:
-    """Mock the behavior of a pylxd Instance."""
+    """Mock the behavior of a lxd Instance."""
 
     def __init__(self, name: str):
         self.name = name
@@ -84,7 +84,7 @@ class MockLxdInstance:
         # Ephemeral virtual machine should be deleted on stop.
         self.deleted = True
 
-    def delete(self, wait: bool = True, timeout: int = 60):
+    def delete(self, wait: bool = True):
         self.deleted = True
 
     def execute(self, cmd: Sequence[str], cwd: Optional[str] = None) -> tuple[int, str, str]:
@@ -92,7 +92,7 @@ class MockLxdInstance:
 
 
 class MockLxdInstanceFileManager:
-    """Mock the behavior of a pylxd Instance files."""
+    """Mock the behavior of a lxd Instance files."""
 
     def __init__(self):
         self.files = {}
@@ -120,7 +120,7 @@ class MockErrorResponse:
         return {"metadata": {"err": "test error"}}
 
 
-def mock_pylxd_error_func(*arg, **kargs):
+def mock_lxd_error_func(*arg, **kargs):
     raise LxdError(MockErrorResponse())
 
 

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -13,7 +13,7 @@ import pytest
 from errors import RunnerCreateError
 from runner import Runner, RunnerClients, RunnerConfig, RunnerStatus
 from runner_type import GitHubOrg, GitHubRepo, VirtualMachineResources
-from tests.unit.mock import MockLxdClient, mock_pylxd_error_func, mock_runner_error_func
+from tests.unit.mock import MockLxdClient, mock_lxd_error_func, mock_runner_error_func
 
 
 @pytest.fixture(scope="module", name="vm_resources")
@@ -41,8 +41,8 @@ def instance_fixture(request):
     return instance
 
 
-@pytest.fixture(scope="function", name="pylxd")
-def mock_pylxd_client_fixture():
+@pytest.fixture(scope="function", name="lxd")
+def mock_lxd_client_fixture():
     return MockLxdClient()
 
 
@@ -57,8 +57,8 @@ def mock_pylxd_client_fixture():
         ),
     ],
 )
-def runner_fixture(request, pylxd: MockLxdClient):
-    client = RunnerClients(MagicMock(), MagicMock(), pylxd)
+def runner_fixture(request, lxd: MockLxdClient):
+    client = RunnerClients(MagicMock(), MagicMock(), lxd)
     config = RunnerConfig("test_app", request.param[0], request.param[1], "test_runner")
     status = RunnerStatus()
     return Runner(
@@ -73,17 +73,17 @@ def test_create(
     vm_resources: VirtualMachineResources,
     token: str,
     binary_path: Path,
-    pylxd: MockLxdClient,
+    lxd: MockLxdClient,
 ):
     """
     arrange: Nothing.
     act: Create a runner.
-    assert: An pylxd instance for the runner is created.
+    assert: An lxd instance for the runner is created.
     """
 
     runner.create("test_image", vm_resources, binary_path, token)
 
-    instances = pylxd.instances.all()
+    instances = lxd.instances.all()
     assert len(instances) == 1
 
     if runner.config.proxies:
@@ -98,25 +98,25 @@ def test_create(
         assert systemd_docker_proxy is not None
 
 
-def test_create_pylxd_fail(
+def test_create_lxd_fail(
     runner: Runner,
     vm_resources: VirtualMachineResources,
     token: str,
     binary_path: Path,
-    pylxd: MockLxdClient,
+    lxd: MockLxdClient,
 ):
     """
-    arrange: Setup the create runner to fail with pylxd error.
+    arrange: Setup the create runner to fail with lxd error.
     act: Create a runner.
     assert: Correct exception should be thrown. Any created instance should be
         cleanup.
     """
-    pylxd.profiles.exists = mock_pylxd_error_func
+    lxd.profiles.exists = mock_lxd_error_func
 
     with pytest.raises(RunnerCreateError):
         runner.create("test_image", vm_resources, binary_path, token)
 
-    assert len(pylxd.instances.all()) == 0
+    assert len(lxd.instances.all()) == 0
 
 
 def test_create_runner_fail(
@@ -124,7 +124,7 @@ def test_create_runner_fail(
     vm_resources: VirtualMachineResources,
     token: str,
     binary_path: Path,
-    pylxd: MockLxdClient,
+    lxd: MockLxdClient,
 ):
     """
     arrange: Setup the create runner to fail with runner error.
@@ -143,29 +143,49 @@ def test_remove(
     vm_resources: VirtualMachineResources,
     token: str,
     binary_path: Path,
-    pylxd: MockLxdClient,
+    lxd: MockLxdClient,
 ):
     """
     arrange: Create a runner.
     act: Remove the runner.
-    assert: The pylxd instance for the runner is removed.
+    assert: The lxd instance for the runner is removed.
     """
 
     runner.create("test_image", vm_resources, binary_path, token)
     runner.remove("test_token")
-    assert len(pylxd.instances.all()) == 0
+    assert len(lxd.instances.all()) == 0
+
+
+def test_remove_failed_instance(
+    runner: Runner,
+    vm_resources: VirtualMachineResources,
+    token: str,
+    binary_path: Path,
+    lxd: MockLxdClient,
+):
+    """
+    arrange: Create a stopped runner that failed to remove itself.
+    act: Remove the runner.
+    assert: The lxd instance for the runner is removed.
+    """
+    # Cases where the ephemeral instance encountered errors and the status was Stopped but not
+    # removed was found before.
+    runner.create("test_image", vm_resources, binary_path, token)
+    runner.instance.status = "Stopped"
+    runner.remove("test_token")
+    assert len(lxd.instances.all()) == 0
 
 
 def test_remove_none(
     runner: Runner,
     token: str,
-    pylxd: MockLxdClient,
+    lxd: MockLxdClient,
 ):
     """
     arrange: Not creating a runner.
     act: Remove the runner.
-    assert: The pylxd instance for the runner is removed.
+    assert: The lxd instance for the runner is removed.
     """
 
     runner.remove(token)
-    assert len(pylxd.instances.all()) == 0
+    assert len(lxd.instances.all()) == 0


### PR DESCRIPTION
- Add unit test for removal of stopped ephemeral instance that LXD failed to remove.
- Fixed missing delete method on the lxd interface class.
- Fix a logging issue. Move logging of current runner count ahead of removing runners.