### PR TITLE
Add configuration needed by test.yaml in operator-workflow.

### DIFF
--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -12,8 +12,14 @@ jobs:
     steps:
       - name: Echo hello world
         run: echo "hello world"
+      - name: File permission for /usr/local/bin
+        run: ls -ld /usr/local/bin | grep drwxrwxrwx
       - name: Proxy set in /etc/environment
-        run: cat /etc/environment | grep PROXY
+        run: cat /etc/environment | grep HTTP_PROXY
+      - name: Proxy set in docker daemon 
+        run: cat /etc/systemd/system/docker.service.d/http-proxy.conf | grep HTTP_PROXY
+      - name: Proxy set in docker client
+        run: cat /home/ubuntu/.docker/config.json | grep httpProxy
       - name: Install microk8s
         run: sudo snap install microk8s --classic
       - name: Wait for microk8s

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -1,6 +1,6 @@
 name: End to end tests
 
-on: 
+on:
   pull_request:
   workflow_call:
   workflow_dispatch:
@@ -14,10 +14,16 @@ jobs:
         run: echo "hello world"
       - name: File permission for /usr/local/bin
         run: ls -ld /usr/local/bin | grep drwxrwxrwx
+      - name: Test fille permission for /usr/local/bin
+        run: touch /usr/local/bin/test_file
+      # "Install microk8s" step will test if the proxies settings are correct.
       - name: Proxy set in /etc/environment
         run: cat /etc/environment | grep HTTP_PROXY
-      - name: Proxy set in docker daemon 
+      # "Update apt in python docker container" step will test docker default proxy settings due to
+      # pulling the python image.
+      - name: Proxy set in docker daemon
         run: sudo cat /etc/systemd/system/docker.service.d/http-proxy.conf | grep HTTP_PROXY
+      # "Update apt in python docker container" step will test docker client default proxy settings.
       - name: Proxy set in docker client
         run: cat /home/ubuntu/.docker/config.json | grep httpProxy
       - name: Install microk8s
@@ -28,6 +34,8 @@ jobs:
         run: sudo microk8s kubectl create deployment nginx --image=nginx
       - name: Wait for nginx to be ready
         run: sudo microk8s kubectl rollout status deployment/nginx --timeout=30m
+      - name: Update apt in python docker container
+        run: docker run python:3.10-slim apt update
   dep-test:
     # Test the dependencies in one job to avoid using too many runners at once.
     name: dependency test
@@ -50,4 +58,4 @@ jobs:
         run: python3 -m pip install check-jsonschema
       # Test program installed by pip. The directory `~/.local/bin` need to be added to PATH.
       - name: test check-jsonschema
-        run: check-jsonschema --version 
+        run: check-jsonschema --version

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -14,7 +14,7 @@ jobs:
         run: echo "hello world"
       - name: File permission for /usr/local/bin
         run: ls -ld /usr/local/bin | grep drwxrwxrwx
-      - name: Test fille permission for /usr/local/bin
+      - name: Test file permission for /usr/local/bin
         run: touch /usr/local/bin/test_file
       # "Install microk8s" step will test if the proxies settings are correct.
       - name: Proxy set in /etc/environment

--- a/.github/workflows/end_to_end_test.yaml
+++ b/.github/workflows/end_to_end_test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Proxy set in /etc/environment
         run: cat /etc/environment | grep HTTP_PROXY
       - name: Proxy set in docker daemon 
-        run: cat /etc/systemd/system/docker.service.d/http-proxy.conf | grep HTTP_PROXY
+        run: sudo cat /etc/systemd/system/docker.service.d/http-proxy.conf | grep HTTP_PROXY
       - name: Proxy set in docker client
         run: cat /home/ubuntu/.docker/config.json | grep httpProxy
       - name: Install microk8s

--- a/src/charm.py
+++ b/src/charm.py
@@ -235,7 +235,16 @@ class GithubRunnerCharm(CharmBase):
         Args:
             event: Event of charm upgrade.
         """
+        logger.info("Reinstalling dependencies...")
         GithubRunnerCharm._install_deps()
+
+        logger.info("Flushing the runners...")
+        runner_manager = self._get_runner_manager()
+        if not runner_manager:
+            return
+
+        runner_manager.flush()
+        self._reconcile_runners(runner_manager)
 
     @catch_unexpected_charm_errors
     def _on_config_changed(self, _event: ConfigChangedEvent) -> None:

--- a/src/lxd.py
+++ b/src/lxd.py
@@ -56,6 +56,7 @@ class LxdInstanceFileManager:
             "/snap/bin/lxc",
             "file",
             "push",
+            "--create-dirs",
             source,
             f"{self.instance.name}/{destination.lstrip('/')}",
         ]

--- a/src/runner.py
+++ b/src/runner.py
@@ -157,12 +157,23 @@ class Runner:
 
         # The runner should cleanup itself.  Cleanup on GitHub in case of runner cleanup error.
         if isinstance(self.config.path, GitHubRepo):
+            logger.debug(
+                "Ensure runner %s is removed from GitHub repo %s/%s",
+                self.config.name,
+                self.config.path.owner,
+                self.config.path.repo,
+            )
             self._clients.github.actions.delete_self_hosted_runner_from_repo(
                 owner=self.config.path.owner,
                 repo=self.config.path.repo,
                 runner_id=self.config.name,
             )
         if isinstance(self.config.path, GitHubOrg):
+            logger.debug(
+                "Ensure runner %s is removed from GitHub org %s",
+                self.config.name,
+                self.config.path.org,
+            )
             self._clients.github.actions.delete_self_hosted_runner_from_org(
                 org=self.config.path.org, runner_id=self.config.name
             )

--- a/src/runner.py
+++ b/src/runner.py
@@ -158,24 +158,27 @@ class Runner:
         # The runner should cleanup itself.  Cleanup on GitHub in case of runner cleanup error.
         if isinstance(self.config.path, GitHubRepo):
             logger.debug(
-                "Ensure runner %s is removed from GitHub repo %s/%s",
+                "Ensure runner %s with id %s is removed from GitHub repo %s/%s",
                 self.config.name,
+                self.status.runner_id,
                 self.config.path.owner,
                 self.config.path.repo,
             )
             self._clients.github.actions.delete_self_hosted_runner_from_repo(
                 owner=self.config.path.owner,
                 repo=self.config.path.repo,
-                runner_id=self.config.name,
+                runner_id=self.status.runner_id,
             )
         if isinstance(self.config.path, GitHubOrg):
             logger.debug(
-                "Ensure runner %s is removed from GitHub org %s",
+                "Ensure runner %s with id %s is removed from GitHub org %s",
                 self.config.name,
+                self.status.runner_id,
                 self.config.path.org,
             )
             self._clients.github.actions.delete_self_hosted_runner_from_org(
-                org=self.config.path.org, runner_id=self.config.name
+                org=self.config.path.org,
+                runner_id=self.status.runner_id,
             )
 
     @retry(tries=5, delay=1, local_logger=logger)

--- a/src/runner.py
+++ b/src/runner.py
@@ -156,30 +156,31 @@ class Runner:
                     raise RunnerRemoveError(f"Unable to remove {self.config.name}") from err
 
         # The runner should cleanup itself.  Cleanup on GitHub in case of runner cleanup error.
-        if isinstance(self.config.path, GitHubRepo):
-            logger.debug(
-                "Ensure runner %s with id %s is removed from GitHub repo %s/%s",
-                self.config.name,
-                self.status.runner_id,
-                self.config.path.owner,
-                self.config.path.repo,
-            )
-            self._clients.github.actions.delete_self_hosted_runner_from_repo(
-                owner=self.config.path.owner,
-                repo=self.config.path.repo,
-                runner_id=self.status.runner_id,
-            )
-        if isinstance(self.config.path, GitHubOrg):
-            logger.debug(
-                "Ensure runner %s with id %s is removed from GitHub org %s",
-                self.config.name,
-                self.status.runner_id,
-                self.config.path.org,
-            )
-            self._clients.github.actions.delete_self_hosted_runner_from_org(
-                org=self.config.path.org,
-                runner_id=self.status.runner_id,
-            )
+        if self.status.runner_id is not None:
+            if isinstance(self.config.path, GitHubRepo):
+                logger.debug(
+                    "Ensure runner %s with id %s is removed from GitHub repo %s/%s",
+                    self.config.name,
+                    self.status.runner_id,
+                    self.config.path.owner,
+                    self.config.path.repo,
+                )
+                self._clients.github.actions.delete_self_hosted_runner_from_repo(
+                    owner=self.config.path.owner,
+                    repo=self.config.path.repo,
+                    runner_id=self.status.runner_id,
+                )
+            if isinstance(self.config.path, GitHubOrg):
+                logger.debug(
+                    "Ensure runner %s with id %s is removed from GitHub org %s",
+                    self.config.name,
+                    self.status.runner_id,
+                    self.config.path.org,
+                )
+                self._clients.github.actions.delete_self_hosted_runner_from_org(
+                    org=self.config.path.org,
+                    runner_id=self.status.runner_id,
+                )
 
     @retry(tries=5, delay=1, local_logger=logger)
     def _create_instance(

--- a/src/runner.py
+++ b/src/runner.py
@@ -416,7 +416,7 @@ class Runner:
             self._put_file("/root/.docker/config.json", docker_client_proxy_content)
             self._put_file("/home/ubuntu/.docker/config.json", docker_client_proxy_content)
             self.instance.execute(
-                ["/usr/bin/chown", "-R", "ubuntu:ubuntu", "/home/ubuntu/.docker/config.json"]
+                ["/usr/bin/chown", "-R", "ubuntu:ubuntu", "/home/ubuntu/.docker"]
             )
 
     @retry(tries=5, delay=30, local_logger=logger)

--- a/src/runner.py
+++ b/src/runner.py
@@ -382,6 +382,8 @@ class Runner:
         self.instance.execute(["/usr/bin/sudo", "chmod", "u+x", str(self.runner_script)])
 
         # Set permission to the same as GitHub-hosted runner for this directory.
+        # Some GitHub Actions require this permission setting to run.
+        # As the user already has sudo access, this does not give the user any additional access.
         self.instance.execute(["/usr/bin/sudo", "chmod", "777", "/usr/local/bin"])
 
         # Load `/etc/environment` file.

--- a/src/runner.py
+++ b/src/runner.py
@@ -402,11 +402,6 @@ class Runner:
             self.instance.execute(["systemctl", "restart", "docker"])
 
             # Set docker client proxy config
-            # Configure the docker client for root user and ubuntu user.
-            docker_config_paths = (
-                Path("/home/ubuntu/.docker/config.json"),
-                Path("/root/.docker/config.json"),
-            )
             docker_client_proxy = {
                 "proxies": {
                     "default": {
@@ -417,8 +412,12 @@ class Runner:
                 }
             }
             docker_client_proxy_content = json.dumps(docker_client_proxy)
-            for path in docker_config_paths:
-                self._put_file(str(path), docker_client_proxy_content)
+            # Configure the docker client for root user and ubuntu user.
+            self._put_file("/root/.docker/config.json", docker_client_proxy_content)
+            self._put_file("/home/ubuntu/.docker/config.json", docker_client_proxy_content)
+            self.instance.execute(
+                ["/usr/bin/chown", "-R", "ubuntu:ubuntu", "/home/ubuntu/.docker/config.json"]
+            )
 
     @retry(tries=5, delay=30, local_logger=logger)
     def _register_runner(self, registration_token: str, labels: Sequence[str]) -> None:

--- a/src/runner.py
+++ b/src/runner.py
@@ -11,8 +11,8 @@ collection of `Runner` instances.
 """
 
 from __future__ import annotations
-import json
 
+import json
 import logging
 import time
 from pathlib import Path

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -411,6 +411,7 @@ class RunnerManager:
                 getattr(local_runner, "status", None),
             )
 
+            runner_id = getattr(remote_runner, "id", None)
             running = local_runner is not None
             online = getattr(remote_runner, "status", None) == "online"
             busy = getattr(remote_runner, "busy", None)
@@ -419,7 +420,7 @@ class RunnerManager:
             return Runner(
                 self._clients,
                 config,
-                RunnerStatus(running, online, busy),
+                RunnerStatus(runner_id, running, online, busy),
                 local_runner,
             )
 

--- a/src/runner_type.py
+++ b/src/runner_type.py
@@ -5,7 +5,7 @@
 
 
 from dataclasses import dataclass
-from typing import NamedTuple, TypedDict, Union
+from typing import NamedTuple, Optional, TypedDict, Union
 
 import jinja2
 from ghapi.all import GhApi
@@ -91,6 +91,7 @@ class RunnerStatus:
         busy: Whether GitHub marks this runner as busy.
     """
 
+    runner_id: Optional[int] = None
     exist: bool = False
     online: bool = False
     busy: bool = False

--- a/tests/unit/test_runner_manager.py
+++ b/tests/unit/test_runner_manager.py
@@ -125,7 +125,8 @@ def test_reconcile_remove_runner(runner_manager: RunnerManager):
         """Create three mock runners."""
         runners = []
         for _ in range(3):
-            status = RunnerStatus(True, True, False)
+            # 0 is a mock runner id.
+            status = RunnerStatus(0, True, True, False)
             runners.append(Runner(MagicMock(), MagicMock(), status, None))
         return runners
 


### PR DESCRIPTION
- Docker client proxy setting according to: https://docs.docker.com/network/proxy/#configure-the-docker-client. Should be the default proxy setting during run and build according to: https://docs.docker.com/network/proxy/#run-containers-with-a-proxy-configuration
- Set the `/usr/local/bin` permission to 777. This is the same as GitHub-hosted runners.
The GitHub-hosted runner has file permission set to 777:
```
ls -la /usr/local
...
drwxrwxrwx  2 root root  4096 May  7 22:37 bin
...
```
- Fix an issue with removal of runner on GitHub if runner failed to do so.
- Flush the runner on charm upgrade.