### PR TITLE
fix: yq

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -36,9 +36,6 @@ from runner_manager import RunnerManager, RunnerManagerConfig
 from runner_type import GitHubOrg, GitHubRepo, ProxySetting, VirtualMachineResources
 from utilities import bytes_with_unit_to_kib, execute_command, get_env_var, retry
 
-if TYPE_CHECKING:
-    from ops.model import JsonObject  # type: ignore
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,7 @@ import secrets
 import shutil
 import urllib.error
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, Optional, TypeVar
+from typing import Any, Callable, Dict, Optional, TypeVar
 
 import jinja2
 from ops.charm import (
@@ -35,9 +35,6 @@ from runner import LXD_PROFILE_YAML
 from runner_manager import RunnerManager, RunnerManagerConfig
 from runner_type import GitHubOrg, GitHubRepo, ProxySetting, VirtualMachineResources
 from utilities import bytes_with_unit_to_kib, execute_command, get_env_var, retry
-
-if TYPE_CHECKING:
-    from ops.model import JsonObject  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
@@ -529,7 +526,7 @@ class GithubRunnerCharm(CharmBase):
                 # Log but ignore error since we're stopping anyway.
                 logger.exception("Failed to clear runners")
 
-    def _reconcile_runners(self, runner_manager: RunnerManager) -> Dict[str, "JsonObject"]:
+    def _reconcile_runners(self, runner_manager: RunnerManager) -> Dict[str, Any]:
         """Reconcile the current runners state and intended runner state.
 
         Args:

--- a/src/runner.py
+++ b/src/runner.py
@@ -40,6 +40,7 @@ LXD_PROFILE_YAML = pathlib.Path(__file__).parent.parent / "lxd-profile.yaml"
 if not LXD_PROFILE_YAML.exists():
     LXD_PROFILE_YAML = LXD_PROFILE_YAML.parent / "lxd-profile.yml"
 
+
 @dataclass
 class WgetExecutable:
     """The executable to be installed through wget.
@@ -48,8 +49,10 @@ class WgetExecutable:
         url: The URL of the executable binary.
         cmd: Executable command name. E.g. yq_linux_amd64 -> yq
     """
+
     url: str
     cmd: str
+
 
 class Runner:
     """Single instance of GitHub self-hosted runner.
@@ -385,7 +388,14 @@ class Runner:
         # machines are created from custom images/GitHub runner image.
 
         self._apt_install(["docker.io", "npm", "python3-pip", "shellcheck", "jq", "wget"])
-        self._wget_install([WgetExecutable(url="https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_amd64", cmd="yq")])
+        self._wget_install(
+            [
+                WgetExecutable(
+                    url="https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_amd64",
+                    cmd="yq",
+                )
+            ]
+        )
 
         # Add the user to docker group.
         self.instance.execute(["/usr/sbin/usermod", "-aG", "docker", "ubuntu"])

--- a/src/runner.py
+++ b/src/runner.py
@@ -627,7 +627,7 @@ class Runner:
         images based on the GitHub action runner image will be used in the future.
 
         Args:
-            binary_urls: The URL to installable binaries.
+            executables: The executables to download.
         """
         if self.instance is None:
             raise RunnerError("Runner operation called prior to runner creation.")

--- a/src/runner.py
+++ b/src/runner.py
@@ -53,7 +53,7 @@ class Runner:
         busy (bool): Whether GitHub marks this runner as busy.
     """
 
-    runner_application = Path("/opt/github-runner")
+    runner_application = Path("/home/ubuntu/github-runner")
     env_file = runner_application / ".env"
     config_script = runner_application / "config.sh"
     runner_script = runner_application / "start.sh"

--- a/src/runner.py
+++ b/src/runner.py
@@ -635,5 +635,5 @@ class Runner:
         for executable in executables:
             executable_path = f"/usr/bin/{executable.cmd}"
             logger.info("Downloading %s via wget to %s...", executable.url, executable_path)
-            self.instance.execute(["wget", executable.url, "-O", executable_path])
-            self.instance.execute(["chmod", "+x", executable_path])
+            self.instance.execute(["/usr/bin/wget", executable.url, "-O", executable_path])
+            self.instance.execute(["/usr/bin/chmod", "+x", executable_path])

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -75,7 +75,7 @@ class RunnerInfo:
 class RunnerManager:
     """Manage a group of runners according to configuration."""
 
-    runner_bin_path = Path("/opt/github-runner-app")
+    runner_bin_path = Path("/home/ubuntu/github-runner-app")
 
     def __init__(
         self,

--- a/templates/start.j2
+++ b/templates/start.j2
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-(/opt/github-runner/run.sh; sudo systemctl halt -i) &>/dev/null &
+(/home/ubuntu/github-runner/run.sh; sudo systemctl halt -i) &>/dev/null &

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -100,7 +100,7 @@ def test_create(
 
     if runner.config.proxies:
         instance = instances[0]
-        env_proxy = instance.files.read_file("/opt/github-runner/.env")
+        env_proxy = instance.files.read_file("/home/ubuntu/github-runner/.env")
         systemd_docker_proxy = instance.files.read_file(
             "/etc/systemd/system/docker.service.d/http-proxy.conf"
         )


### PR DESCRIPTION
This PR addresses issues with snap installed `yq` that runs in confined mode which makes the CI pipeline fail.

Related issue: https://github.com/canonical/operator-workflows/pull/157

Further changes:
- ops update changes (`ops.model.JsonObject` is changed to `typing.Any`)
- pathing changes `/opt/github-runner/` is changed to `/home/ubuntu/` to match Github runner.