### PR TITLE
fix: use proxy for wget

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,11 @@
 name: Tests
 
 on:
-  pull_request: { }
+  pull_request: {}
 
 jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
+    with:
+      self-hosted-runner: false

--- a/src/runner.py
+++ b/src/runner.py
@@ -635,5 +635,12 @@ class Runner:
         for executable in executables:
             executable_path = f"/usr/bin/{executable.cmd}"
             logger.info("Downloading %s via wget to %s...", executable.url, executable_path)
-            self.instance.execute(["/usr/bin/wget", executable.url, "-O", executable_path])
+            wget_cmd = ["/usr/bin/wget", executable.url, "-O", executable_path]
+            if self.config.proxies["http"] or self.config.proxies["https"]:
+                wget_cmd += ["-e", "use_proxy=on"]
+            if self.config.proxies["http"]:
+                wget_cmd += ["-e", f"http_proxy={self.config.proxies['http']}"]
+            if self.config.proxies["https"]:
+                wget_cmd += ["-e", f"https_proxy={self.config.proxies['https']}"]
+            self.instance.execute(wget_cmd)
             self.instance.execute(["/usr/bin/chmod", "+x", executable_path])

--- a/src/runner.py
+++ b/src/runner.py
@@ -643,6 +643,6 @@ class Runner:
             if self.config.proxies["https"]:
                 wget_cmd += ["-e", f"https_proxy={self.config.proxies['https']}"]
             if self.config.proxies["no_proxy"]:
-                wget_cmd += ["-e", f"https_proxy={self.config.proxies['no_proxy']}"]
+                wget_cmd += ["-e", f"no_proxy={self.config.proxies['no_proxy']}"]
             self.instance.execute(wget_cmd)
             self.instance.execute(["/usr/bin/chmod", "+x", executable_path])

--- a/src/runner.py
+++ b/src/runner.py
@@ -636,13 +636,13 @@ class Runner:
             executable_path = f"/usr/bin/{executable.cmd}"
             logger.info("Downloading %s via wget to %s...", executable.url, executable_path)
             wget_cmd = ["/usr/bin/wget", executable.url, "-O", executable_path]
-            if self.config.proxies["http"] or self.config.proxies["https"]:
+            if self.config.proxies.get("http", None) or self.config.proxies.get("https", None):
                 wget_cmd += ["-e", "use_proxy=on"]
-            if self.config.proxies["http"]:
+            if self.config.proxies.get("http", None):
                 wget_cmd += ["-e", f"http_proxy={self.config.proxies['http']}"]
-            if self.config.proxies["https"]:
+            if self.config.proxies.get("https", None):
                 wget_cmd += ["-e", f"https_proxy={self.config.proxies['https']}"]
-            if self.config.proxies["no_proxy"]:
+            if self.config.proxies.get("no_proxy", None):
                 wget_cmd += ["-e", f"no_proxy={self.config.proxies['no_proxy']}"]
             self.instance.execute(wget_cmd)
             self.instance.execute(["/usr/bin/chmod", "+x", executable_path])

--- a/src/runner.py
+++ b/src/runner.py
@@ -620,24 +620,6 @@ class Runner:
             logger.info("Installing %s via APT...", pkg)
             self.instance.execute(["/usr/bin/apt-get", "install", "-yq", pkg])
 
-    def _get_filtered_proxies(self) -> tuple[str, str]:
-        """Filter http and https proxy with no proxy.
-
-        Returns:
-            Filtered http and https proxy values.
-        """
-        http_proxy = self.config.proxies["http"]
-        https_proxy = self.config.proxies["https"]
-        if not self.config.proxies["no_proxy"]:
-            return (http_proxy, https_proxy)
-
-        no_proxy_hosts = set(self.config.proxies["no_proxy"].split(","))
-        if http_proxy in no_proxy_hosts:
-            http_proxy = ""
-        if https_proxy in no_proxy_hosts:
-            https_proxy = ""
-        return (http_proxy, https_proxy)
-
     def _wget_install(self, executables: Iterable[WgetExecutable]) -> None:
         """Installs the given binaries.
 
@@ -654,12 +636,13 @@ class Runner:
             executable_path = f"/usr/bin/{executable.cmd}"
             logger.info("Downloading %s via wget to %s...", executable.url, executable_path)
             wget_cmd = ["/usr/bin/wget", executable.url, "-O", executable_path]
-            http_proxy, https_proxy = self._get_filtered_proxies()
-            if http_proxy or https_proxy:
+            if self.config.proxies["http"] or self.config.proxies["https"]:
                 wget_cmd += ["-e", "use_proxy=on"]
-            if http_proxy:
-                wget_cmd += ["-e", f"http_proxy={http_proxy}"]
-            if https_proxy:
-                wget_cmd += ["-e", f"https_proxy={https_proxy}"]
+            if self.config.proxies["http"]:
+                wget_cmd += ["-e", f"http_proxy={self.config.proxies['http']}"]
+            if self.config.proxies["https"]:
+                wget_cmd += ["-e", f"https_proxy={self.config.proxies['https']}"]
+            if self.config.proxies["no_proxy"]:
+                wget_cmd += ["-e", f"https_proxy={self.config.proxies['no_proxy']}"]
             self.instance.execute(wget_cmd)
             self.instance.execute(["/usr/bin/chmod", "+x", executable_path])


### PR DESCRIPTION
Tested command: `wget https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_amd64 -O yq -e use_proxy=yes http_proxy=127.0.0.1:8080 https_proxy=127.0.0.1:8080`

Output:
```
--2023-07-04 19:42:58--  http://http_proxy=127.0.0.1:8080/
Resolving http_proxy=127.0.0.1 (http_proxy=127.0.0.1)... failed: Name or service not known.
wget: unable to resolve host address 'http_proxy=127.0.0.1'
--2023-07-04 19:42:58--  http://https_proxy=127.0.0.1:8080/
Resolving https_proxy=127.0.0.1 (https_proxy=127.0.0.1)... failed: Name or service not known.
wget: unable to resolve host address 'https_proxy=127.0.0.1'
FINISHED --2023-07-04 19:42:58--
Total wall clock time: 1.3s
Downloaded: 1 files, 8.5M in 0.3s (27.6 MB/s)
```
Due to the stuck test runner (my bad!), attaching a screenshot to show that the tests pass.
<img width="1205" alt="image" src="https://github.com/canonical/github-runner-operator/assets/37652070/3c77d941-5eaf-4209-8cd9-beaee7494bbb">
