### PR TITLE
Use GA kernel over HWE kernel

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -317,7 +317,7 @@ class GithubRunnerCharm(CharmBase):
     def _upgrade_kernel(self) -> None:
         """Upgrade the Linux kernel."""
         execute_command(["/usr/bin/apt-get", "update"])
-        execute_command(["/usr/bin/apt-get", "install", "-qy", "linux-generic-hwe-22.04"])
+        execute_command(["/usr/bin/apt-get", "install", "-qy", "linux-generic"])
 
         _, exit_code = execute_command(["ls", "/var/run/reboot-required"], check_exit=False)
         if exit_code == 0:


### PR DESCRIPTION
The current charm uses HWE kernel to avoid a kernel bug.
Feedback from kernel team mention, the kernel in jammy-update (5.15.0-76.83) should includes some fixes.

From testing, this change should update the kernel to 5.15.0-76.83.
```
~$ uname -r
5.15.0-76-generic
~$ uname -v
#83-Ubuntu SMP Thu Jun 15 19:16:32 UTC 2023
```