### PR TITLE
Add workflow_dispatch github event handling and upgrade rpc

### DIFF
--- a/.github/workflows/workflow_dispatch_test.yaml
+++ b/.github/workflows/workflow_dispatch_test.yaml
@@ -1,0 +1,15 @@
+name: Workflow Dispatch Tests
+
+on:
+  # Manually dispatched workflow action
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: 'Self hosted gh runner'
+        required: true
+jobs:
+  workflow-dispatch-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run a one-line script
+        run: echo Hello, world of workflow dispatches!

--- a/src/charm.py
+++ b/src/charm.py
@@ -576,6 +576,7 @@ class GithubRunnerCharm(CharmBase):
         """Install dependencies."""
         logger.info("Installing charm dependencies.")
 
+        # Snap and Apt will use any proxies configured in the Juju model.
         # Binding for snap, apt, and lxd init commands are not available so subprocess.run used.
         execute_command(["/usr/bin/apt-get", "update"])
         # install dependencies used by repo-policy-compliance and the firewall
@@ -583,7 +584,7 @@ class GithubRunnerCharm(CharmBase):
             ["/usr/bin/apt-get", "install", "-qy", "gunicorn", "python3-pip", "nftables"]
         )
 
-        # Install repo-policy-compliance package.
+        # Prepare environment for pip subprocess
         env = {}
         if "http" in self.proxies:
             env["HTTP_PROXY"] = self.proxies["http"]
@@ -595,6 +596,7 @@ class GithubRunnerCharm(CharmBase):
             env["NO_PROXY"] = self.proxies["no_proxy"]
             env["no_proxy"] = self.proxies["no_proxy"]
 
+        # Install repo-policy-compliance package
         execute_command(
             [
                 "/usr/bin/pip",

--- a/src/charm.py
+++ b/src/charm.py
@@ -332,7 +332,7 @@ class GithubRunnerCharm(CharmBase):
             event: Event of charm upgrade.
         """
         logger.info("Reinstalling dependencies...")
-        self._install_deps(upgrade_compliance=True)
+        self._install_deps()
         self._start_services()
         self._refresh_firewall()
 
@@ -572,14 +572,8 @@ class GithubRunnerCharm(CharmBase):
             return {"delta": {"virtual-machines": 0}}
 
     @retry(tries=10, delay=15, max_delay=60, backoff=1.5, local_logger=logger)
-    def _install_deps(self, upgrade_compliance: bool = False) -> None:
-        """Install dependencies.
-
-        Args:
-            upgrade_compliance: Upgrade (True) or install (False)
-                the repo-policy-compliance package.
-
-        """
+    def _install_deps(self) -> None:
+        """Install dependencies."""
         logger.info("Installing charm dependencies.")
 
         # Binding for snap, apt, and lxd init commands are not available so subprocess.run used.
@@ -601,17 +595,13 @@ class GithubRunnerCharm(CharmBase):
             env["NO_PROXY"] = self.proxies["no_proxy"]
             env["no_proxy"] = self.proxies["no_proxy"]
 
-        command = [
-            "/usr/bin/pip",
-            "install",
-            "git+https://github.com/canonical/repo-policy-compliance@main",
-        ]
-
-        if upgrade_compliance is True:
-            command.insert(2, "--upgrade")
-
         execute_command(
-            command,
+            [
+                "/usr/bin/pip",
+                "install",
+                "--upgrade",
+                "git+https://github.com/canonical/repo-policy-compliance@main",
+            ],
             env=env,
         )
 

--- a/templates/pre-job.j2
+++ b/templates/pre-job.j2
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
+# Log common env variables.
+logger -s "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}, \
+  GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}, \
+  GITHUB_SHA: ${GITHUB_SHA}"
+
 # Workflow dispatch - Request repo-policy-compliance service check:
 if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
 
-  logger -s "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}, \
-  GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}, \
-  GITHUB_REF_NAME: ${GITHUB_REF_NAME}, \
-  GITHUB_SHA: ${GITHUB_SHA}"
+  logger -s "GITHUB_REF_NAME: ${GITHUB_REF_NAME}"
 
   curl --noproxy '*' \
       --fail-with-body \
@@ -20,13 +22,11 @@ elif [[ "${GITHUB_EVENT_NAME}" ==  "pull_request" ]]; then
 
   GITHUB_SOURCE_REPOSITORY=$(cat "${GITHUB_EVENT_PATH}" | jq -r '.pull_request.head.repo.full_name')
 
-  logger -s "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}, \
+  logger -s " \
   GITHUB_SOURCE_REPOSITORY: ${GITHUB_SOURCE_REPOSITORY}, \
-  GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}, \
   GITHUB_SOURCE_REPOSITORY: ${GITHUB_SOURCE_REPOSITORY} \
   GITHUB_BASE_REF: ${GITHUB_BASE_REF}, \
-  GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}, \
-  GITHUB_SHA: ${GITHUB_SHA}"
+  GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}"
 
   curl --noproxy '*' \
       --fail-with-body \

--- a/templates/pre-job.j2
+++ b/templates/pre-job.j2
@@ -1,11 +1,44 @@
 #!/usr/bin/env bash
 
-GITHUB_SOURCE_REPOSITORY=$(cat "${GITHUB_EVENT_PATH}" | jq -r '.pull_request.head.repo.full_name')
+# Workflow dispatch - Request repo-policy-compliance service check:
+if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
 
-# Request repo-policy-compliance service check.
-curl --noproxy '*' \
-    --fail-with-body \
-    -H 'Authorization: Bearer {{one_time_token}}' \
-    -H 'Content-Type: application/json' \
-    -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"source_repository_name\": \"${GITHUB_SOURCE_REPOSITORY}\", \"target_branch_name\": \"${GITHUB_BASE_REF}\", \"source_branch_name\": \"${GITHUB_HEAD_REF}\", \"commit_sha\": \"${GITHUB_SHA}\"}" \
-    http://{{host_ip}}:8080/check-run
+  logger -s "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}, \
+  GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}, \
+  GITHUB_REF_NAME: ${GITHUB_REF_NAME}, \
+  GITHUB_SHA: ${GITHUB_SHA}"
+
+  curl --noproxy '*' \
+      --fail-with-body \
+      -H 'Authorization: Bearer {{one_time_token}}' \
+      -H 'Content-Type: application/json' \
+      -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"branch_name\": \"${GITHUB_REF_NAME}\", \"commit_sha\": \"${GITHUB_SHA}\"}" \
+      http://{{host_ip}}:8080/workflow_dispatch/check-run
+
+# Pull request - Request repo-policy-compliance service check:
+elif [[ "${GITHUB_EVENT_NAME}" ==  "pull_request" ]]; then
+
+  GITHUB_SOURCE_REPOSITORY=$(cat "${GITHUB_EVENT_PATH}" | jq -r '.pull_request.head.repo.full_name')
+
+  logger -s "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}, \
+  GITHUB_SOURCE_REPOSITORY: ${GITHUB_SOURCE_REPOSITORY}, \
+  GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}, \
+  GITHUB_SOURCE_REPOSITORY: ${GITHUB_SOURCE_REPOSITORY} \
+  GITHUB_BASE_REF: ${GITHUB_BASE_REF}, \
+  GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}, \
+  GITHUB_SHA: ${GITHUB_SHA}"
+
+  curl --noproxy '*' \
+      --fail-with-body \
+      -H 'Authorization: Bearer {{one_time_token}}' \
+      -H 'Content-Type: application/json' \
+      -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"source_repository_name\": \"${GITHUB_SOURCE_REPOSITORY}\", \"target_branch_name\": \"${GITHUB_BASE_REF}\", \"source_branch_name\": \"${GITHUB_HEAD_REF}\", \"commit_sha\": \"${GITHUB_SHA}\"}" \
+      http://{{host_ip}}:8080/check-run
+
+else
+
+  logger -p user.error -s "${GITHUB_EVENT_NAME} is not handled."
+
+  return 1
+
+fi

--- a/templates/pre-job.j2
+++ b/templates/pre-job.j2
@@ -33,7 +33,7 @@ elif [[ "${GITHUB_EVENT_NAME}" ==  "pull_request" ]]; then
       -H 'Authorization: Bearer {{one_time_token}}' \
       -H 'Content-Type: application/json' \
       -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"source_repository_name\": \"${GITHUB_SOURCE_REPOSITORY}\", \"target_branch_name\": \"${GITHUB_BASE_REF}\", \"source_branch_name\": \"${GITHUB_HEAD_REF}\", \"commit_sha\": \"${GITHUB_SHA}\"}" \
-      http://{{host_ip}}:8080/check-run
+      http://{{host_ip}}:8080/pull_request/check-run
 
 else
 

--- a/templates/pre-job.j2
+++ b/templates/pre-job.j2
@@ -5,15 +5,18 @@ logger -s "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}, \
   GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}, \
   GITHUB_SHA: ${GITHUB_SHA}"
 
+# Prepare curl auth arguments
+CURL_AUTH_ARGS="--noproxy '*' \
+--fail-with-body \
+-H 'Authorization: Bearer {{one_time_token}}' \
+-H 'Content-Type: application/json'"
+
 # Workflow dispatch - Request repo-policy-compliance service check:
 if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
 
   logger -s "GITHUB_REF_NAME: ${GITHUB_REF_NAME}"
 
-  curl --noproxy '*' \
-      --fail-with-body \
-      -H 'Authorization: Bearer {{one_time_token}}' \
-      -H 'Content-Type: application/json' \
+  curl "${CURL_AUTH_ARGS}" \
       -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"branch_name\": \"${GITHUB_REF_NAME}\", \"commit_sha\": \"${GITHUB_SHA}\"}" \
       http://{{host_ip}}:8080/workflow_dispatch/check-run
 
@@ -28,10 +31,7 @@ elif [[ "${GITHUB_EVENT_NAME}" ==  "pull_request" ]]; then
   GITHUB_BASE_REF: ${GITHUB_BASE_REF}, \
   GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}"
 
-  curl --noproxy '*' \
-      --fail-with-body \
-      -H 'Authorization: Bearer {{one_time_token}}' \
-      -H 'Content-Type: application/json' \
+  curl "${CURL_AUTH_ARGS}" \
       -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"source_repository_name\": \"${GITHUB_SOURCE_REPOSITORY}\", \"target_branch_name\": \"${GITHUB_BASE_REF}\", \"source_branch_name\": \"${GITHUB_HEAD_REF}\", \"commit_sha\": \"${GITHUB_SHA}\"}" \
       http://{{host_ip}}:8080/pull_request/check-run
 

--- a/templates/pre-job.j2
+++ b/templates/pre-job.j2
@@ -5,8 +5,9 @@ logger -s "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}, \
   GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}, \
   GITHUB_SHA: ${GITHUB_SHA}"
 
-# Prepare curl auth arguments
-CURL_AUTH_ARGS="--noproxy '*' \
+# Prepare curl arguments
+CURL_ARGS="--max-time 60 \
+ --noproxy '*' \
 --fail-with-body \
 -H 'Authorization: Bearer {{one_time_token}}' \
 -H 'Content-Type: application/json'"
@@ -16,7 +17,7 @@ if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
 
   logger -s "GITHUB_REF_NAME: ${GITHUB_REF_NAME}"
 
-  curl "${CURL_AUTH_ARGS}" \
+  curl "${CURL_ARGS}" \
       -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"branch_name\": \"${GITHUB_REF_NAME}\", \"commit_sha\": \"${GITHUB_SHA}\"}" \
       http://{{host_ip}}:8080/workflow_dispatch/check-run
 
@@ -31,7 +32,7 @@ elif [[ "${GITHUB_EVENT_NAME}" ==  "pull_request" ]]; then
   GITHUB_BASE_REF: ${GITHUB_BASE_REF}, \
   GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}"
 
-  curl "${CURL_AUTH_ARGS}" \
+  curl "${CURL_ARGS}" \
       -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"source_repository_name\": \"${GITHUB_SOURCE_REPOSITORY}\", \"target_branch_name\": \"${GITHUB_BASE_REF}\", \"source_branch_name\": \"${GITHUB_HEAD_REF}\", \"commit_sha\": \"${GITHUB_SHA}\"}" \
       http://{{host_ip}}:8080/pull_request/check-run
 

--- a/templates/pre-job.j2
+++ b/templates/pre-job.j2
@@ -37,7 +37,7 @@ elif [[ "${GITHUB_EVENT_NAME}" ==  "pull_request" ]]; then
 
 else
 
-  logger -p user.error -s "${GITHUB_EVENT_NAME} is not handled."
+  logger -p user.error -s "${GITHUB_EVENT_NAME} is not supported yet. Please request it to be added on https://github.com/canonical/github-runner-operator/issues/new/choose"
 
   return 1
 


### PR DESCRIPTION
Requirements: 
 - A self-hosted runner should handle the workflow_dispatch event.
 - The repo-policy-compliance (rpc for short) should be updated to the latest version on charm upgrade.

This PR modifies pre-job.j2 allowing it to differentiate between different github events, handles workflow_dispatch and logs useful variables to syslog.
Also the repo-policy-compliance package is upgraded on upgrade_charm. 
