### PR TITLE
Pre-create microk8s group

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -72,7 +72,7 @@ jobs:
   deploy-e2e-test-runner:
     name: Deploy End-to-End Test Runner
     runs-on: ubuntu-latest
-    needs: [ build-charm, run-id ]
+    needs: [build-charm, run-id]
     steps:
       - name: Setup Lxd Juju Controller
         uses: charmed-kubernetes/actions-operator@main
@@ -121,7 +121,7 @@ jobs:
         timeout-minutes: 30
         run: |
           juju debug-log --replay --tail &
-          
+
           while :; do
             JOBS=$(gh api \
             -H "Accept: application/vnd.github+json" \
@@ -146,8 +146,8 @@ jobs:
 
   e2e-test:
     name: End-to-End Test
-    needs: [ build-charm, run-id ]
-    runs-on: [ self-hosted, linux, x64, "${{ needs.run-id.outputs.run-id }}" ]
+    needs: [build-charm, run-id]
+    runs-on: [self-hosted, linux, x64, "${{ needs.run-id.outputs.run-id }}"]
     steps:
       # below is a series of simple tests to assess the functionality of the newly spawned runner.
       - name: Echo hello world
@@ -174,7 +174,7 @@ jobs:
         run: sudo snap install microk8s --classic
       - name: Wait for microk8s
         timeout-minutes: 10
-        run: sudo microk8s status --wait-ready
+        run: microk8s status --wait-ready
       - name: Deploy nginx for testing
         run: sudo microk8s kubectl create deployment nginx --image=nginx
       - name: Wait for nginx to be ready

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -176,9 +176,9 @@ jobs:
         timeout-minutes: 10
         run: microk8s status --wait-ready
       - name: Deploy nginx for testing
-        run: sudo microk8s kubectl create deployment nginx --image=nginx
+        run: microk8s kubectl create deployment nginx --image=nginx
       - name: Wait for nginx to be ready
-        run: sudo microk8s kubectl rollout status deployment/nginx --timeout=30m
+        run: microk8s kubectl rollout status deployment/nginx --timeout=30m
       - name: Update apt in python docker container
         run: docker run python:3.10-slim apt update
       - name: Docker version

--- a/src/runner.py
+++ b/src/runner.py
@@ -387,6 +387,10 @@ class Runner:
         # TEMP: Install common tools used in GitHub Actions. This will be removed once virtual
         # machines are created from custom images/GitHub runner image.
 
+        # Pre-create the microk8s group and add the user to it.
+        self.instance.execute(["/usr/sbin/groupadd", "microk8s"])
+        self.instance.execute(["/usr/sbin/usermod", "-aG", "microk8s", "ubuntu"])
+
         self._apt_install(["docker.io", "npm", "python3-pip", "shellcheck", "jq", "wget"])
         self._wget_install(
             [
@@ -399,7 +403,6 @@ class Runner:
 
         # Add the user to docker group.
         self.instance.execute(["/usr/sbin/usermod", "-aG", "docker", "ubuntu"])
-        self.instance.execute(["/usr/bin/newgrp", "docker"])
 
         # The LXD instance is meant to run untrusted workload. Hardcoding the tmp directory should
         # be fine.


### PR DESCRIPTION
Create the `microk8s` group during runner setup.
The goal of this change is to allow the user of self-hosted runner to install `microk8s` and use it without `sudo`.