### PR TITLE
Point to the new pylxd package repo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ghapi
 jinja2
 ops
-pylxd @ git+https://github.com/lxc/pylxd
+pylxd @ git+https://github.com/canonical/pylxd
 requests
 typing-extensions
 # Newer version does not work with default OpenSSL version on jammy.


### PR DESCRIPTION
The `pylxd` package seems to have moved to https://github.com/canonical/pylxd.

This PR updates the entry in the file `requirements.txt`


----

This is the same as PR https://github.com/canonical/github-runner-operator/pull/82 but from a branch belonging to the repository.

This way the secrets will be accessible in the workflows.