### PR TITLE
Add integration test for repo-policy-compliance check failure 

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -24,7 +24,6 @@ jobs:
             --token ${{secrets.E2E_TESTING_TOKEN}} \
             --token-alt ${{secrets.E2E_TESTING_TOKEN_ALT}} \
             tests/integration/test_charm_no_runner.py
-
   integration-test-charm:
     name: Integration test charm
     runs-on: ubuntu-latest
@@ -45,3 +44,23 @@ jobs:
             --token ${{secrets.E2E_TESTING_TOKEN}} \
             --token-alt ${{secrets.E2E_TESTING_TOKEN_ALT}} \
             tests/integration/test_charm.py
+  integration-test-unsigned-commit-repo:
+    name: Integration test charm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: 3.1/stable
+          provider: lxd
+      - name: Enable br_netfilter
+        run: sudo modprobe br_netfilter
+      - name: Run Integration tests
+        run: |
+          tox -e integration -- \
+            --keep-models \
+            --path ${{secrets.E2E_TESTING_REPO}} \
+            --token ${{secrets.E2E_TESTING_TOKEN}} \
+            --token-alt ${{secrets.E2E_TESTING_TOKEN_ALT}} \
+            tests/integration/test_unsigned_commit_repo.py

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -44,7 +44,7 @@ jobs:
             --token ${{secrets.E2E_TESTING_TOKEN}} \
             --token-alt ${{secrets.E2E_TESTING_TOKEN_ALT}} \
             tests/integration/test_charm.py
-  integration-test-unsigned-commit-repo:
+  integration-test-repo-policy-compliance:
     name: Integration test repo policy compliance
     runs-on: ubuntu-latest
     steps:
@@ -72,7 +72,7 @@ jobs:
       - integration-test-charm
       - integration-test-unsigned-commit-repo
     if: always() && !cancelled()
-    timeout-minutes: 5
+    timeout-minutes: 30
     steps:
       - run: |
           [ '${{ needs.integration-test.result }}' = 'success' ] || (echo integration-test failed && false)

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -70,9 +70,11 @@ jobs:
     needs:
       - integration-test-charm-no-runner
       - integration-test-charm
-      - integration-test-unsigned-commit-repo
+      - integration-test-repo-policy-compliance
     if: always() && !cancelled()
     timeout-minutes: 30
     steps:
       - run: |
-          [ '${{ needs.integration-test.result }}' = 'success' ] || (echo integration-test failed && false)
+          [ '${{ needs.integration-test-charm-no-runner.result }}' = 'success' ] &&
+          [ '${{ needs.integration-test-charm.result }}' = 'success' ] &&
+          [ '${{ needs.integration-test-repo-policy-compliance.result }}' = 'success' ] || (echo integration-test failed && false)

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -45,7 +45,7 @@ jobs:
             --token-alt ${{secrets.E2E_TESTING_TOKEN_ALT}} \
             tests/integration/test_charm.py
   integration-test-unsigned-commit-repo:
-    name: Integration test charm
+    name: Integration test repo policy compliance
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -63,4 +63,4 @@ jobs:
             --path ${{secrets.E2E_TESTING_REPO}} \
             --token ${{secrets.E2E_TESTING_TOKEN}} \
             --token-alt ${{secrets.E2E_TESTING_TOKEN_ALT}} \
-            tests/integration/test_unsigned_commit_repo.py
+            tests/integration/test_repo_policy_compliance.py

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -64,3 +64,15 @@ jobs:
             --token ${{secrets.E2E_TESTING_TOKEN}} \
             --token-alt ${{secrets.E2E_TESTING_TOKEN_ALT}} \
             tests/integration/test_repo_policy_compliance.py
+  required_status_checks:
+    name: Required Integration Test Status Checks
+    runs-on: ubuntu-latest
+    needs:
+      - integration-test-charm-no-runner
+      - integration-test-charm
+      - integration-test-unsigned-commit-repo
+    if: always() && !cancelled()
+    timeout-minutes: 5
+    steps:
+      - run: |
+          [ '${{ needs.integration-test.result }}' = 'success' ] || (echo integration-test failed && false)

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -75,6 +75,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - run: |
-          [ '${{ needs.integration-test-charm-no-runner.result }}' = 'success' ] &&
-          [ '${{ needs.integration-test-charm.result }}' = 'success' ] &&
-          [ '${{ needs.integration-test-repo-policy-compliance.result }}' = 'success' ] || (echo integration-test failed && false)
+          [ '${{ needs.integration-test-charm-no-runner.result }}' = 'success' ] || (echo integration-test-charm-no-runner failed && false)
+          [ '${{ needs.integration-test-charm.result }}' = 'success' ] || (echo integration-test-charm failed && false)
+          [ '${{ needs.integration-test-repo-policy-compliance.result }}' = 'success' ] || (echo integration-test-repo-policy-compliance failed && false)

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,4 +1,4 @@
-name: Integration test
+name: Integration tests
 
 on:
   pull_request:

--- a/tests/integration/test_repo_policy_compliance.py
+++ b/tests/integration/test_repo_policy_compliance.py
@@ -39,7 +39,7 @@ def forked_github_repository(
     github_repository: Repository,
 ) -> Iterator[Repository]:
     """Create a fork for a GitHub repository."""
-    forked_repository = github_repository.create_fork(f"{github_repository.name}/{uuid4()}")
+    forked_repository = github_repository.create_fork(name=f"{github_repository.name}/{uuid4()}")
 
     # Wait for repo to be ready
     for _ in range(10):

--- a/tests/integration/test_repo_policy_compliance.py
+++ b/tests/integration/test_repo_policy_compliance.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+"""Integration tests for repo-policy-compliance with github-runner charm."""
+
 from time import sleep
 from typing import AsyncIterator, Iterator
 from uuid import uuid4
@@ -22,6 +24,7 @@ DISPATCH_TEST_WORKFLOW_FILENAME = "workflow_dispatch_test.yaml"
 
 @pytest.fixture(scope="module")
 def github_client(token: str) -> Github:
+    """Returns the github client."""
     return Github(token)
 
 
@@ -36,7 +39,7 @@ def forked_github_repository(
     github_repository: Repository,
 ) -> Iterator[Repository]:
     """Create a fork for a GitHub repository."""
-    forked_repository = github_repository.create_fork()
+    forked_repository = github_repository.create_fork(f"{github_repository.name}/{uuid4()}")
 
     # Wait for repo to be ready
     for _ in range(10):

--- a/tests/integration/test_repo_policy_compliance.py
+++ b/tests/integration/test_repo_policy_compliance.py
@@ -167,6 +167,7 @@ async def test_dispatch_workflow_failure(
         branch_with_unsigned_commit, {"runner": app_with_unsigned_commit_repo.name}
     )
 
+    # Wait until the runner is used up.
     for _ in range(30):
         runners = await get_runner_names(unit)
         if runner_to_be_used not in runners:
@@ -175,5 +176,7 @@ async def test_dispatch_workflow_failure(
     else:
         assert False, "Timeout wait for workflow to complete"
 
+    # The only job in the workflow is job that `echo` the runner name. If it fails then it should
+    # be the pre-run job that failed.
     run = workflow.get_runs()[0]
     assert run.jobs()[0].conclusion == "failure"

--- a/tests/integration/test_unsigned_commit_repo.py
+++ b/tests/integration/test_unsigned_commit_repo.py
@@ -1,0 +1,176 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from time import sleep
+from typing import AsyncIterator, Iterator
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from github import Consts, Github
+from github.Branch import Branch
+from github.GithubException import GithubException
+from github.Repository import Repository
+from juju.application import Application
+from juju.model import Model
+
+from tests.integration.helpers import assesrt_num_of_runners, get_runner_names
+from tests.status_name import ACTIVE_STATUS_NAME
+
+DISPATCH_TEST_WORKFLOW_FILENAME = "workflow_dispatch_test.yaml"
+
+
+@pytest.fixture(scope="module")
+def github_client(token: str) -> Github:
+    return Github(token)
+
+
+@pytest.fixture(scope="module")
+def github_repository(github_client: Github, path: str) -> Repository:
+    """Returns client to the Github repository."""
+    return github_client.get_repo(path)
+
+
+@pytest.fixture(scope="module")
+def forked_github_repository(
+    github_repository: Repository,
+) -> Iterator[Repository]:
+    """Create a fork for a GitHub repository."""
+    forked_repository = github_repository.create_fork()
+
+    # Wait for repo to be ready
+    for _ in range(10):
+        try:
+            sleep(10)
+            forked_repository.get_branches()
+            break
+        except GithubException:
+            pass
+    else:
+        assert False, "timed out whilst waiting for repository creation"
+
+    yield forked_repository
+
+    forked_repository.delete()
+
+
+@pytest.fixture(scope="module")
+def forked_github_branch(forked_github_repository: Repository) -> Iterator[Branch]:
+    """Create a new forked branch for testing."""
+    branch_name = f"test/{uuid4()}"
+
+    main_branch = forked_github_repository.get_branch(forked_github_repository.default_branch)
+    branch_ref = forked_github_repository.create_git_ref(
+        ref=f"refs/heads/{branch_name}", sha=main_branch.commit.sha
+    )
+    branch = forked_github_repository.get_branch(branch_name)
+
+    yield branch
+
+    branch_ref.delete()
+
+
+@pytest.fixture(scope="module")
+def branch_with_unsigned_commit(
+    forked_github_branch: Branch, forked_github_repository: Repository
+):
+    """Create branch that would fail the branch protection check.
+
+    Makes the branch the default branch for the repository and makes the latest commit unsigned.
+    """
+    # Make an unsigned commit
+    forked_github_repository.create_file(
+        "test.txt", "testing", "some content", branch=forked_github_branch.name
+    )
+
+    # Change default branch so that the commit is ignored by the check for unique commits being
+    # signed
+    forked_github_repository.edit(default_branch=forked_github_branch.name)
+
+    # forked_github_branch.edit_protection seems to be broken as of version 1.59 of PyGithub.
+    # Without passing the users_bypass_pull_request_allowances the API returns a 422 indicating
+    # that None is not a valid value for bypass pull request allowances, with it there is a 422 for
+    # forks indicating that users and teams allowances can only be set on organisation
+    # repositories.
+    post_parameters = {
+        "required_status_checks": None,
+        "enforce_admins": None,
+        "required_pull_request_reviews": {"dismiss_stale_reviews": False},
+        "restrictions": None,
+    }
+    # pylint: disable=protected-access
+    forked_github_branch._requester.requestJsonAndCheck(  # type: ignore
+        "PUT",
+        forked_github_branch.protection_url,
+        headers={"Accept": Consts.mediaTypeRequireMultipleApprovingReviews},
+        input=post_parameters,
+    )
+    # pylint: enable=protected-access
+    forked_github_branch.add_required_signatures()
+
+    yield forked_github_branch
+
+    forked_github_branch.remove_protection()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def app_with_unsigned_commit_repo(
+    model: Model, app_no_runner: Application, forked_github_repository: Repository
+) -> AsyncIterator[Application]:
+    """Application with a single runner on a repo with unsigned commit.
+
+    Test should ensure it returns with the application in a good state and has
+    one runner.
+    """
+    unit = app_no_runner.units[0]
+
+    await app_no_runner.set_config(
+        {"virtual-machines": "1", "path": forked_github_repository.full_name}
+    )
+    action = await unit.run_action("reconcile-runners")
+    await action.wait()
+    await model.wait_for_idle(status=ACTIVE_STATUS_NAME)
+
+    # Wait until there is one runner.
+    await assesrt_num_of_runners(unit, 1)
+
+    yield app_no_runner
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_dispatch_workflow_failure(
+    app_with_unsigned_commit_repo: Application,
+    forked_github_repository: Repository,
+    branch_with_unsigned_commit: Branch,
+) -> None:
+    """
+    arrange:
+        1. A forked repository with unsigned commit in default branch.
+        2. A working application with one runner on the forked repository.
+    act: Trigger a workflow dispatch on a branch in the forked repository.
+    assert: The workflow that was dispatched failed.
+    """
+    unit = app_with_unsigned_commit_repo.units[0]
+    runners = await get_runner_names(unit)
+    assert len(runners) == 1
+    runner_to_be_used = runners[0]
+
+    workflow = forked_github_repository.get_workflow(id_or_name=DISPATCH_TEST_WORKFLOW_FILENAME)
+
+    assert not list(workflow.get_runs()), "Existing workflow runs in created fork repo"
+
+    workflow.create_dispatch(
+        branch_with_unsigned_commit, {"runner": app_with_unsigned_commit_repo.name}
+    )
+
+    for _ in range(30):
+        runners = await get_runner_names(unit)
+        if runner_to_be_used not in runners:
+            break
+        sleep(30)
+    else:
+        assert False, "Timeout wait for workflow to complete"
+
+    run = workflow.get_runs()[0]
+    assert run.jobs()[0].conclusion == "failure"

--- a/tox.ini
+++ b/tox.ini
@@ -106,6 +106,7 @@ deps =
     pytest-operator
     pytest-asyncio
     pyyaml
+    pygithub
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
Added test for repo-policy-compliance failure on job start. This is to ensure the runner correctly stops jobs that does not pass repo-policy-compliance check.

The end-to-end test will check for success case of the repo-policy-compliance check.