### PR TITLE
Allow traffic for docker user

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -22,7 +22,6 @@ jobs:
             security.nesting: true
             security.privileged: true
             raw.lxc: |
-              lxc.apparmor.profile=unconfined
               lxc.mount.auto=proc:rw sys:rw cgroup:rw
               lxc.cgroup.devices.allow=a
               lxc.cap.drop=

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -22,6 +22,7 @@ jobs:
             security.nesting: true
             security.privileged: true
             raw.lxc: |
+              lxc.apparmor.profile=unconfined
               lxc.mount.auto=proc:rw sys:rw cgroup:rw
               lxc.cgroup.devices.allow=a
               lxc.cap.drop=

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -270,7 +270,9 @@ jobs:
           [[ -z "${http_proxy}" && -z "${HTTP_PROXY}" ]] \
             || cat /home/ubuntu/.docker/config.json | grep httpProxy
       - name: Install microk8s
-        run: sudo snap install microk8s --classic
+        # TMP: Pin version of microk8s to older version due to issues with running microk8s in LXD
+        # containers. Currently, in discussion with microk8s developer on the issue.
+        run: sudo snap install microk8s --classic --channel=1.24/stable
       - name: Wait for microk8s
         timeout-minutes: 10
         run: microk8s status --wait-ready

--- a/src/charm.py
+++ b/src/charm.py
@@ -725,6 +725,7 @@ class GithubRunnerCharm(CharmBase):
                 "security.port_isolation=true",
             ]
         )
+        execute_command(["/usr/sbin/service", "snapd.apparmor", "start"])
         logger.info("Finished installing charm dependencies.")
 
     @retry(tries=10, delay=15, max_delay=60, backoff=1.5, local_logger=logger)

--- a/src/charm.py
+++ b/src/charm.py
@@ -725,7 +725,6 @@ class GithubRunnerCharm(CharmBase):
                 "security.port_isolation=true",
             ]
         )
-        execute_command(["/usr/sbin/service", "snapd.apparmor", "start"])
         logger.info("Finished installing charm dependencies.")
 
     @retry(tries=10, delay=15, max_delay=60, backoff=1.5, local_logger=logger)

--- a/src/runner.py
+++ b/src/runner.py
@@ -423,6 +423,8 @@ class Runner:
 
         # Add the user to docker group.
         self.instance.execute(["/usr/sbin/usermod", "-aG", "docker", "ubuntu"])
+        # Allow traffic for docker user.
+        self.instance.execute(["/usr/sbin/iptables", "-I", "DOCKER-USER", "-j", "ACCEPT"])
 
         # The LXD instance is meant to run untrusted workload. Hardcoding the tmp directory should
         # be fine.


### PR DESCRIPTION
Run command within self-hosted runner instance to allow docker user to access network.
Docker is installed within the self-hosted runner by default, however this configuration change was missing.