### PR TITLE
Automatically add LXD instance name to NO_PROXY

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -94,8 +94,12 @@ class Runner:
         self.instance = instance
 
         # If the proxy setting are set, then add NO_PROXY local variables.
-        if self.config.proxies["no_proxy"]:
-            self.config.proxies["no_proxy"] += f",{self.config.name},.svc"
+        if self.config.proxies.get("http") or self.config.proxies.get("https"):
+            if self.config.proxies.get("no_proxy"):
+                self.config.proxies["no_proxy"] += ","
+            self.config.proxies[
+                "no_proxy"
+            ] += f"localhost,{self.config.name},.svc,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,::1"
 
     def create(
         self,

--- a/src/runner.py
+++ b/src/runner.py
@@ -93,9 +93,9 @@ class Runner:
         self.status = runner_status
         self.instance = instance
 
-        # Add the LXD instance name to no_proxy if no_proxy setting is used.
+        # If the proxy setting are set, then add NO_PROXY local variables.
         if self.config.proxies["no_proxy"]:
-            self.config.proxies["no_proxy"] += f",{self.config.name}"
+            self.config.proxies["no_proxy"] += f",{self.config.name},.svc"
 
     def create(
         self,

--- a/src/runner.py
+++ b/src/runner.py
@@ -97,9 +97,11 @@ class Runner:
         if self.config.proxies.get("http") or self.config.proxies.get("https"):
             if self.config.proxies.get("no_proxy"):
                 self.config.proxies["no_proxy"] += ","
-            self.config.proxies[
-                "no_proxy"
-            ] += f"localhost,{self.config.name},.svc,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,::1"
+            self.config.proxies["no_proxy"] += (
+                "localhost,127.0.0.1,::1,"
+                "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,"
+                f"{self.config.name},.svc"
+            )
 
     def create(
         self,

--- a/src/runner.py
+++ b/src/runner.py
@@ -506,6 +506,9 @@ class Runner:
         self._put_file(str(self.env_file), env_contents)
         self.instance.execute(["/usr/bin/chown", "ubuntu:ubuntu", str(self.env_file)])
 
+        # Ensure the apparmor service is running.
+        self.instance.execute(["/usr/sbin/service", "snapd.apparmor", "start"])
+
         if self.config.proxies:
             # Creating directory and putting the file are idempotent, and can be retried.
             logger.info("Adding proxy setting to the runner.")

--- a/src/runner.py
+++ b/src/runner.py
@@ -97,11 +97,7 @@ class Runner:
         if self.config.proxies.get("http") or self.config.proxies.get("https"):
             if self.config.proxies.get("no_proxy"):
                 self.config.proxies["no_proxy"] += ","
-            self.config.proxies["no_proxy"] += (
-                "localhost,127.0.0.1,::1,"
-                "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,"
-                f"{self.config.name},.svc"
-            )
+            self.config.proxies["no_proxy"] += f"{self.config.name},.svc"
 
     def create(
         self,

--- a/src/runner.py
+++ b/src/runner.py
@@ -506,15 +506,6 @@ class Runner:
         self._put_file(str(self.env_file), env_contents)
         self.instance.execute(["/usr/bin/chown", "ubuntu:ubuntu", str(self.env_file)])
 
-        # Ensure the apparmor service is running.
-        self.instance.execute(["/usr/bin/systemctl", "start", "apparmor"])
-        self.instance.execute(
-            ["/usr/sbin/apparmor_parser", "-r", "/etc/apparmor.d/*snap-confine*"]
-        )
-        self.instance.execute(
-            ["/usr/sbin/apparmor_parser", "-r", "/var/lib/snapd/apparmor/profiles/snap-confine*"]
-        )
-
         if self.config.proxies:
             # Creating directory and putting the file are idempotent, and can be retried.
             logger.info("Adding proxy setting to the runner.")

--- a/src/runner.py
+++ b/src/runner.py
@@ -507,7 +507,13 @@ class Runner:
         self.instance.execute(["/usr/bin/chown", "ubuntu:ubuntu", str(self.env_file)])
 
         # Ensure the apparmor service is running.
-        self.instance.execute(["/usr/sbin/service", "snapd.apparmor", "start"])
+        self.instance.execute(["/usr/bin/systemctl", "start", "apparmor"])
+        self.instance.execute(
+            ["/usr/sbin/apparmor_parser", "-r", "/etc/apparmor.d/*snap-confine*"]
+        )
+        self.instance.execute(
+            ["/usr/sbin/apparmor_parser", "-r", "/var/lib/snapd/apparmor/profiles/snap-confine*"]
+        )
 
         if self.config.proxies:
             # Creating directory and putting the file are idempotent, and can be retried.

--- a/src/runner.py
+++ b/src/runner.py
@@ -93,6 +93,10 @@ class Runner:
         self.status = runner_status
         self.instance = instance
 
+        # Add the LXD instance name to no_proxy if no_proxy setting is used.
+        if self.config.proxies["no_proxy"]:
+            self.config.proxies["no_proxy"] += f",{self.config.name}"
+
     def create(
         self,
         image: str,


### PR DESCRIPTION
### Overview

Append needed no_proxy variable if http_proxy or https_proxy are used.

The appended variables are:
* The LXD instance name this is used by microk8s to refer to the localhost.
* `.svc` used by k8s/microk8s local services.
The above are added since they are specific to k8s/microk8s and the self-hosted runner are configured to support them if they are installed.

The following are not added as normally, these would be set by the user of the proxy.
* Local IPv4 address (`10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`)
* Localhost address (`localhost,127.0.0.1,::1`)

### Rationale

This is needed for microk8s to run on the self-hosted runners.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
The `src-docs` for this repo is still WIP. There is an WIP PR for it.