### PR TITLE
Update maintainers to new format

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,7 +4,7 @@
 name: github-runner
 display-name: GitHub runner
 maintainers:
-  - launchpad.net/~canonical-is-devops
+  - https://launchpad.net/~canonical-is-devops
 docs: https://discourse.charmhub.io/t/github-runner-documentation-overview/7817
 issues: https://github.com/canonical/github-runner-operator/issues
 source: https://github.com/canonical/github-runner-operator


### PR DESCRIPTION
### Overview

Update the maintainers in `metadata.yaml` to the new format.

### Rationale

Needed for the charm to build with newer version of `charmcraft`.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
The `src-docs` for this repo is still WIP. There is an WIP PR for it.