### PR TITLE
Flush runner during install hook as temp fix for juju issue.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -288,6 +288,7 @@ class GithubRunnerCharm(CharmBase):
             # The charm cannot proceed without dependencies.
             self.unit.status = BlockedStatus("Failed to install dependencies")
             return
+
         self._refresh_firewall()
         runner_manager = self._get_runner_manager()
         if runner_manager:
@@ -309,6 +310,10 @@ class GithubRunnerCharm(CharmBase):
 
             self.unit.status = MaintenanceStatus("Starting runners")
             try:
+                # TMP: Juju install event can be emitted multiple times after rebooting the juju
+                # machine. This results install event can be fired while runners exists. Flushing
+                # these runners as temp solution.
+                runner_manager.flush()
                 self._reconcile_runners(runner_manager)
                 self.unit.status = ActiveStatus()
             except RunnerError as err:
@@ -416,9 +421,6 @@ class GithubRunnerCharm(CharmBase):
         if not runner_manager:
             return False
 
-        self.unit.status = MaintenanceStatus("Checking for service updates")
-        service_updated = self._install_repo_policy_compliance()
-
         # Check if the runner binary file exists.
         if not runner_manager.check_runner_bin():
             self._stored.runner_bin_url = None
@@ -446,12 +448,17 @@ class GithubRunnerCharm(CharmBase):
             self._stored.runner_bin_url = runner_info.download_url
             runner_bin_updated = True
 
+        self.unit.status = MaintenanceStatus("Checking for service updates")
+        service_updated = self._install_repo_policy_compliance()
+
         if service_updated or runner_bin_updated:
             logger.info(
                 "Flushing runner due to: service updated=%s, runner binary update=%s",
                 service_updated,
                 runner_bin_updated,
             )
+
+            self.unit.status = MaintenanceStatus("Flushing runners due to updated deps")
 
             self._start_services()
             runner_manager.flush(flush_busy=False)


### PR DESCRIPTION
### Overview

Flushing runner during install hook.

### Rationale

There is an issue where juju install event is emitted twice after reboot. This cause the application to have runners while the install hook is being ran. This change prevents bugs arising from this issue.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
The `src-docs` for this repo is still WIP. There is an WIP PR for it.