### PR TITLE
Add support for push event

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -154,8 +154,8 @@ jobs:
             exit 1
           fi
 
-      - name: Watch github-runner (Workflow Dispatch)
-        if: matrix.event.name == 'workflow_dispatch'
+      - name: Watch github-runner (Workflow Dispatch and Push)
+        if: matrix.event.name == 'workflow_dispatch' || matrix.event.name == 'push'
         env:
           GH_TOKEN: ${{ secrets.E2E_TESTING_TOKEN }}
         run: |
@@ -169,6 +169,8 @@ jobs:
             --jq .object.sha)
 
           # Create a temporary reference/branch
+          # For push, this should trigger the "Push Event Tests" workflow automatically
+          # because the test is run for branches matching the pattern "push-e2e-*"
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
@@ -177,11 +179,13 @@ jobs:
             -f ref='refs/heads/${{ steps.runner-name.outputs.name }}' \
             -f sha=$REF_SHA
 
-          # Dispatch other workflow
-          gh workflow run workflow_dispatch_test.yaml \
-            -R ${{ secrets.E2E_TESTING_REPO }} \
-            --ref ${{ steps.runner-name.outputs.name }} \
-            -f runner=${{ steps.runner-name.outputs.name }}
+          # For workflow_dispatch, we need to trigger the "Workflow Dispatch Tests" workflow manually
+          if ${{ matrix.event.name == 'workflow_dispatch' }}; then
+            gh workflow run workflow_dispatch_test.yaml \
+              -R ${{ secrets.E2E_TESTING_REPO }} \
+              --ref ${{ steps.runner-name.outputs.name }} \
+              -f runner=${{ steps.runner-name.outputs.name }}
+          fi
 
           get-workflow-status() {
               # Search recent workflow runs for the one designated by the run-id ref
@@ -228,80 +232,12 @@ jobs:
             echo "Workflow completed with status: $status, conclusion: $conclusion, run-id: ${{ steps.runner-name.outputs.name }}"
             kill $(jobs -p)
           fi
-      - name: Watch github-runner (Push)
-        if: matrix.event.name == 'push'
-        env:
-          GH_TOKEN: ${{ secrets.E2E_TESTING_TOKEN }}
-        run: |
-          juju debug-log --replay --tail &
-
-          # Base any future branches on the current branch
-          REF_SHA=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ secrets.E2E_TESTING_REPO }}/git/ref/heads/$GITHUB_HEAD_REF \
-            --jq .object.sha)
-
-          # Create a push-test-* branch, which should trigger the push test
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ secrets.E2E_TESTING_REPO }}/git/refs \
-            -f ref='refs/heads/push-test-${{ steps.runner-name.outputs.name }}' \
-            -f sha=$REF_SHA
-
-          get-workflow-status() {
-              # Search recent workflow runs for the one designated by the run-id ref
-              output=$(gh run list \
-                        -R ${{ secrets.E2E_TESTING_REPO }} \
-                        -L 100 \
-                        --json headBranch,status \
-                        --jq '[.[] | select(.headBranch=="push-test-${{ steps.runner-name.outputs.name }}")]')
-
-              # Workflows that have not started have no status
-              if [ $(echo "$output" | jq 'length') -eq 0 ]
-              then
-                  echo "not_started"
-              else
-                  # Parse output with jq to get the status field of the first object
-                  status=$(echo "$output" | jq -r '.[0].status')
-                  echo "$status"
-              fi
-          }
-
-          # Wait for the workflow to start while checking its status
-          for i in {1..360}
-          do
-            status=$(get-workflow-status)
-            echo "workflow status: $status"
-            if [[ $status != "not_started" && $status != "queued" && $status != "in_progress" ]]; then
-              break
-            fi
-            sleep 10
-          done
-
-          # Make sure the workflow was completed or else consider it failed
-          conclusion=$(gh run list \
-            -R ${{ secrets.E2E_TESTING_REPO }} \
-            -L 100 \
-            --json headBranch,conclusion \
-            --jq '.[] | select(.headBranch=="push-test-${{ steps.runner-name.outputs.name }}") | .conclusion')
-
-          if [[ $status != "completed" || $conclusion != "success" ]]; then
-            echo "test workflow failed with status: $status, conclusion: $conclusion"
-            kill $(jobs -p)
-            exit 1
-          else
-            echo "Workflow completed with status: $status, conclusion: $conclusion, run-id: ${{ steps.runner-name.outputs.name }}"
-            kill $(jobs -p)
-          fi
       - name: Show Firewall Rules
         run: |
           juju ssh ${{ steps.runner-name.outputs.name }}/0 sudo nft list ruleset
 
-      - name: Clean Up (Workflow Dispatch)
-        if: always() && matrix.event.name == 'workflow_dispatch'
+      - name: Clean Up (Workflow Dispatch and Push)
+        if: always() && (matrix.event.name == 'workflow_dispatch' || matrix.event.name == 'push')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -311,18 +247,6 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           "/repos/${{ secrets.E2E_TESTING_REPO }}/git/refs/heads/${{ steps.runner-name.outputs.name }}"
           echo "Deleted ref ${{ steps.runner-name.outputs.name }}"
-
-      - name: Clean Up (Push)
-        if: always() && matrix.event.name == 'push'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-            gh api \
-            --method DELETE \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/${{ secrets.E2E_TESTING_REPO }}/git/refs/heads/push-test-${{ steps.runner-name.outputs.name }}"
-            echo "Deleted ref push-test-${{ steps.runner-name.outputs.name }}"
 
   e2e-test:
     name: End-to-End Test

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -80,6 +80,8 @@ jobs:
             abbreviation: pr
           - name: workflow_dispatch
             abbreviation: wd
+          - name: push
+            abbreviation: push
     steps:
       - name: Setup Lxd Juju Controller
         uses: charmed-kubernetes/actions-operator@main
@@ -226,12 +228,79 @@ jobs:
             echo "Workflow completed with status: $status, conclusion: $conclusion, run-id: ${{ steps.runner-name.outputs.name }}"
             kill $(jobs -p)
           fi
+      - name: Watch github-runner (Push)
+        if: matrix.event.name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.E2E_TESTING_TOKEN }}
+        run: |
+          juju debug-log --replay --tail &
 
+          # Base any future branches on the current branch
+          REF_SHA=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ secrets.E2E_TESTING_REPO }}/git/ref/heads/$GITHUB_HEAD_REF \
+            --jq .object.sha)
+
+          # Create a push-test-* branch, which should trigger the push test
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ secrets.E2E_TESTING_REPO }}/git/refs \
+            -f ref='refs/heads/push-test-${{ steps.runner-name.outputs.name }}' \
+            -f sha=$REF_SHA
+
+          get-workflow-status() {
+              # Search recent workflow runs for the one designated by the run-id ref
+              output=$(gh run list \
+                        -R ${{ secrets.E2E_TESTING_REPO }} \
+                        -L 100 \
+                        --json headBranch,status \
+                        --jq '[.[] | select(.headBranch=="push-test-${{ steps.runner-name.outputs.name }})]')
+
+              # Workflows that have not started have no status
+              if [ $(echo "$output" | jq 'length') -eq 0 ]
+              then
+                  echo "not_started"
+              else
+                  # Parse output with jq to get the status field of the first object
+                  status=$(echo "$output" | jq -r '.[0].status')
+                  echo "$status"
+              fi
+          }
+
+          # Wait for the workflow to start while checking its status
+          for i in {1..360}
+          do
+            status=$(get-workflow-status)
+            echo "workflow status: $status"
+            if [[ $status != "not_started" && $status != "queued" && $status != "in_progress" ]]; then
+              break
+            fi
+            sleep 10
+          done
+
+          # Make sure the workflow was completed or else consider it failed
+          conclusion=$(gh run list \
+            -R ${{ secrets.E2E_TESTING_REPO }} \
+            -L 100 \
+            --json headBranch,conclusion \
+            --jq '.[] | select(.headBranch=="push-test-${{ steps.runner-name.outputs.name }}") | .conclusion')
+
+          if [[ $status != "completed" || $conclusion != "success" ]]; then
+            echo "test workflow failed with status: $status, conclusion: $conclusion"
+            kill $(jobs -p)
+            exit 1
+          else
+            echo "Workflow completed with status: $status, conclusion: $conclusion, run-id: ${{ steps.runner-name.outputs.name }}"
+            kill $(jobs -p)
+          fi
       - name: Show Firewall Rules
         run: |
           juju ssh ${{ steps.runner-name.outputs.name }}/0 sudo nft list ruleset
 
-      - name: Clean Up
+      - name: Clean Up (Workflow Dispatch)
         if: always() && matrix.event.name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -242,6 +311,18 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           "/repos/${{ secrets.E2E_TESTING_REPO }}/git/refs/heads/${{ steps.runner-name.outputs.name }}"
           echo "Deleted ref ${{ steps.runner-name.outputs.name }}"
+
+      - name: Clean Up (Push)
+        if: always() && matrix.event.name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+            gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ secrets.E2E_TESTING_REPO }}/git/refs/heads/push-test-${{ steps.runner-name.outputs.name }}"
+            echo "Deleted ref push-test-${{ steps.runner-name.outputs.name }}"
 
   e2e-test:
     name: End-to-End Test

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -257,7 +257,7 @@ jobs:
                         -R ${{ secrets.E2E_TESTING_REPO }} \
                         -L 100 \
                         --json headBranch,status \
-                        --jq '[.[] | select(.headBranch=="push-test-${{ steps.runner-name.outputs.name }})]')
+                        --jq '[.[] | select(.headBranch=="push-test-${{ steps.runner-name.outputs.name }}")]')
 
               # Workflows that have not started have no status
               if [ $(echo "$output" | jq 'length') -eq 0 ]

--- a/.github/workflows/push_test.yaml
+++ b/.github/workflows/push_test.yaml
@@ -1,0 +1,23 @@
+name: Push Event Tests
+
+on:
+  push:
+    branches:
+      - push-test-*
+
+jobs:
+  runner-name:
+    name: Extract runner name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract runner name
+        id: runner-name
+        run: |
+          echo "Extracting runner name from branch: ${{ github.ref_name }}"
+          echo name=$(echo ${{ github.ref_name }} | cut -c 11-) >> $GITHUB_OUTPUT
+  push-event-tests:
+    runs-on: [self-hosted, linux, x64, "${{ needs.runner-name.outputs.runner-name }}"]
+    steps:
+      - name: Echo runner name
+        run: |
+          echo "Hello, runner: ${{ needs.runner-name.outputs.runner-name }}"

--- a/.github/workflows/push_test.yaml
+++ b/.github/workflows/push_test.yaml
@@ -3,25 +3,12 @@ name: Push Event Tests
 on:
   push:
     branches:
-      - push-test-*
+      - push-e2e-*
 
 jobs:
-  runner-name:
-    name: Extract runner name
-    runs-on: ubuntu-latest
-    outputs:
-      runner-name: ${{ steps.runner-name.outputs.name }}
-    steps:
-      - name: Extract runner name
-        id: runner-name
-        run: |
-          echo "Extracting runner name from branch: ${{ github.ref_name }}"
-          echo name=$(echo ${{ github.ref_name }} | cut -c 11-) >> $GITHUB_OUTPUT
-
   push-event-tests:
-    runs-on: [self-hosted, linux, x64, "${{ needs.runner-name.outputs.runner-name }}"]
-    needs: runner-name
+    runs-on: [self-hosted, linux, x64, "${{ github.ref_name }}"]
     steps:
       - name: Echo runner name
         run: |
-          echo "Hello, runner: ${{ needs.runner-name.outputs.runner-name }}"
+          echo "Hello, runner: ${{ github.ref_name }}"

--- a/.github/workflows/push_test.yaml
+++ b/.github/workflows/push_test.yaml
@@ -9,12 +9,15 @@ jobs:
   runner-name:
     name: Extract runner name
     runs-on: ubuntu-latest
+    outputs:
+      runner-name: ${{ steps.runner-name.outputs.name }}
     steps:
       - name: Extract runner name
         id: runner-name
         run: |
           echo "Extracting runner name from branch: ${{ github.ref_name }}"
           echo name=$(echo ${{ github.ref_name }} | cut -c 11-) >> $GITHUB_OUTPUT
+
   push-event-tests:
     runs-on: [self-hosted, linux, x64, "${{ needs.runner-name.outputs.runner-name }}"]
     steps:

--- a/.github/workflows/push_test.yaml
+++ b/.github/workflows/push_test.yaml
@@ -20,6 +20,7 @@ jobs:
 
   push-event-tests:
     runs-on: [self-hosted, linux, x64, "${{ needs.runner-name.outputs.runner-name }}"]
+    needs: runner-name
     steps:
       - name: Echo runner name
         run: |

--- a/templates/pre-job.j2
+++ b/templates/pre-job.j2
@@ -14,14 +14,14 @@ CURL_ARGS=(
   -H 'Content-Type: application/json'
 )
 
-# Workflow dispatch - Request repo-policy-compliance service check:
-if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+# Workflow dispatch and Push - Request repo-policy-compliance service check:
+if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]] || [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
 
   logger -s "GITHUB_REF_NAME: ${GITHUB_REF_NAME}"
 
   curl "${CURL_ARGS[@]}" \
       -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"branch_name\": \"${GITHUB_REF_NAME}\", \"commit_sha\": \"${GITHUB_SHA}\"}" \
-      http://{{host_ip}}:8080/workflow_dispatch/check-run
+      http://{{host_ip}}:8080/${GITHUB_EVENT_NAME}/check-run
 
 # Pull request - Request repo-policy-compliance service check:
 elif [[ "${GITHUB_EVENT_NAME}" ==  "pull_request" ]]; then


### PR DESCRIPTION
### Overview

The github push event handling is added to the pre-job script and an additional end-to-end test is added.

### Rationale

A self-hosted runner should handle the push event.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
- The `src-docs` for this repo is still WIP. There is a WIP PR for it.
- There is currently no related documentation for charmhub that could be updated.