### PR TITLE
Rename integration tests workflow

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -97,7 +97,7 @@ jobs:
             --token-alt ${{secrets.E2E_TESTING_TOKEN_ALT}} \
             tests/integration/test_charm_scheduled_events.py
   required_status_checks:
-    name: Required Integration Test Status Checks
+    name: integration-tests / Required Integration Test Status Checks
     runs-on: ubuntu-latest
     needs:
       - integration-test-charm-no-runner

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -97,7 +97,7 @@ jobs:
             --token-alt ${{secrets.E2E_TESTING_TOKEN_ALT}} \
             tests/integration/test_charm_scheduled_events.py
   required_status_checks:
-    name: integration-tests / Required Integration Test Status Checks
+    name: Required Integration Test Status Checks
     runs-on: ubuntu-latest
     needs:
       - integration-test-charm-no-runner

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,4 +1,4 @@
-name: Integration tests
+name: integration-tests
 
 on:
   pull_request:


### PR DESCRIPTION
Applicable spec: NA

### Overview

Change the workflow name to match all IS DevOps owned repository workflow names.

### Rationale

To follow the convention for workflow naming.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->