### PR TITLE
Change method to get commit SHA

### DIFF
--- a/templates/pre-job.j2
+++ b/templates/pre-job.j2
@@ -10,8 +10,6 @@ logger -s "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}, \
 
 # Prepare curl arguments
 CURL_ARGS=(
-  --silent
-  --show-error
   --max-time 60
   --noproxy '*'
   --fail-with-body
@@ -36,14 +34,16 @@ if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]] || [[ "${GITHUB_EVENT_NAM
 elif [[ "${GITHUB_EVENT_NAME}" ==  "pull_request" ]]; then
 
   GITHUB_SOURCE_REPOSITORY=$(cat "${GITHUB_EVENT_PATH}" | jq -r '.pull_request.head.repo.full_name')
+  COMMIT_SHA=$(cat "${GITHUB_EVENT_PATH}" | jq -r '.pull_request.head.sha')
 
   logger -s " \
   GITHUB_SOURCE_REPOSITORY: ${GITHUB_SOURCE_REPOSITORY} \
   GITHUB_BASE_REF: ${GITHUB_BASE_REF}, \
-  GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}"
+  GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}, \
+  COMMIT_SHA: ${COMMIT_SHA}"
 
   curl "${CURL_ARGS[@]}" \
-      -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"source_repository_name\": \"${GITHUB_SOURCE_REPOSITORY}\", \"target_branch_name\": \"${GITHUB_BASE_REF}\", \"source_branch_name\": \"${GITHUB_HEAD_REF}\", \"commit_sha\": \"${GITHUB_SHA}\"}" \
+      -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"source_repository_name\": \"${GITHUB_SOURCE_REPOSITORY}\", \"target_branch_name\": \"${GITHUB_BASE_REF}\", \"source_branch_name\": \"${GITHUB_HEAD_REF}\", \"commit_sha\": \"${COMMIT_SHA}\"}" \
       http://{{host_ip}}:8080/pull_request/check-run
   REPO_CHECK=$?
 


### PR DESCRIPTION
Applicable spec: NA

### Overview

Change method of getting commit SHA from using GITHUB_SHA env var to getting it from the pull request event.

### Rationale

GitHub sometimes generates a hidden commit SHA on a pull requests, so the GITHUB_SHA is not always the commit SHA.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->