### PR TITLE
Fix promote charm usage

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   promote-charm:
-    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@promote-charm-base
+    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@main
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}


### PR DESCRIPTION
Applicable spec: NA

### Overview

Update the `promote_charm.yaml` usage of `operator-workflow` to use the main branch.

### Rationale

The `promote_charm.yaml` is merged into main branch. The reference to the original branch is not needed anymore.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->