### PR TITLE
Add missing contributing documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,11 @@
+## Github-runner operator
 GitHub self-hosted runner offer a way to run GitHub action workloads on non-GitHub servers.
 
 For information on GitHub Actions, see [this page](https://docs.github.com/en/actions).
 
 For information on self-hosted runner, see [this page](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners).
+
+## Contributing to this documentation
+Documentation is an important part of this project, and we take the same open-source approach to the documentation as the code. As such, we welcome community contributions, suggestions and constructive feedback on our documentation. Our documentation is hosted on the [Charmhub forum](https://discourse.charmhub.io/t/github-runner-documentation-overview/7817) to enable easy collaboration. Please use the "Help us improve this documentation" links on each documentation page to either directly change something you see that's wrong, ask a question, or make a suggestion about a potential change via the comments section.
+
+If there's a particular area of documentation that you'd like to see that's missing, please [file a bug](https://github.com/canonical/github-runner-operator/issues).


### PR DESCRIPTION
Duplicate of #120 to add signed commits

### Overview
Add a new contributing section to the documentation front page
### Rationale
This is to comply with the ISD050 spec.
### Juju Events Changes
No changes
### Module Changes
No changes
### Library Changes
No changes
### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)