### PR TITLE
Ensure kernel modules are loaded after reboot

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -119,6 +119,18 @@ Unit that this execution is responsible for.
 
 
 
+---
+
+<a href="../src/charm.py#L682"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `enable_kernel_modules`
+
+```python
+enable_kernel_modules() → None
+```
+
+Enable kernel modules needed by the charm. 
+
 
 ---
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -119,18 +119,6 @@ Unit that this execution is responsible for.
 
 
 
----
-
-<a href="../src/charm.py#L682"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-### <kbd>function</kbd> `enable_kernel_modules`
-
-```python
-enable_kernel_modules() → None
-```
-
-Enable kernel modules needed by the charm. 
-
 
 ---
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -679,7 +679,7 @@ class GithubRunnerCharm(CharmBase):
         )
         return old_version != new_version
 
-    def enable_kernel_modules(self) -> None:
+    def _enable_kernel_modules(self) -> None:
         """Enable kernel modules needed by the charm."""
         execute_command(["/usr/sbin/modprobe", "br_netfilter"])
 
@@ -717,7 +717,7 @@ class GithubRunnerCharm(CharmBase):
         execute_command(["/snap/bin/lxc", "network", "set", "lxdbr0", "ipv6.address", "none"])
         execute_command(["/snap/bin/lxd", "waitready"])
         if not LXD_PROFILE_YAML.exists():
-            self.enable_kernel_modules()
+            self._enable_kernel_modules()
         execute_command(
             [
                 "/snap/bin/lxc",

--- a/src/charm.py
+++ b/src/charm.py
@@ -679,6 +679,13 @@ class GithubRunnerCharm(CharmBase):
         )
         return old_version != new_version
 
+    def enable_kernel_modules(self) -> None:
+        """Enable kernel modules needed by the charm."""
+        execute_command(["/usr/sbin/modprobe", "br_netfilter"])
+
+        with open("/etc/modules", "a", encoding="utf-8") as modules_file:
+            modules_file.write("br_netfilter\n")
+
     @retry(tries=10, delay=15, max_delay=60, backoff=1.5, local_logger=logger)
     def _install_deps(self) -> None:
         """Install dependencies."""
@@ -710,7 +717,7 @@ class GithubRunnerCharm(CharmBase):
         execute_command(["/snap/bin/lxc", "network", "set", "lxdbr0", "ipv6.address", "none"])
         execute_command(["/snap/bin/lxd", "waitready"])
         if not LXD_PROFILE_YAML.exists():
-            execute_command(["/usr/sbin/modprobe", "br_netfilter"])
+            self.enable_kernel_modules()
         execute_command(
             [
                 "/snap/bin/lxc",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -66,7 +66,8 @@ class TestCharm(unittest.TestCase):
 
     @patch("pathlib.Path.write_text")
     @patch("subprocess.run")
-    def test_install(self, run, wt):
+    @patch("builtins.open")
+    def test_install(self, open, run, wt):
         harness = Harness(GithubRunnerCharm)
         harness.begin()
         harness.charm.on.install.emit()
@@ -225,7 +226,8 @@ class TestCharm(unittest.TestCase):
     @patch("pathlib.Path.mkdir")
     @patch("pathlib.Path.write_text")
     @patch("subprocess.run")
-    def test_on_install_failure(self, run, wt, mkdir, rm):
+    @patch("builtins.open")
+    def test_on_install_failure(self, open, run, wt, mkdir, rm):
         """Test various error thrown during install."""
 
         rm.return_value = mock_rm = MagicMock()


### PR DESCRIPTION
Applicable spec: NA

### Overview

Ensure kernel modules are loaded after reboot.

### Rationale

The charm will reboots on upgrade to kernel or some dependencies. After reboot if the kernel modules are not loaded, it can cause crashes in LXD.

A deployment is running multiple jobs without any crashes:
https://github.com/canonical/github-runner-operator/actions/runs/6181781894
The failure from job 3 is due to unsigned commits on the `do-not-merge` branch as I am testing something else.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->