### PR TITLE
Add temporary schedule test

### DIFF
--- a/.github/workflows/temp_schedule_test.yaml
+++ b/.github/workflows/temp_schedule_test.yaml
@@ -1,0 +1,13 @@
+name: Temporary Schedule Event Tests
+
+on:
+  schedule:
+    - cron: '* */1 * * *'
+
+jobs:
+  schedule-event-tests:
+    runs-on: [ self-hosted, linux, X64, large, jammy ]
+    steps:
+      - name: Echo Hello World
+        run: |
+          echo "Hello, world!"


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Add a schedule test to test the correct handling of the event with production runners. Once successfully tested, the test will be removed by another PR.

### Rationale

Schedule event can only be tested on the default branch, so we need to add the workflow file to the default branch.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

