### PR TITLE
Revert to using GA kernel

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -364,7 +364,7 @@ class GithubRunnerCharm(CharmBase):
             now: Whether the reboot should trigger at end of event handler or now.
         """
         logger.info("Upgrading kernel")
-        self._apt_install(["linux-generic-hwe-22.04"])
+        self._apt_install(["linux-generic"])
 
         _, exit_code = execute_command(["ls", "/var/run/reboot-required"], check_exit=False)
         if exit_code == 0:


### PR DESCRIPTION
### Overview

Switch to using general availability(GA) kernel over HWE kernel.

### Rationale

Due to a kernel bug, HWE kernel is currently used. The new GA kernel should have the bug fixed.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->