### PR TITLE
Add beta channel as option for promote charm

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -7,12 +7,14 @@ on:
         type: choice
         description: 'Origin Channel'
         options:
+        - latest/beta
         - latest/edge
       destination-channel:
         type: choice
         description: 'Destination Channel'
         options:
         - latest/stable
+        - latest/beta
     secrets:
       CHARMHUB_TOKEN:
         required: true


### PR DESCRIPTION


### Overview

<!-- A high level overview of the change -->

Add beta channel as option for promote charm workflow.

### Rationale

<!-- The reason the change is needed -->

Beta channel is used to indict the revision that is active being tested, and would become the next release candidate.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->