### PR TITLE
COS integration: Issue remaining metrics

### DIFF
--- a/src-docs/metrics.py.md
+++ b/src-docs/metrics.py.md
@@ -12,7 +12,7 @@ Models and functions for the metric events.
 
 ---
 
-<a href="../src/metrics.py#L98"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/metrics.py#L136"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `issue_event`
 
@@ -39,7 +39,7 @@ The metric event is logged to the metrics log.
 
 ---
 
-<a href="../src/metrics.py#L149"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/metrics.py#L187"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `setup_logrotate`
 
@@ -67,6 +67,41 @@ Base class for metric events.
  
  - <b>`timestamp`</b>:  The UNIX time stamp of the time at which the event was originally issued. 
  - <b>`event`</b>:  The name of the event. Will be set to the class name in snake case if not provided. 
+
+<a href="../src/metrics.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(*args, **kwargs)
+```
+
+Initialize the event. 
+
+
+
+**Args:**
+ 
+ - <b>`*args`</b>:  The positional arguments to pass to the base class. 
+ - <b>`**kwargs`</b>:  The keyword arguments to pass to the base class. These are used to set the  specific fields. E.g. timestamp=12345 will set the timestamp field to 12345. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `Reconciliation`
+Metric event for when a runner is stopped. 
+
+
+
+**Attributes:**
+ 
+ - <b>`flavor`</b>:  Describes the characteristics of the runner.  The flavor could be for example "small". 
+ - <b>`crashed_runners`</b>:  The number of crashed runners. 
+ - <b>`idle_runners`</b>:  The number of idle runners. 
+ - <b>`duration`</b>:  The duration of the reconciliation in seconds. 
 
 <a href="../src/metrics.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
@@ -136,6 +171,43 @@ Metric event for when a runner is started.
  - <b>`repo`</b>:  The repository name. 
  - <b>`github_event`</b>:  The github event. 
  - <b>`idle`</b>:  The idle time in seconds. 
+
+<a href="../src/metrics.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(*args, **kwargs)
+```
+
+Initialize the event. 
+
+
+
+**Args:**
+ 
+ - <b>`*args`</b>:  The positional arguments to pass to the base class. 
+ - <b>`**kwargs`</b>:  The keyword arguments to pass to the base class. These are used to set the  specific fields. E.g. timestamp=12345 will set the timestamp field to 12345. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `RunnerStop`
+Metric event for when a runner is stopped. 
+
+
+
+**Attributes:**
+ 
+ - <b>`flavor`</b>:  Describes the characteristics of the runner.  The flavor could be for example "small". 
+ - <b>`workflow`</b>:  The workflow name. 
+ - <b>`repo`</b>:  The repository name. 
+ - <b>`github_event`</b>:  The github event. 
+ - <b>`status`</b>:  A string describing the reason for stopping the runner. 
+ - <b>`job_duration`</b>:  The duration of the job in seconds. 
 
 <a href="../src/metrics.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 

--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -72,7 +72,7 @@ Check if runner binary exists.
 
 ---
 
-<a href="../src/runner_manager.py#L453"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L522"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `flush`
 
@@ -141,7 +141,7 @@ The runner binary URL changes when a new version is available.
 
 ---
 
-<a href="../src/runner_manager.py#L351"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L455"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 

--- a/src-docs/runner_metrics.py.md
+++ b/src-docs/runner_metrics.py.md
@@ -14,12 +14,12 @@ Classes and function to extract the metrics from a shared filesystem.
 
 ---
 
-<a href="../src/runner_metrics.py#L198"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_metrics.py#L228"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `extract`
 
 ```python
-extract(flavor: str, ignore_runners: set[str]) → None
+extract(flavor: str, ignore_runners: set[str]) → dict[Type[Event], int]
 ```
 
 Extract and issue metrics from runners. 
@@ -36,6 +36,11 @@ If corrupt data is found, an error is raised immediately, as this may indicate t
  - <b>`ignore_runners`</b>:  The set of runners to ignore. 
 
 
+
+**Returns:**
+ A dictionary containing the number of issued events per event type. 
+
+
 ---
 
 ## <kbd>class</kbd> `PostJobMetrics`
@@ -47,6 +52,15 @@ Metrics for the post-job phase of a runner.
  
  - <b>`timestamp`</b>:  The UNIX time stamp of the time at which the event was originally issued. 
  - <b>`status`</b>:  The status of the job. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `PostJobStatus`
+The status of the post-job phase of a runner. 
 
 
 

--- a/src/grafana_dashboards/metrics.json
+++ b/src/grafana_dashboards/metrics.json
@@ -284,14 +284,14 @@
             "uid": "${lokids}"
           },
           "editorMode": "code",
-          "expr": "sum by(filename) (last_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", idle_runners=\"idle_runners\" | event = `reconciliation` | unwrap idle_runners [10m]))",
+          "expr": "sum by(filename)(last_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle_runners=\"idle_runners\" | event=\"reconciliation\" | unwrap idle_runners[10m]))",
           "hide": false,
-          "legendFormat": "Idle",
+          "legendFormat": "Idle Runners",
           "queryType": "range",
           "refId": "D"
         }
       ],
-      "title": "Runners Gauges",
+      "title": "Gauges",
       "transformations": [
         {
           "id": "calculateField",

--- a/src/grafana_dashboards/metrics.json
+++ b/src/grafana_dashboards/metrics.json
@@ -43,7 +43,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
+            "drawStyle": "bars",
             "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
@@ -61,7 +61,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -80,7 +80,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": []
       },
@@ -109,8 +110,8 @@
             "type": "loki",
             "uid": "${lokids}"
           },
-          "editorMode": "code",
-          "expr": "count_over_time({filename=\"/var/log/github-runner-metrics.log\"} | json event=\"event\" | event = `runner_start` [$__range])",
+          "editorMode": "builder",
+          "expr": "sum by(filename) (count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event = `runner_start` [$__range]))",
           "key": "Q-f7c42eab-69be-43b5-a807-35c071f708a0-0",
           "legendFormat": "Started",
           "queryType": "range",
@@ -121,15 +122,94 @@
             "type": "loki",
             "uid": "${lokids}"
           },
-          "editorMode": "code",
-          "expr": "count_over_time({filename=\"/var/log/github-runner-metrics.log\"} | json event=\"event\" | event = `runner_installed` [$__range])",
+          "editorMode": "builder",
+          "expr": "sum by(filename) (count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event = `runner_installed` [$__range]))",
           "hide": false,
           "legendFormat": "Initialized",
           "queryType": "range",
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(filename) (count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event = `runner_stop` [$__range]))",
+          "hide": false,
+          "legendFormat": "Stopped",
+          "queryType": "range",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(filename) (sum_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", crashed_runners=\"crashed_runners\" | event = `reconciliation` | unwrap crashed_runners [$__range]))",
+          "hide": false,
+          "legendFormat": "Crashed",
+          "queryType": "range",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(filename) (sum_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", idle_runners=\"idle_runners\" | event = `reconciliation` | unwrap idle_runners [$__range]))",
+          "hide": false,
+          "legendFormat": "Idle",
+          "queryType": "range",
+          "refId": "E"
         }
       ],
       "title": "Runners Total",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": "Started",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Stopped"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Active",
+            "binary": {
+              "left": "Started - Stopped",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Crashed"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Started - Stopped": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
       "type": "timeseries"
     },
     {
@@ -186,7 +266,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "m"
         },
         "overrides": []
       },
@@ -216,7 +297,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\"} | json event=\"event\", idle=\"idle\" | event = `runner_start` | unwrap idle [1h]) / 60",
+          "expr": "(avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) / 60)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Average",
           "queryType": "range",
@@ -228,7 +309,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\"} | json event=\"event\", idle=\"idle\" | event = `runner_start` | unwrap idle [1h]) / 60",
+          "expr": "(max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) / 60)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Max",
           "queryType": "range",
@@ -240,14 +321,14 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\"} | json event=\"event\", idle=\"idle\" | event = `runner_start` | unwrap idle [1h]) / 60",
+          "expr": "(min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) / 60)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Min",
           "queryType": "range",
           "refId": "C"
         }
       ],
-      "title": "Runner Idle Duration in minutes",
+      "title": "Runner Idle Duration",
       "type": "timeseries"
     },
     {
@@ -304,7 +385,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "s"
         },
         "overrides": []
       },
@@ -334,7 +416,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\"} | json event=\"event\", duration=\"duration\" | event = `runner_installed` | unwrap duration [1h])",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"runner_installed\" | unwrap duration[1h])",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Average",
           "queryType": "range",
@@ -346,7 +428,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\"} | json event=\"event\", duration=\"duration\" | event = `runner_installed` | unwrap duration [1h])",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"runner_installed\" | unwrap duration[1h])",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Max",
           "queryType": "range",
@@ -358,7 +440,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\"} | json event=\"event\", duration=\"duration\" | event = `runner_installed` | unwrap duration [1h])",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"runner_installed\" | unwrap duration[1h])",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Min",
           "queryType": "range",
@@ -367,13 +449,446 @@
       ],
       "title": "Runner Installation Duration in seconds",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${lokids}"
+      },
+      "description": "All aggregations are based on a 1-hour time period.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",job_duration=\"job_duration\" | event=\"runner_stop\" | unwrap idle[1h])",
+          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
+          "legendFormat": "Average",
+          "queryType": "range",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",job_duration=\"job_duration\" | event=\"runner_stop\" | unwrap idle[1h])",
+          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
+          "legendFormat": "Max",
+          "queryType": "range",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",job_duration=\"job_duration\" | event=\"runner_stop\" | unwrap job_duration[1h])",
+          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
+          "legendFormat": "Min",
+          "queryType": "range",
+          "refId": "C"
+        }
+      ],
+      "title": "Job Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${lokids}"
+      },
+      "description": "All aggregations are based on a 1-hour time period.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h])",
+          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
+          "legendFormat": "Average",
+          "queryType": "range",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h])",
+          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
+          "legendFormat": "Max",
+          "queryType": "range",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h])",
+          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
+          "legendFormat": "Min",
+          "queryType": "range",
+          "refId": "C"
+        }
+      ],
+      "title": "Reconciliation Duration",
+      "type": "timeseries"
     }
   ],
   "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Loki datasource",
+        "multi": true,
+        "name": "lokids",
+        "options": [],
+        "query": "loki",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Prometheus datasource",
+        "multi": true,
+        "name": "prometheusds",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "${lokids}"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju unit",
+        "multi": true,
+        "name": "juju_unit",
+        "options": [],
+        "query": {
+          "label": "juju_unit",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "",
+          "type": 1
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "${lokids}"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju application",
+        "multi": true,
+        "name": "juju_application",
+        "options": [],
+        "query": {
+          "label": "juju_application",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "",
+          "type": 1
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "${lokids}"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju model uuid",
+        "multi": true,
+        "name": "juju_model_uuid",
+        "options": [],
+        "query": {
+          "label": "juju_model_uuid",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "",
+          "type": 1
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "${lokids}"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju model",
+        "multi": true,
+        "name": "juju_model",
+        "options": [],
+        "query": {
+          "label": "juju_model",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "",
+          "type": 1
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-6h",
@@ -382,6 +897,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "GitHub Self-Hosted Runner Metrics",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/src/grafana_dashboards/metrics.json
+++ b/src/grafana_dashboards/metrics.json
@@ -43,7 +43,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "bars",
+            "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
@@ -61,7 +61,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -152,18 +152,6 @@
           "legendFormat": "Crashed",
           "queryType": "range",
           "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "${lokids}"
-          },
-          "editorMode": "builder",
-          "expr": "sum by(filename)(sum_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle_runners=\"idle_runners\" | event=\"reconciliation\" | unwrap idle_runners[$__range]))",
-          "hide": false,
-          "legendFormat": "Idle",
-          "queryType": "range",
-          "refId": "E"
         }
       ],
       "title": "Runners Total",
@@ -217,7 +205,6 @@
         "type": "loki",
         "uid": "${lokids}"
       },
-      "description": "All aggregations are based on a 1-hour time period.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -267,7 +254,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -277,7 +264,7 @@
         "x": 12,
         "y": 0
       },
-      "id": 4,
+      "id": 7,
       "options": {
         "legend": {
           "calcs": [],
@@ -296,39 +283,58 @@
             "type": "loki",
             "uid": "${lokids}"
           },
-          "editorMode": "builder",
-          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) by(filename)",
-          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
-          "legendFormat": "Average",
+          "editorMode": "code",
+          "expr": "sum by(filename) (last_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", idle_runners=\"idle_runners\" | event = `reconciliation` | unwrap idle_runners [10m]))",
+          "hide": false,
+          "legendFormat": "Idle",
           "queryType": "range",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "${lokids}"
-          },
-          "editorMode": "builder",
-          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) by(filename)",
-          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
-          "legendFormat": "Max",
-          "queryType": "range",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "${lokids}"
-          },
-          "editorMode": "builder",
-          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) by(filename)",
-          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
-          "legendFormat": "Min",
-          "queryType": "range",
-          "refId": "C"
+          "refId": "D"
         }
       ],
-      "title": "Runner Idle Duration",
+      "title": "Runners Gauges",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": "Started",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Stopped"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Active",
+            "binary": {
+              "left": "Started - Stopped",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Crashed"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Started - Stopped": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
       "type": "timeseries"
     },
     {
@@ -515,7 +521,7 @@
         "x": 12,
         "y": 8
       },
-      "id": 5,
+      "id": 4,
       "options": {
         "legend": {
           "calcs": [],
@@ -535,7 +541,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", job_duration=\"job_duration\" | event = `runner_stop` | unwrap job_duration [1h])",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Average",
           "queryType": "range",
@@ -547,7 +553,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", job_duration=\"job_duration\" | event = `runner_stop` | unwrap job_duration [1h])",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Max",
           "queryType": "range",
@@ -559,14 +565,133 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",job_duration=\"job_duration\" | event=\"runner_stop\" | unwrap job_duration[1h]) by(filename)",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Min",
           "queryType": "range",
           "refId": "C"
         }
       ],
-      "title": "Job Duration",
+      "title": "Runner Idle Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${lokids}"
+      },
+      "description": "All aggregations are based on a 1-hour time period.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h]) by(filename)",
+          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
+          "legendFormat": "Average",
+          "queryType": "range",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h]) by(filename)",
+          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
+          "legendFormat": "Max",
+          "queryType": "range",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "builder",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h]) by(filename)",
+          "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
+          "legendFormat": "Min",
+          "queryType": "range",
+          "refId": "C"
+        }
+      ],
+      "title": "Reconciliation Duration",
       "type": "timeseries"
     },
     {
@@ -634,7 +759,7 @@
         "x": 12,
         "y": 16
       },
-      "id": 6,
+      "id": 5,
       "options": {
         "legend": {
           "calcs": [],
@@ -654,7 +779,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h]) by(filename)",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",job_duration=\"job_duration\",status=\"status\" | event=\"runner_stop\" | status=\"normal\" | unwrap job_duration[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Average",
           "queryType": "range",
@@ -666,7 +791,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h]) by(filename)",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",job_duration=\"job_duration\",status=\"status\" | event=\"runner_stop\" | status=\"normal\" | unwrap job_duration[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Max",
           "queryType": "range",
@@ -678,14 +803,14 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h]) by(filename)",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",job_duration=\"job_duration\",status=\"status\" | event=\"runner_stop\" | status=\"normal\" | unwrap job_duration[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Min",
           "queryType": "range",
           "refId": "C"
         }
       ],
-      "title": "Reconciliation Duration",
+      "title": "Job Duration",
       "type": "timeseries"
     }
   ],

--- a/src/grafana_dashboards/metrics.json
+++ b/src/grafana_dashboards/metrics.json
@@ -297,7 +297,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", idle=\"idle\" | event = `runner_start` | unwrap idle [1h]) by (filename)",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Average",
           "queryType": "range",
@@ -309,7 +309,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", idle=\"idle\" | event = `runner_start` | unwrap idle [1h]) by (filename)",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Max",
           "queryType": "range",
@@ -321,7 +321,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", idle=\"idle\" | event = `runner_start` | unwrap idle [1h]) by (filename)",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Min",
           "queryType": "range",
@@ -416,7 +416,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", duration=\"duration\" | event = `runner_installed` | unwrap duration [1h]) by (filename)",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"runner_installed\" | unwrap duration[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Average",
           "queryType": "range",
@@ -428,7 +428,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", duration=\"duration\" | event = `runner_installed` | unwrap duration [1h]) by (filename)",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"runner_installed\" | unwrap duration[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Max",
           "queryType": "range",
@@ -440,7 +440,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", duration=\"duration\" | event = `runner_installed` | unwrap duration [1h]) by (filename)",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"runner_installed\" | unwrap duration[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Min",
           "queryType": "range",
@@ -535,7 +535,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", job_duration=\"job_duration\" | event = `runner_stop` | unwrap idle [1h]) by (filename)",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", job_duration=\"job_duration\" | event = `runner_stop` | unwrap job_duration [1h])",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Average",
           "queryType": "range",
@@ -547,7 +547,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", job_duration=\"job_duration\" | event = `runner_stop` | unwrap idle [1h]) by (filename)",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", job_duration=\"job_duration\" | event = `runner_stop` | unwrap job_duration [1h])",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Max",
           "queryType": "range",
@@ -559,7 +559,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", job_duration=\"job_duration\" | event = `runner_stop` | unwrap job_duration [1h]) by (filename)",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",job_duration=\"job_duration\" | event=\"runner_stop\" | unwrap job_duration[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Min",
           "queryType": "range",
@@ -654,7 +654,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h])",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Average",
           "queryType": "range",
@@ -666,7 +666,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h])",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Max",
           "queryType": "range",
@@ -678,7 +678,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h])",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"reconciliation\" | unwrap duration[1h]) by(filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Min",
           "queryType": "range",

--- a/src/grafana_dashboards/metrics.json
+++ b/src/grafana_dashboards/metrics.json
@@ -111,7 +111,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "sum by(filename) (count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event = `runner_start` [$__range]))",
+          "expr": "sum by(filename)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_start\"[$__range]))",
           "key": "Q-f7c42eab-69be-43b5-a807-35c071f708a0-0",
           "legendFormat": "Started",
           "queryType": "range",
@@ -123,7 +123,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "sum by(filename) (count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event = `runner_installed` [$__range]))",
+          "expr": "sum by(filename)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_installed\"[$__range]))",
           "hide": false,
           "legendFormat": "Initialized",
           "queryType": "range",
@@ -135,7 +135,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "sum by(filename) (count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event = `runner_stop` [$__range]))",
+          "expr": "sum by(filename)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_stop\"[$__range]))",
           "hide": false,
           "legendFormat": "Stopped",
           "queryType": "range",
@@ -147,7 +147,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "sum by(filename) (sum_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", crashed_runners=\"crashed_runners\" | event = `reconciliation` | unwrap crashed_runners [$__range]))",
+          "expr": "sum by(filename)(sum_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",crashed_runners=\"crashed_runners\" | event=\"reconciliation\" | unwrap crashed_runners[$__range]))",
           "hide": false,
           "legendFormat": "Crashed",
           "queryType": "range",
@@ -159,7 +159,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "sum by(filename) (sum_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", idle_runners=\"idle_runners\" | event = `reconciliation` | unwrap idle_runners [$__range]))",
+          "expr": "sum by(filename)(sum_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle_runners=\"idle_runners\" | event=\"reconciliation\" | unwrap idle_runners[$__range]))",
           "hide": false,
           "legendFormat": "Idle",
           "queryType": "range",
@@ -267,7 +267,7 @@
               }
             ]
           },
-          "unit": "m"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -297,7 +297,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "(avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) / 60)",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", idle=\"idle\" | event = `runner_start` | unwrap idle [1h]) by (filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Average",
           "queryType": "range",
@@ -309,7 +309,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "(max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) / 60)",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", idle=\"idle\" | event = `runner_start` | unwrap idle [1h]) by (filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Max",
           "queryType": "range",
@@ -321,7 +321,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "(min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle=\"idle\" | event=\"runner_start\" | unwrap idle[1h]) / 60)",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", idle=\"idle\" | event = `runner_start` | unwrap idle [1h]) by (filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Min",
           "queryType": "range",
@@ -416,7 +416,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"runner_installed\" | unwrap duration[1h])",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", duration=\"duration\" | event = `runner_installed` | unwrap duration [1h]) by (filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Average",
           "queryType": "range",
@@ -428,7 +428,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"runner_installed\" | unwrap duration[1h])",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", duration=\"duration\" | event = `runner_installed` | unwrap duration [1h]) by (filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Max",
           "queryType": "range",
@@ -440,14 +440,14 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",duration=\"duration\" | event=\"runner_installed\" | unwrap duration[1h])",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", duration=\"duration\" | event = `runner_installed` | unwrap duration [1h]) by (filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Min",
           "queryType": "range",
           "refId": "C"
         }
       ],
-      "title": "Runner Installation Duration in seconds",
+      "title": "Runner Installation Duration",
       "type": "timeseries"
     },
     {
@@ -535,7 +535,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",job_duration=\"job_duration\" | event=\"runner_stop\" | unwrap idle[1h])",
+          "expr": "avg_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", job_duration=\"job_duration\" | event = `runner_stop` | unwrap idle [1h]) by (filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Average",
           "queryType": "range",
@@ -547,7 +547,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",job_duration=\"job_duration\" | event=\"runner_stop\" | unwrap idle[1h])",
+          "expr": "max_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", job_duration=\"job_duration\" | event = `runner_stop` | unwrap idle [1h]) by (filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Max",
           "queryType": "range",
@@ -559,7 +559,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",job_duration=\"job_duration\" | event=\"runner_stop\" | unwrap job_duration[1h])",
+          "expr": "min_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\", job_duration=\"job_duration\" | event = `runner_stop` | unwrap job_duration [1h]) by (filename)",
           "key": "Q-9302bc4d-cce0-4674-bad5-353257fdd2f4-0",
           "legendFormat": "Min",
           "queryType": "range",
@@ -696,7 +696,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],
@@ -719,7 +719,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -95,6 +95,44 @@ class RunnerStart(Event):
     idle: NonNegativeFloat
 
 
+class RunnerStop(Event):
+    """Metric event for when a runner is stopped.
+
+    Attributes:
+        flavor: Describes the characteristics of the runner.
+          The flavor could be for example "small".
+        workflow: The workflow name.
+        repo: The repository name.
+        github_event: The github event.
+        status: A string describing the reason for stopping the runner.
+        job_duration: The duration of the job in seconds.
+    """
+
+    flavor: str
+    workflow: str
+    repo: str
+    github_event: str
+    status: str
+    job_duration: NonNegativeFloat
+
+
+class Reconciliation(Event):
+    """Metric event for when the charm has finished reconciliation.
+
+    Attributes:
+        flavor: Describes the characteristics of the runner.
+          The flavor could be for example "small".
+        crashed_runners: The number of crashed runners.
+        idle_runners: The number of idle runners.
+        duration: The duration of the reconciliation in seconds.
+    """
+
+    flavor: str
+    crashed_runners: int
+    idle_runners: int
+    duration: NonNegativeFloat
+
+
 def issue_event(event: Event) -> None:
     """Issue a metric event.
 

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -328,7 +328,7 @@ class RunnerManager:
                     ),
                 )
             except IssueMetricEventError:
-                logger.exception("Failed to issue metrics")
+                logger.exception("Failed to issue RunnerInstalled metric")
 
             fs = shared_fs.get(runner.config.name)
             try:
@@ -348,6 +348,110 @@ class RunnerManager:
                 registration_token,
             )
 
+    def _issue_runner_metrics(self) -> runner_metrics.IssuedMetricEventsStats:
+        """Issue runner metrics.
+
+        Returns:
+            The stats of issued metric events.
+        """
+        runner_states = self._get_runner_health_states()
+
+        return runner_metrics.extract(
+            flavor=self.app_name, ignore_runners=set(runner_states.healthy)
+        )
+
+    def _issue_reconciliation_metric(
+        self,
+        metric_stats: runner_metrics.IssuedMetricEventsStats,
+        reconciliation_start_ts: float,
+        reconciliation_end_ts: float,
+    ):
+        """Issue reconciliation metric.
+
+        Args:
+            metric_stats: The stats of issued metric events.
+            reconciliation_start_ts: The timestamp of when reconciliation started.
+            reconciliation_end_ts: The timestamp of when reconciliation ended.
+        """
+        runners = self._get_runners()
+        idle_runners = [
+            runner
+            for runner in runners
+            if runner.status.exist and runner.status.online and not runner.status.busy
+        ]
+
+        try:
+            metrics.issue_event(
+                event=metrics.Reconciliation(
+                    timestamp=time.time(),
+                    flavor=self.app_name,
+                    # Ignore line break before binary operator
+                    crashed_runners=metric_stats.get(metrics.RunnerStart, 0)
+                    - metric_stats.get(metrics.RunnerStop, 0),  # noqa: W503
+                    idle_runners=len(idle_runners),
+                    duration=reconciliation_end_ts - reconciliation_start_ts,
+                )
+            )
+        except IssueMetricEventError:
+            logger.exception("Failed to issue Reconciliation metric")
+
+    def _spawn_new_runners(self, count: int, resources: VirtualMachineResources):
+        """Spawn new runners.
+
+        Args:
+            count: Number of runners to spawn.
+            resources: Configuration of the virtual machine resources.
+        """
+        if not RunnerManager.runner_bin_path.exists():
+            raise RunnerCreateError("Unable to create runner due to missing runner binary.")
+        logger.info("Getting registration token for GitHub runners.")
+        registration_token = self._get_github_registration_token()
+        remove_token = self._get_github_remove_token()
+        logger.info("Attempting to add %i runner(s).", count)
+        for _ in range(count):
+            config = RunnerConfig(
+                self.app_name,
+                self.config.path,
+                self.proxies,
+                self.config.lxd_storage_path,
+                self._generate_runner_name(),
+                self.config.charm_state.is_metrics_logging_available,
+            )
+            runner = Runner(self._clients, config, RunnerStatus())
+            try:
+                self._create_runner(registration_token, resources, runner)
+                logger.info("Created runner: %s", runner.config.name)
+            except RunnerCreateError:
+                logger.error("Unable to create runner: %s", runner.config.name)
+                runner.remove(remove_token)
+                logger.info("Cleaned up runner: %s", runner.config.name)
+                raise
+
+    def _remove_runners(self, count: int, runners: list[Runner]) -> None:
+        """Remove runners.
+
+        Args:
+            count: Number of runners to remove.
+            runners: List of online runners.
+        """
+        logger.info("Attempting to remove %i runner(s).", count)
+        # Idle runners are online runners that have not taken a job.
+        idle_runners = [runner for runner in runners if not runner.status.busy]
+        offset = min(count, len(idle_runners))
+        if offset != 0:
+            logger.info("Removing %i runner(s).", offset)
+            remove_runners = idle_runners[:offset]
+
+            logger.info("Cleaning up idle runners.")
+
+            remove_token = self._get_github_remove_token()
+
+            for runner in remove_runners:
+                runner.remove(remove_token)
+                logger.info("Removed runner: %s", runner.config.name)
+        else:
+            logger.info("There are no idle runners to remove.")
+
     def reconcile(self, quantity: int, resources: VirtualMachineResources) -> int:
         """Bring runners in line with target.
 
@@ -358,6 +462,9 @@ class RunnerManager:
         Returns:
             Difference between intended runners and actual runners.
         """
+        if self.config.charm_state.is_metrics_logging_available:
+            start_ts = time.time()
+
         runners = self._get_runners()
 
         # Add/Remove runners to match the target quantity
@@ -379,9 +486,6 @@ class RunnerManager:
             len(runner_states.unhealthy),
         )
 
-        if self.config.charm_state.is_metrics_logging_available:
-            runner_metrics.extract(flavor=self.app_name, ignore_runners=set(runner_states.healthy))
-
         # Clean up offline runners
         if runner_states.unhealthy:
             logger.info("Cleaning up unhealthy runners.")
@@ -399,55 +503,20 @@ class RunnerManager:
         delta = quantity - len(runner_states.healthy)
         # Spawn new runners
         if delta > 0:
-            if not RunnerManager.runner_bin_path.exists():
-                raise RunnerCreateError("Unable to create runner due to missing runner binary.")
-
-            logger.info("Getting registration token for GitHub runners.")
-
-            registration_token = self._get_github_registration_token()
-            remove_token = self._get_github_remove_token()
-
-            logger.info("Attempting to add %i runner(s).", delta)
-            for _ in range(delta):
-                config = RunnerConfig(
-                    self.app_name,
-                    self.config.path,
-                    self.proxies,
-                    self.config.lxd_storage_path,
-                    self._generate_runner_name(),
-                    self.config.charm_state.is_metrics_logging_available,
-                )
-                runner = Runner(self._clients, config, RunnerStatus())
-                try:
-                    self._create_runner(registration_token, resources, runner)
-                    logger.info("Created runner: %s", runner.config.name)
-                except RunnerCreateError:
-                    logger.error("Unable to create runner: %s", runner.config.name)
-                    runner.remove(remove_token)
-                    logger.info("Cleaned up runner: %s", runner.config.name)
-                    raise
-
+            self._spawn_new_runners(delta, resources)
         elif delta < 0:
-            logger.info("Attempting to remove %i runner(s).", -delta)
-            # Idle runners are online runners that have not taken a job.
-            idle_runners = [runner for runner in online_runners if not runner.status.busy]
-            offset = min(-delta, len(idle_runners))
-            if offset != 0:
-                logger.info("Removing %i runner(s).", offset)
-                remove_runners = idle_runners[:offset]
-
-                logger.info("Cleaning up idle runners.")
-
-                remove_token = self._get_github_remove_token()
-
-                for runner in remove_runners:
-                    runner.remove(remove_token)
-                    logger.info("Removed runner: %s", runner.config.name)
-            else:
-                logger.info("There are no idle runners to remove.")
+            self._remove_runners(count=-delta, runners=online_runners)
         else:
             logger.info("No changes to number of runners needed.")
 
+        if self.config.charm_state.is_metrics_logging_available:
+            end_ts = time.time()
+            metric_stats = self._issue_runner_metrics()
+            self._issue_reconciliation_metric(
+                metric_stats=metric_stats,
+                reconciliation_start_ts=start_ts,
+                reconciliation_end_ts=end_ts,
+            )
         return delta
 
     def flush(self, flush_busy: bool = True) -> int:

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -486,6 +486,9 @@ class RunnerManager:
             len(runner_states.unhealthy),
         )
 
+        if self.config.charm_state.is_metrics_logging_available:
+            metric_stats = self._issue_runner_metrics()
+
         # Clean up offline runners
         if runner_states.unhealthy:
             logger.info("Cleaning up unhealthy runners.")
@@ -511,7 +514,6 @@ class RunnerManager:
 
         if self.config.charm_state.is_metrics_logging_available:
             end_ts = time.time()
-            metric_stats = self._issue_runner_metrics()
             self._issue_reconciliation_metric(
                 metric_stats=metric_stats,
                 reconciliation_start_ts=start_ts,

--- a/templates/pre-job.j2
+++ b/templates/pre-job.j2
@@ -84,6 +84,21 @@ if [[ $REPO_CHECK -ne 0 ]]; then
   # Killing the runner.Listener process to stop the runner application. This will prevent jobs from being executed.
   pkill -2 Runner.Listener
 
+
+    {% if issue_metrics %}
+        # Write Post Job metrics with status "repo-policy-check-failure" .
+        # We write it here, rather than relying on the post-job script,
+        # as it may not run due to the poweroff command below.
+        post_job_timestamp=$(date +%s)
+
+        jq -n \
+          --argjson timestamp "$post_job_timestamp" \
+          '{
+            "timestamp": $timestamp,
+            "status": "repo-policy-check-failure"
+          }' > /metrics-exchange/post-job-metrics.json || true
+    {% endif %}
+
   # Shutdown the instance as a safe guard. The time delay is needed for the runner application to upload the logs.
   bash -c "sleep 10; sudo systemctl poweroff -i" &
 

--- a/templates/start.j2
+++ b/templates/start.j2
@@ -6,6 +6,13 @@ set +e
 {% if issue_metrics %}
 
 write_post_metrics(){
+    # Only write the post-job metrics if the file does not already exist - which may indicate
+    # that the job has failed inside pre-job.
+
+    if [ -f /metrics-exchange/post-job-metrics.json ]; then
+        return
+    fi
+
     timestamp=$(date +%s)
 
     jq -n \

--- a/tests/integration/test_charm_metrics.py
+++ b/tests/integration/test_charm_metrics.py
@@ -9,13 +9,16 @@ from typing import AsyncIterator
 
 import pytest
 import pytest_asyncio
+import requests
 from github.Branch import Branch
 from github.Repository import Repository
+from github.Workflow import Workflow
 from juju.application import Application
 from juju.model import Model
 from juju.unit import Unit
 
 from metrics import METRICS_LOG_PATH
+from runner_metrics import PostJobStatus
 from tests.integration.helpers import (
     DISPATCH_TEST_WORKFLOW_FILENAME,
     ensure_charm_has_runner,
@@ -25,6 +28,8 @@ from tests.integration.helpers import (
     run_in_unit,
 )
 from tests.status_name import ACTIVE_STATUS_NAME
+
+TEST_WORKFLOW_NAME = "Workflow Dispatch Tests"
 
 
 @pytest.fixture(scope="module", name="branch_with_protection")
@@ -120,6 +125,95 @@ async def _wait_until_runner_is_used_up(unit: Unit):
         assert False, "Timeout while waiting for the runner to be used up"
 
 
+async def _assert_workflow_run_conclusion(app: Application, conclusion: str, workflow: Workflow):
+    """Assert that the workflow run has the expected conclusion.
+
+    Args:
+        app: The charm to assert the workflow run conclusion for.
+        conclusion: The expected workflow run conclusion.
+        workflow: The workflow to assert the workflow run conclusion for.
+    """
+    for run in workflow.get_runs():
+        logs_url = run.jobs()[0].logs_url()
+        logs = requests.get(logs_url).content.decode("utf-8")
+
+        if f"Job is about to start running on the runner: {app.name}-" in logs:
+            assert run.jobs()[0].conclusion == conclusion
+
+
+async def _wait_for_workflow_to_complete(app: Application, workflow: Workflow, conclusion: str):
+    """Wait for the workflow to complete.
+
+    Args:
+        app: The charm to wait for the workflow to complete.
+        workflow: The workflow to wait for.
+        conclusion: The workflow conclusion to wait for.
+    """
+    await _wait_until_runner_is_used_up(app.units[0])
+    # Wait for the workflow log to contain the conclusion
+    sleep(60)
+
+    await _assert_workflow_run_conclusion(app, conclusion, workflow)
+
+
+async def _dispatch_workflow(
+    app: Application, branch: Branch, github_repository: Repository, conclusion: str
+):
+    """Dispatch a workflow on a branch for the runner to run.
+
+    Args:
+        app: The charm to dispatch the workflow for.
+        branch: The branch to dispatch the workflow on.
+        github_repository: The github repository to dispatch the workflow on.
+        conclusion: The expected workflow run conclusion.
+    """
+    workflow = github_repository.get_workflow(id_or_file_name=DISPATCH_TEST_WORKFLOW_FILENAME)
+    # The `create_dispatch` returns True on success.
+    assert workflow.create_dispatch(branch, {"runner": app.name})
+    await _wait_for_workflow_to_complete(app=app, workflow=workflow, conclusion=conclusion)
+
+
+async def _assert_events_after_reconciliation(
+    app: Application, github_repository: Repository, post_job_status: PostJobStatus
+):
+    """Assert that the RunnerStart, RunnerStop and Reconciliation metric is logged.
+
+    Args:
+        app: The charm to assert the events for.
+        github_repository: The github repository to assert the events for.
+        post_job_status: The expected post job status of the reconciliation event.
+    """
+    unit = app.units[0]
+
+    metrics_log = await _get_metrics_log(unit=unit)
+    log_lines = list(map(lambda line: json.loads(line), metrics_log.splitlines()))
+    events = set(map(lambda line: line.get("event"), log_lines))
+    assert {
+        "runner_start",
+        "runner_stop",
+        "reconciliation",
+    } <= events, "Not all events were logged"
+    for metric_log in log_lines:
+        if metric_log.get("event") == "runner_start":
+            assert metric_log.get("flavor") == app.name
+            assert metric_log.get("workflow") == TEST_WORKFLOW_NAME
+            assert metric_log.get("repo") == github_repository.full_name
+            assert metric_log.get("github_event") == "workflow_dispatch"
+            assert metric_log.get("idle") >= 0
+        if metric_log.get("event") == "runner_stop":
+            assert metric_log.get("flavor") == app.name
+            assert metric_log.get("workflow") == TEST_WORKFLOW_NAME
+            assert metric_log.get("repo") == github_repository.full_name
+            assert metric_log.get("github_event") == "workflow_dispatch"
+            assert metric_log.get("status") == PostJobStatus.NORMAL
+            assert metric_log.get("job_duration") >= 0
+        if metric_log.get("event") == "reconciliation":
+            assert metric_log.get("flavor") == app.name
+            assert metric_log.get("duration") >= 0
+            assert metric_log.get("crashed_runners") == 0
+            assert metric_log.get("idle_runners") == 0
+
+
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
 async def test_charm_issues_runner_installed_metric(app: Application, model: Model):
@@ -132,15 +226,20 @@ async def test_charm_issues_runner_installed_metric(app: Application, model: Mod
     await ensure_charm_has_runner(app=app, model=model)
 
     metrics_log = await _get_metrics_log(app.units[0])
-    metric_log = json.loads(metrics_log)
-    assert metric_log.get("flavor") == app.name
-    assert metric_log.get("event") == "runner_installed"
-    assert metric_log.get("duration") >= 0
+    log_lines = list(map(lambda line: json.loads(line), metrics_log.splitlines()))
+    events = set(map(lambda line: line.get("event"), log_lines))
+    assert "runner_installed" in events, "runner_installed event has not been logged"
+
+    for metric_log in log_lines:
+        if metric_log.get("event") == "runner_installed":
+            assert metric_log.get("flavor") == app.name
+            assert metric_log.get("event") == "runner_installed"
+            assert metric_log.get("duration") >= 0
 
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_charm_issues_runner_metrics_during_reconciliation(
+async def test_charm_issues_metrics_after_reconciliation(
     model: Model,
     app: Application,
     forked_github_repository: Repository,
@@ -149,31 +248,65 @@ async def test_charm_issues_runner_metrics_during_reconciliation(
     """
     arrange: A properly integrated charm with a runner registered on the fork repo.
     act: Dispatch a workflow on a branch for the runner to run. After completion, reconcile.
-    assert: The RunnerStart metric is logged.
+    assert: The RunnerStart, RunnerStop and Reconciliation metric is logged.
+        The Reconciliation metric has the post job status set to normal.
     """
     await app.set_config({"path": forked_github_repository.full_name})
     await ensure_charm_has_runner(app=app, model=model)
 
-    workflow = forked_github_repository.get_workflow(
-        id_or_file_name=DISPATCH_TEST_WORKFLOW_FILENAME
-    )
-    # The `create_dispatch` returns True on success.
-    assert workflow.create_dispatch(branch_with_protection, {"runner": app.name})
+    # Clear metrics log to make reconciliation event more predictable
     unit = app.units[0]
-    await _wait_until_runner_is_used_up(unit=unit)
+    await _clear_metrics_log(unit)
+    await _dispatch_workflow(
+        app=app,
+        branch=branch_with_protection,
+        github_repository=forked_github_repository,
+        conclusion="success",
+    )
+
     # Set the number of virtual machines to 0 to speedup reconciliation
     await app.set_config({"virtual-machines": "0"})
     await reconcile(app=app, model=model)
 
-    metrics_log = await _get_metrics_log(unit=unit)
-    log_lines = map(lambda line: json.loads(line), metrics_log.splitlines())
-    for metric_log in log_lines:
-        if metric_log.get("event") == "runner_start":
-            assert metric_log.get("flavor") == app.name
-            assert metric_log.get("workflow") == "Workflow Dispatch Tests"
-            assert metric_log.get("repo") == forked_github_repository.full_name
-            assert metric_log.get("github_event") == "workflow_dispatch"
-            assert metric_log.get("idle") >= 0
-            break
-    else:
-        assert False, "No runner_start metric found"
+    await _assert_events_after_reconciliation(
+        app=app, github_repository=forked_github_repository, post_job_status=PostJobStatus.NORMAL
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_charm_issues_metrics_for_failed_runner(
+    model: Model,
+    app: Application,
+    forked_github_repository: Repository,
+    forked_github_branch: Branch,
+):
+    """
+    arrange: A properly integrated charm with a runner registered on the fork repo.
+    act: Dispatch a workflow on a branch which has not been properly setup to pass
+        the repo-policy check. After completion, reconcile.
+    assert: The RunnerStart, RunnerStop and Reconciliation metric is logged.
+        The Reconciliation metric has the post job status set to failure.
+    """
+    await app.set_config({"path": forked_github_repository.full_name})
+    await ensure_charm_has_runner(app=app, model=model)
+
+    # Clear metrics log to make reconciliation event more predictable
+    unit = app.units[0]
+    await _clear_metrics_log(unit)
+    await _dispatch_workflow(
+        app=app,
+        branch=forked_github_branch,
+        github_repository=forked_github_repository,
+        conclusion="failure",
+    )
+
+    # Set the number of virtual machines to 0 to speedup reconciliation
+    await app.set_config({"virtual-machines": "0"})
+    await reconcile(app=app, model=model)
+
+    await _assert_events_after_reconciliation(
+        app=app,
+        github_repository=forked_github_repository,
+        post_job_status=PostJobStatus.REPO_POLICY_CHECK_FAILURE,
+    )

--- a/tests/unit/test_runner_manager.py
+++ b/tests/unit/test_runner_manager.py
@@ -2,10 +2,10 @@
 # See LICENSE file for licensing details.
 
 """Test cases of RunnerManager class."""
-
+import random
 import secrets
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -13,7 +13,7 @@ from _pytest.monkeypatch import MonkeyPatch
 import shared_fs
 from charm_state import State
 from errors import IssueMetricEventError, RunnerBinaryError
-from metrics import RunnerInstalled
+from metrics import Reconciliation, RunnerInstalled, RunnerStart, RunnerStop
 from runner import Runner, RunnerStatus
 from runner_manager import RunnerManager, RunnerManagerConfig
 from runner_metrics import RUNNER_INSTALLED_TS_FILE_NAME
@@ -84,6 +84,14 @@ def shared_fs_fixture(tmp_path: Path, monkeypatch: MonkeyPatch) -> MagicMock:
     monkeypatch.setattr("runner_manager.shared_fs", shared_fs_mock)
     monkeypatch.setattr("runner.shared_fs", shared_fs_mock)
     return shared_fs_mock
+
+
+@pytest.fixture(autouse=True, name="runner_metrics")
+def runner_metrics_fixture(monkeypatch: MonkeyPatch) -> MagicMock:
+    """Mock the runner metrics module."""
+    runner_metrics_mock = MagicMock()
+    monkeypatch.setattr("runner_manager.runner_metrics", runner_metrics_mock)
+    return runner_metrics_mock
 
 
 def test_get_latest_runner_bin_url(runner_manager: RunnerManager):
@@ -242,8 +250,8 @@ def test_reconcile_issues_runner_installed_event(
 
     runner_manager.reconcile(1, VirtualMachineResources(2, "7GiB", "10Gib"))
 
-    issue_event_mock.assert_called_once_with(
-        event=RunnerInstalled(timestamp=12345, flavor=runner_manager.app_name, duration=0)
+    issue_event_mock.assert_has_calls(
+        [call(event=RunnerInstalled(timestamp=12345, flavor=runner_manager.app_name, duration=0))]
     )
 
 
@@ -262,14 +270,14 @@ def test_reconcile_issues_no_runner_installed_event_if_metrics_disabled(
     issue_event_mock.assert_not_called()
 
 
-def test_reconcile_error_on_runner_installed_event_is_ignored(
+def test_reconcile_error_on_issue_event_is_ignored(
     runner_manager: RunnerManager,
     issue_event_mock: MagicMock,
     charm_state: MagicMock,
 ):
     """
     arrange: Enable issuing of metrics and mock the metric issuing to raise an expected error.
-    act: Reconcile to create a runner.
+    act: Reconcile.
     assert: No error is raised.
     """
     charm_state.is_metrics_logging_available = True
@@ -279,6 +287,62 @@ def test_reconcile_error_on_runner_installed_event_is_ignored(
     delta = runner_manager.reconcile(1, VirtualMachineResources(2, "7GiB", "10Gib"))
 
     assert delta == 1
+
+
+def test_reconcile_issues_reconciliation_metric_event(
+    runner_manager: RunnerManager,
+    monkeypatch: MonkeyPatch,
+    issue_event_mock: MagicMock,
+    charm_state: MagicMock,
+    runner_metrics: MagicMock,
+):
+    """
+    arrange:
+        - Enable issuing of metrics
+        - Mock timestamps
+        - The result of runner_metrics.extract
+        - Create three online runners , where two are idle
+    act: Reconcile.
+    assert: The expected event is issued.
+    """
+    charm_state.is_metrics_logging_available = True
+    t_mock = MagicMock(return_value=12345)
+    monkeypatch.setattr("runner_manager.time.time", t_mock)
+    runner_metrics.extract.return_value = {RunnerStart: 3, RunnerStop: 1}
+
+    def mock_get_runners():
+        """Create three mock runners where one is busy."""
+        runners = []
+        for i in range(3):
+            # 0 is a mock runner id.
+            status = RunnerStatus(0, True, True, False if i < 2 else True)
+            runners.append(Runner(MagicMock(), MagicMock(), status, None))
+        return runners
+
+    # Create online runners.
+    runner_manager._get_runners = mock_get_runners
+    runner_manager._get_runner_health_states = lambda: RunnerByHealth(
+        (
+            f"{runner_manager.instance_name}-0",
+            f"{runner_manager.instance_name}-1",
+            f"{runner_manager.instance_name}-2",
+        ),
+        (),
+    )
+
+    runner_manager.reconcile(
+        quantity=random.randint(0, 5), resources=VirtualMachineResources(2, "7GiB", "10Gib")
+    )
+
+    issue_event_mock.assert_any_call(
+        event=Reconciliation(
+            timestamp=12345,
+            flavor=runner_manager.app_name,
+            crashed_runners=2,
+            idle_runners=2,
+            duration=0,
+        )
+    )
 
 
 def test_reconcile_places_timestamp_in_newly_created_runner(


### PR DESCRIPTION
Applicable spec: [ISD-075](https://discourse.charmhub.io/t/specification-isd075-github-runner-cos-integration/12084)

### Overview

Issue the remaining metrics (except jog queuing time) mentioned in the spec and update the grafana dashboard.

![image](https://github.com/canonical/github-runner-operator/assets/4182921/0d67c654-81de-430f-abbe-94dce200fb5f)


### Rationale

To implement the COS integration as specified in the spec, the GitHub Runner charm needs to log all the metrics mentioned in the spec.

### Juju Events Changes

n/a

### Module Changes

- `metrics` : Add `RunnerStop` and `Reconciliation` events
- `runner_metrics`: Adapt code to emit `RunnerStop` event
- `runner_manager`: Issue the `Reconciliation` event

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->