### PR TITLE
Add verfication of checksum for yq binary

### DIFF
--- a/src-docs/runner.py.md
+++ b/src-docs/runner.py.md
@@ -18,7 +18,7 @@ Single instance of GitHub self-hosted runner.
 
 Attrs:  app_name (str): Name of the charm.  path (GitHubPath): Path to GitHub repo or org.  proxies (ProxySetting): HTTP proxy setting for juju charm.  name (str): Name of the runner instance.  exist (bool): Whether the runner instance exists on LXD.  online (bool): Whether GitHub marks this runner as online.  busy (bool): Whether GitHub marks this runner as busy. 
 
-<a href="../src/runner.py#L83"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L84"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -46,7 +46,7 @@ Construct the runner instance.
 
 ---
 
-<a href="../src/runner.py#L111"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L112"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `create`
 
@@ -78,7 +78,7 @@ Create the runner instance on LXD and register it on GitHub.
 
 ---
 
-<a href="../src/runner.py#L154"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `remove`
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -31,11 +31,11 @@ def mocks(monkeypatch, tmp_path, exec_command):
     monkeypatch.setattr("firewall.Firewall.refresh_firewall", unittest.mock.MagicMock())
     monkeypatch.setattr("runner.execute_command", exec_command)
     monkeypatch.setattr("runner.shared_fs", unittest.mock.MagicMock())
+    monkeypatch.setattr("runner.time", unittest.mock.MagicMock())
+    monkeypatch.setattr("runner.Runner._verify_yq_checksum", unittest.mock.MagicMock())
     monkeypatch.setattr("metrics.execute_command", exec_command)
     monkeypatch.setattr("metrics.METRICS_LOG_PATH", Path(tmp_path / "metrics.log"))
     monkeypatch.setattr("metrics.LOGROTATE_CONFIG", Path(tmp_path / "github-runner-metrics"))
-
-    monkeypatch.setattr("runner.time", unittest.mock.MagicMock())
     monkeypatch.setattr("runner_manager.GhApi", MockGhapiClient)
     monkeypatch.setattr("runner_manager.jinja2", unittest.mock.MagicMock())
     monkeypatch.setattr("runner_manager.LxdClient", MockLxdClient)


### PR DESCRIPTION
### Overview

Add checkout verification of yq binary.

### Rationale

Verify the yq binary in the runners are correct.

Our e2e test would only test if the yq binary downloaded in the e2e test is correct, but not what the runner downloaded during deployment.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

The integration test/e2e test would test if the checksum downloaded matches.
The e2e test would test if the yq binary is working.

<!-- Explanation for any unchecked items above -->