### PR TITLE
copy - feat (trivial): use ops to tell juju to reboot the machine.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ghapi
 jinja2
-ops
+ops>2.8
 pylxd @ git+https://github.com/canonical/pylxd
 requests
 typing-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ghapi
 jinja2
-ops>2.8
+ops>=2.8
 pylxd @ git+https://github.com/canonical/pylxd
 requests
 typing-extensions

--- a/src/charm.py
+++ b/src/charm.py
@@ -385,12 +385,7 @@ class GithubRunnerCharm(CharmBase):
         _, exit_code = execute_command(["ls", "/var/run/reboot-required"], check_exit=False)
         if exit_code == 0:
             logger.info("Rebooting system...")
-
-            # The juju-reboot is inject to PATH by juju.
-            cmd = ["juju-reboot"]
-            if now:
-                cmd += ["--now"]
-            execute_command(cmd)
+            self.unit.reboot(now=now)
 
     @catch_charm_errors
     def _on_upgrade_charm(self, _event: UpgradeCharmEvent) -> None:


### PR DESCRIPTION
Author: Tony Meyer
Copy of https://github.com/canonical/github-runner-operator/pull/146 .
The above PR is not able to run the tests because secrets are not passed for PRs from forks.

Applicable spec: N/A

### Overview

`ops` 2.8 exposes `Unit.reboot` to ask Juju to reboot the machine. This means that the code can be slightly simplified to work through `ops` rather than manually running a juju command.

### Rationale

Trivial change to utilise new `ops` functionality and keep interaction with juju within op.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->

No documentation changes (no user-visible changes).