### PR TITLE
Use shorter runner names

### DIFF
--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -5,10 +5,10 @@
 
 import hashlib
 import logging
+import secrets
 import tarfile
 import time
 import urllib.request
-import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterator, Optional
@@ -558,7 +558,7 @@ class RunnerManager:
         Returns:
             Generated name of runner.
         """
-        suffix = str(uuid.uuid4())
+        suffix = secrets.token_hex(12)
         return f"{self.instance_name}-{suffix}"
 
     def _get_runner_github_info(self) -> Dict[str, SelfHostedRunner]:


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Use a shorter suffix for runner names (12 instead of 36 characters). The probability of runner name collisions should still be low enough.


### Rationale

To work around the https://github.com/canonical/lxd/issues/12539 problem with too long lxd instance names.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->