### PR TITLE
COS: Add a gauge for active runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,27 +45,11 @@ The charm is designed to provide comprehensive metrics and monitoring capabiliti
 
 ### Loki Integration
 #### Loki Push API
-The charm seamlessly integrates with Loki, a powerful log aggregation system, through the `cos_agent` interface. This integration allows the charm to push various metrics and logs related to the Runners and the Charm itself to a Loki instance. This provides valuable insights into the performance and behavior of your deployment.
+The charm integrates seamlessly with Loki, a powerful log aggregation system, through the `cos-agent` integration. This integration allows the charm to push various metrics and logs related to the runners and the charm itself to a Loki instance. This provides valuable insight into the performance and behaviour of your deployment.
 
 ### Grafana Dashboard
-To make monitoring even more accessible, the charm comes with a pre-configured Grafana Dashboard. This dashboard is designed to visualize the metrics collected by the charm, making it easier for operators to track the health and performance of the system.
-
-#### Automated Dashboard Deployment
-You can automate the deployment of the Grafana Dashboard using the [cos-integration-k8s](https://charmhub.io/cos-configuration-k8s) charm. This simplifies the setup process and ensures that your monitoring infrastructure is ready to go with minimal manual intervention.
-
-#### Configuration Options
-To enable the automated deployment of the Grafana Dashboard, you can provide the following configuration options when deploying the `cos-integration-k8s` charm:
-
-```ini
-git_repo=https://https://github.com/canonical/github-runner-operator
-git_branch=main
-git_depth=1
-grafana_dashboards_path=src/grafana_dashboard_metrics
-```
-
-
-
-
+To make monitoring even more accessible, the charm comes with a pre-configured Grafana dashboard. This dashboard is designed to visualise the metrics collected by the charm, making it easier for operators to track the health and performance of the system.
+This dashboard can be transferred to Grafana using the [Grafana Agent](https://charmhub.io/grafana-agent), which consumes the `cos-agent` integration.
 
 ## Development
 

--- a/src-docs/metrics.py.md
+++ b/src-docs/metrics.py.md
@@ -12,7 +12,7 @@ Models and functions for the metric events.
 
 ---
 
-<a href="../src/metrics.py#L136"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/metrics.py#L138"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `issue_event`
 
@@ -39,7 +39,7 @@ The metric event is logged to the metrics log.
 
 ---
 
-<a href="../src/metrics.py#L187"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/metrics.py#L189"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `setup_logrotate`
 
@@ -101,6 +101,7 @@ Metric event for when the charm has finished reconciliation.
  - <b>`flavor`</b>:  Describes the characteristics of the runner.  The flavor could be for example "small". 
  - <b>`crashed_runners`</b>:  The number of crashed runners. 
  - <b>`idle_runners`</b>:  The number of idle runners. 
+ - <b>`active_runners`</b>:  The number of active runners. 
  - <b>`duration`</b>:  The duration of the reconciliation in seconds. 
 
 <a href="../src/metrics.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>

--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -8,6 +8,7 @@ Runner Manager manages the runners on LXD and GitHub.
 **Global Variables**
 ---------------
 - **RUNNER_INSTALLED_TS_FILE_NAME**
+- **REMOVED_RUNNER_LOG_STR**
 
 
 ---
@@ -26,7 +27,7 @@ Used as a returned type to method querying runner information.
 ## <kbd>class</kbd> `RunnerManager`
 Manage a group of runners according to configuration. 
 
-<a href="../src/runner_manager.py#L97"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L99"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -55,7 +56,7 @@ Construct RunnerManager object for creating and managing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L158"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L160"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `check_runner_bin`
 
@@ -72,7 +73,7 @@ Check if runner binary exists.
 
 ---
 
-<a href="../src/runner_manager.py#L527"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L530"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `flush`
 
@@ -95,7 +96,7 @@ Remove existing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L273"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_github_info`
 
@@ -112,7 +113,7 @@ Get information on the runners from GitHub.
 
 ---
 
-<a href="../src/utilities.py#L166"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/utilities.py#L168"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_latest_runner_bin_url`
 
@@ -141,7 +142,7 @@ The runner binary URL changes when a new version is available.
 
 ---
 
-<a href="../src/runner_manager.py#L458"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L461"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 
@@ -165,7 +166,7 @@ Bring runners in line with target.
 
 ---
 
-<a href="../src/utilities.py#L204"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/utilities.py#L206"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_runner_bin`
 

--- a/src/grafana_dashboards/metrics.json
+++ b/src/grafana_dashboards/metrics.json
@@ -154,7 +154,7 @@
           "refId": "D"
         }
       ],
-      "title": "Runners Total",
+      "title": "Lifecycle Status",
       "transformations": [],
       "type": "timeseries"
     },
@@ -244,7 +244,7 @@
           "editorMode": "code",
           "expr": "sum by(filename)(last_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",idle_runners=\"idle_runners\" | event=\"reconciliation\" | unwrap idle_runners[10m]))",
           "hide": false,
-          "legendFormat": "Idle Runners",
+          "legendFormat": "Idle",
           "queryType": "range",
           "refId": "D"
         },
@@ -256,12 +256,12 @@
           "editorMode": "code",
           "expr": "sum by(filename)(last_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",active_runners=\"active_runners\" | event=\"reconciliation\" | unwrap active_runners[10m]))",
           "hide": false,
-          "legendFormat": "Active Runners",
+          "legendFormat": "Active",
           "queryType": "range",
           "refId": "A"
         }
       ],
-      "title": "Gauges",
+      "title": "Active and Idle Runners",
       "transformations": [
         {
           "id": "calculateField",

--- a/src/grafana_dashboards/metrics.json
+++ b/src/grafana_dashboards/metrics.json
@@ -155,49 +155,7 @@
         }
       ],
       "title": "Runners Total",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "binary": {
-              "left": "Started",
-              "operator": "-",
-              "reducer": "sum",
-              "right": "Stopped"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Active",
-            "binary": {
-              "left": "Started - Stopped",
-              "operator": "-",
-              "reducer": "sum",
-              "right": "Crashed"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Started - Stopped": true
-            },
-            "indexByName": {},
-            "renameByName": {}
-          }
-        }
-      ],
+      "transformations": [],
       "type": "timeseries"
     },
     {
@@ -289,6 +247,18 @@
           "legendFormat": "Idle Runners",
           "queryType": "range",
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(filename)(last_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",active_runners=\"active_runners\" | event=\"reconciliation\" | unwrap active_runners[10m]))",
+          "hide": false,
+          "legendFormat": "Active Runners",
+          "queryType": "range",
+          "refId": "A"
         }
       ],
       "title": "Gauges",
@@ -1022,6 +992,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "GitHub Self-Hosted Runner Metrics",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -124,12 +124,14 @@ class Reconciliation(Event):
           The flavor could be for example "small".
         crashed_runners: The number of crashed runners.
         idle_runners: The number of idle runners.
+        active_runners: The number of active runners.
         duration: The duration of the reconciliation in seconds.
     """
 
     flavor: str
     crashed_runners: int
     idle_runners: int
+    active_runners: int
     duration: NonNegativeFloat
 
 

--- a/tests/integration/test_charm_metrics.py
+++ b/tests/integration/test_charm_metrics.py
@@ -243,6 +243,7 @@ async def _assert_events_after_reconciliation(
             assert metric_log.get("duration") >= 0
             assert metric_log.get("crashed_runners") == 0
             assert metric_log.get("idle_runners") == 0
+            assert metric_log.get("active_runners") == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runner_manager.py
+++ b/tests/unit/test_runner_manager.py
@@ -21,6 +21,8 @@ from runner_type import GitHubOrg, GitHubRepo, RunnerByHealth, VirtualMachineRes
 from shared_fs import SharedFilesystem
 from tests.unit.mock import TEST_BINARY
 
+RUNNER_MANAGER_TIME_MODULE = "runner_manager.time.time"
+
 
 @pytest.fixture(scope="function", name="token")
 def token_fixture():
@@ -246,7 +248,7 @@ def test_reconcile_issues_runner_installed_event(
     """
     charm_state.is_metrics_logging_available = True
     t_mock = MagicMock(return_value=12345)
-    monkeypatch.setattr("runner_manager.time.time", t_mock)
+    monkeypatch.setattr(RUNNER_MANAGER_TIME_MODULE, t_mock)
 
     runner_manager.reconcile(1, VirtualMachineResources(2, "7GiB", "10Gib"))
 
@@ -307,7 +309,7 @@ def test_reconcile_issues_reconciliation_metric_event(
     """
     charm_state.is_metrics_logging_available = True
     t_mock = MagicMock(return_value=12345)
-    monkeypatch.setattr("runner_manager.time.time", t_mock)
+    monkeypatch.setattr(RUNNER_MANAGER_TIME_MODULE, t_mock)
     runner_metrics.extract.return_value = {RunnerStart: 3, RunnerStop: 1}
 
     def mock_get_runners():
@@ -340,6 +342,7 @@ def test_reconcile_issues_reconciliation_metric_event(
             flavor=runner_manager.app_name,
             crashed_runners=2,
             idle_runners=2,
+            active_runners=1,
             duration=0,
         )
     )
@@ -360,7 +363,7 @@ def test_reconcile_places_timestamp_in_newly_created_runner(
     """
     charm_state.is_metrics_logging_available = True
     t_mock = MagicMock(return_value=12345)
-    monkeypatch.setattr("runner_manager.time.time", t_mock)
+    monkeypatch.setattr(RUNNER_MANAGER_TIME_MODULE, t_mock)
     runner_shared_fs = tmp_path / "runner_fs"
     runner_shared_fs.mkdir()
     fs = SharedFilesystem(path=runner_shared_fs, runner_name="test_runner")


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Add a gauge for the number of active runners and update the dashboard.

![image](https://github.com/canonical/github-runner-operator/assets/4182921/f9312816-b6b7-450c-9f8a-76156cb1ff75)

Also a small README update to reflect our current approach to submitting the dashboard to Grafana.

### Rationale

Currently the active number of runners is calculated from the other counters (`(Started - Stopped) - Crashed`). Since the current approach is to send only the metrics for runners who have finished, `Active` cannot be properly determined (because a runner who has finished obviously cannot be active any more). Also, adding `Active` to the counter panel is confusing, as its value is limited, but the value of the other counters increases without a strictly defined limit. Having `Active` and `Idle` on the same panel allows you to quickly deduce the total number of runners.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->