### PR TITLE
Bug fix: Increase the disk size for building VM image

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -51,7 +51,7 @@ cleanup() {
 cleanup '/snap/bin/lxc info builder &> /dev/null' '/snap/bin/lxc delete builder --force' 'Cleanup LXD VM of previous run' 10
 
 if [[ "$1" == "test" ]]; then
-    retry '/snap/bin/lxc launch ubuntu-daily:jammy builder --device root,size=5GiB' 'Starting LXD VM'
+    retry '/snap/bin/lxc launch ubuntu-daily:jammy builder --device root,size=8GiB' 'Starting LXD VM'
 else
     retry '/snap/bin/lxc launch ubuntu-daily:jammy builder --vm --device root,size=5GiB' 'Starting LXD container'
 fi

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -51,9 +51,9 @@ cleanup() {
 cleanup '/snap/bin/lxc info builder &> /dev/null' '/snap/bin/lxc delete builder --force' 'Cleanup LXD VM of previous run' 10
 
 if [[ "$1" == "test" ]]; then
-    retry '/snap/bin/lxc launch ubuntu-daily:jammy builder --device root,size=8GiB' 'Starting LXD VM'
+    retry '/snap/bin/lxc launch ubuntu-daily:jammy builder --device root,size=5GiB' 'Starting LXD container'
 else
-    retry '/snap/bin/lxc launch ubuntu-daily:jammy builder --vm --device root,size=5GiB' 'Starting LXD container'
+    retry '/snap/bin/lxc launch ubuntu-daily:jammy builder --vm --device root,size=8GiB' 'Starting LXD VM'
 fi
 retry '/snap/bin/lxc exec builder -- /usr/bin/who' 'Wait for lxd agent to be ready' 30
 retry '/snap/bin/lxc exec builder -- /usr/bin/nslookup github.com' 'Wait for network to be ready' 30


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Increase the root-disk size when building virtual machine images.

### Rationale

<!-- The reason the change is needed -->

The existing root-disk size is only enough for container images.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->