### PR TITLE
Sync disk prior to publishing image

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -96,13 +96,14 @@ else
     echo "Unsupported CPU architecture: $(uname -m)"
     return 1
 fi
-/usr/bin/wget "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$YQ_ARCH"
-/usr/bin/wget https://github.com/mikefarah/yq/releases/latest/download/checksums
-/usr/bin/wget https://github.com/mikefarah/yq/releases/latest/download/checksums_hashes_order
-/usr/bin/wget https://github.com/mikefarah/yq/releases/latest/download/extract-checksum.sh
+/usr/bin/wget "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$YQ_ARCH" -O "yq_linux_$YQ_ARCH"
+/usr/bin/wget https://github.com/mikefarah/yq/releases/latest/download/checksums -O checksums
+/usr/bin/wget https://github.com/mikefarah/yq/releases/latest/download/checksums_hashes_order -O checksums_hashes_order
+/usr/bin/wget https://github.com/mikefarah/yq/releases/latest/download/extract-checksum.sh -O extract-checksum.sh
 /usr/bin/bash extract-checksum.sh SHA-256 "yq_linux_$YQ_ARCH" | /usr/bin/awk '{print $2,$1}' | /usr/bin/sha256sum -c | /usr/bin/grep OK
 /snap/bin/lxc file push "yq_linux_$YQ_ARCH" builder/usr/bin/yq --mode 755
 
+/snap/bin/lxc exec builder -- /usr/bin/sync
 /snap/bin/lxc publish builder --alias builder --reuse -f
 
 # Swap in the built image
@@ -111,4 +112,4 @@ fi
 /snap/bin/lxc image delete old-runner || true
 
 # Clean up LXD instance
-cleanup '/snap/bin/lxc info builder &> /dev/null' '/snap/bin/lxc delete builder --force' 'Cleanup LXD VM' 10
+cleanup '/snap/bin/lxc info builder &> /dev/null' '/snap/bin/lxc delete builder --force' 'Cleanup LXD instance' 10

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -657,4 +657,6 @@ class RunnerManager:
         minute = random.randint(0, 59)  # nosec B311
         base_hour = random.randint(0, 5)  # nosec B311
         hours = ",".join([str(base_hour + offset) for offset in (0, 6, 12, 18)])
-        cron_file.write_text(f"{minute} {hours} * * * ubuntu {self._build_image_command()} ")
+        cron_file.write_text(
+            f"{minute} {hours} * * * ubuntu {' '.join(self._build_image_command())}"
+        )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

During building of runner image, run`/usr/bin/sync` prior to stopping the VM instance and publishing the VM as image.

### Rationale

Not running the `sync` can result in missing/broken file in the published image.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->