### PR TITLE
Update year in license header to 2024

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 check-runners:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 type: charm

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 options:

--- a/generate-src-docs.sh
+++ b/generate-src-docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 lazydocs --no-watermark --output-path src-docs src/*

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 r"""## Overview.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: github-runner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tool.bandit]

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 set -e

--- a/scripts/pre-integration-test.sh
+++ b/scripts/pre-integration-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Enable kernel module br_netfilter

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Charm for creating and managing GitHub self-hosted runner instances."""

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
 """State of the Charm."""

--- a/src/errors.py
+++ b/src/errors.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Errors used by the charm."""

--- a/src/event_timer.py
+++ b/src/event_timer.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """EventTimer for scheduling dispatch of juju event on regular intervals."""

--- a/src/firewall.py
+++ b/src/firewall.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """The runner firewall manager."""

--- a/src/github_client.py
+++ b/src/github_client.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """GitHub API client.

--- a/src/github_metrics.py
+++ b/src/github_metrics.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
 """Functions to calculate metrics from data retrieved from GitHub."""

--- a/src/github_type.py
+++ b/src/github_type.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Return type for the GitHub web API."""

--- a/src/lxd.py
+++ b/src/lxd.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Low-level LXD client interface.

--- a/src/lxd_type.py
+++ b/src/lxd_type.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Types used by Lxd class.

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
 """Models and functions for the metric events."""

--- a/src/repo_policy_compliance_client.py
+++ b/src/repo_policy_compliance_client.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Client for requesting repo policy compliance service."""

--- a/src/runner.py
+++ b/src/runner.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Manage the lifecycle of runners.

--- a/src/runner_logs.py
+++ b/src/runner_logs.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
 """Functions to pull and remove the logs of the crashed runners."""

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Runner Manager manages the runners on LXD and GitHub."""

--- a/src/runner_manager_type.py
+++ b/src/runner_manager_type.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Types used by RunnerManager class."""

--- a/src/runner_metrics.py
+++ b/src/runner_metrics.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
 """Classes and function to extract the metrics from a shared filesystem."""

--- a/src/runner_type.py
+++ b/src/runner_type.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Types used by Runner class."""

--- a/src/shared_fs.py
+++ b/src/shared_fs.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
 """Classes and functions to operate on the shared filesystem between the charm and the runners."""

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Utilities used by the charm."""

--- a/templates/repo_policy_compliance_service.py
+++ b/templates/repo_policy_compliance_service.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Flask application for repo policy compliance.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Fixtures for github runner charm."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Fixtures for github runner charm integration tests."""

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Utilities for integration test."""

--- a/tests/integration/test_charm_fork_repo.py
+++ b/tests/integration/test_charm_fork_repo.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Integration tests for github-runner charm with a fork repo.

--- a/tests/integration/test_charm_metrics.py
+++ b/tests/integration/test_charm_metrics.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
 """Integration tests for metrics/logs."""

--- a/tests/integration/test_charm_no_runner.py
+++ b/tests/integration/test_charm_no_runner.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Integration tests for github-runner charm with no runner."""

--- a/tests/integration/test_charm_one_runner.py
+++ b/tests/integration/test_charm_one_runner.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Integration tests for github-runner charm."""

--- a/tests/integration/test_charm_scheduled_events.py
+++ b/tests/integration/test_charm_scheduled_events.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Integration tests for github-runner charm with scheduled events.

--- a/tests/integration/test_charm_with_proxy.py
+++ b/tests/integration/test_charm_with_proxy.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
 """Test the usage of a proxy server."""

--- a/tests/integration/test_self_hosted_runner.py
+++ b/tests/integration/test_self_hosted_runner.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Integration tests for self-hosted runner managed by the github-runner charm."""

--- a/tests/status_name.py
+++ b/tests/status_name.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 from ops.model import ActiveStatus, BlockedStatus

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import unittest.mock

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Mock for testing."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Test cases for GithubRunnerCharm."""

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 import os
 import platform

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 import http
 import random

--- a/tests/unit/test_github_metrics.py
+++ b/tests/unit/test_github_metrics.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 import secrets
 from datetime import datetime, timedelta, timezone

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 import json
 from pathlib import Path

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Test cases of Runner class."""

--- a/tests/unit/test_runner_logs.py
+++ b/tests/unit/test_runner_logs.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 from pathlib import Path
 from unittest.mock import MagicMock, call

--- a/tests/unit/test_runner_manager.py
+++ b/tests/unit/test_runner_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Test cases of RunnerManager class."""

--- a/tests/unit/test_runner_metrics.py
+++ b/tests/unit/test_runner_metrics.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 import json
 import secrets

--- a/tests/unit/test_shared_fs.py
+++ b/tests/unit/test_shared_fs.py
@@ -1,4 +1,4 @@
-#  Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 import secrets
 import tarfile

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Test cases of utilities."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]


### PR DESCRIPTION
### Overview

Update year in license header to 2024

### Rationale

Needed to pass license checks in CI/CD

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->