### PR TITLE
Change built image name to jammy

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -431,7 +431,7 @@ jobs:
   e2e-test:
     name: End-to-End Test
     needs: [build-charm, run-id]
-    runs-on: [self-hosted, linux, x64, "pr-${{ needs.run-id.outputs.run-id }}"]
+    runs-on: [self-hosted, linux, x64, jammy, "pr-${{ needs.run-id.outputs.run-id }}"]
     steps:
       # Snapd can have some issues in privileged LXD containers without setting
       # security.nesting=True and this.

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -107,9 +107,9 @@ fi
 /snap/bin/lxc publish builder --alias builder --reuse -f
 
 # Swap in the built image
-/snap/bin/lxc image alias rename runner old-runner || true
-/snap/bin/lxc image alias rename builder runner
-/snap/bin/lxc image delete old-runner || true
+/snap/bin/lxc image alias rename jammy old-jammy || true
+/snap/bin/lxc image alias rename builder jammy
+/snap/bin/lxc image delete old-jammy || true
 
 # Clean up LXD instance
 cleanup '/snap/bin/lxc info builder &> /dev/null' '/snap/bin/lxc delete builder --force' 'Cleanup LXD instance' 10

--- a/src/charm.py
+++ b/src/charm.py
@@ -306,7 +306,7 @@ class GithubRunnerCharm(CharmBase):
             RunnerManagerConfig(
                 path=path,
                 token=token,
-                image="runner",
+                image="jammy",
                 service_token=self.service_token,
                 lxd_storage_path=self.ram_pool_path,
                 charm_state=self._state,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -120,7 +120,7 @@ class TestCharm(unittest.TestCase):
             RunnerManagerConfig(
                 path=GithubOrg(org="mockorg", group="mockgroup"),
                 token="mocktoken",
-                image="runner",
+                image="jammy",
                 service_token=token,
                 lxd_storage_path=GithubRunnerCharm.ram_pool_path,
                 charm_state=harness.charm._state,
@@ -146,7 +146,7 @@ class TestCharm(unittest.TestCase):
             RunnerManagerConfig(
                 path=GithubRepo(owner="mockorg", repo="repo"),
                 token="mocktoken",
-                image="runner",
+                image="jammy",
                 service_token=token,
                 lxd_storage_path=GithubRunnerCharm.ram_pool_path,
                 charm_state=harness.charm._state,
@@ -177,7 +177,7 @@ class TestCharm(unittest.TestCase):
             RunnerManagerConfig(
                 path=GithubRepo(owner="mockorg", repo="repo"),
                 token="mocktoken",
-                image="runner",
+                image="jammy",
                 service_token=token,
                 lxd_storage_path=GithubRunnerCharm.ram_pool_path,
                 charm_state=harness.charm._state,
@@ -197,7 +197,7 @@ class TestCharm(unittest.TestCase):
             RunnerManagerConfig(
                 path=GithubRepo(owner="mockorg", repo="repo"),
                 token="mocktoken",
-                image="runner",
+                image="jammy",
                 service_token=token,
                 lxd_storage_path=GithubRunnerCharm.ram_pool_path,
                 charm_state=harness.charm._state,


### PR DESCRIPTION

### Overview

Change name of the built image to jammy.

### Rationale

The image name is added to the label for self-hosted runners. The previous version was using jammy as the label/image name and some existing workflows are relying on that.

This will be a temp fix until a more full-featured solution for controlling the label come with the custom image support.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->