### PR TITLE
Use instant type for pie charts

### DIFF
--- a/src/grafana_dashboards/metrics.json
+++ b/src/grafana_dashboards/metrics.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 155,
+  "id": 29,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -788,6 +788,7 @@
         "y": 26
       },
       "id": 14,
+      "maxDataPoints": 1,
       "options": {
         "displayLabels": [],
         "legend": {
@@ -804,7 +805,7 @@
             "lastNotNull"
           ],
           "fields": "",
-          "values": false
+          "values": true
         },
         "tooltip": {
           "mode": "single",
@@ -818,9 +819,9 @@
             "uid": "${lokids}"
           },
           "editorMode": "code",
-          "expr": "sum by(filename,status)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_stop\" | json status=\"status\",repo=\"repo\" | repo=~\"$repository\"[$__range]))",
-          "legendFormat": "{{status}}",
-          "queryType": "range",
+          "expr": "sum by(status)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_stop\" | json status=\"status\",repo=\"repo\" | repo=~\"$repository\"[$__range]))",
+          "legendFormat": "",
+          "queryType": "instant",
           "refId": "A"
         }
       ],
@@ -856,6 +857,7 @@
         "y": 26
       },
       "id": 20,
+      "maxDataPoints": 1,
       "options": {
         "legend": {
           "displayMode": "list",
@@ -871,7 +873,7 @@
             "lastNotNull"
           ],
           "fields": "",
-          "values": false
+          "values": true
         },
         "tooltip": {
           "mode": "single",
@@ -885,9 +887,9 @@
             "uid": "${lokids}"
           },
           "editorMode": "code",
-          "expr": "sum by(filename,job_conclusion)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_stop\" | json job_conclusion=\"job_conclusion\",repo=\"repo\" | repo=~\"$repository\"[$__range]))",
-          "legendFormat": "{{job_conclusion}}",
-          "queryType": "range",
+          "expr": "sum by(job_conclusion)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_stop\" | json job_conclusion=\"job_conclusion\",repo=\"repo\" | repo=~\"$repository\"[$__range]))",
+          "legendFormat": "",
+          "queryType": "instant",
           "refId": "A"
         }
       ],
@@ -923,6 +925,7 @@
         "y": 34
       },
       "id": 18,
+      "maxDataPoints": 1,
       "options": {
         "legend": {
           "displayMode": "list",
@@ -938,7 +941,7 @@
             "lastNotNull"
           ],
           "fields": "",
-          "values": false
+          "values": true
         },
         "tooltip": {
           "mode": "single",
@@ -952,9 +955,9 @@
             "uid": "${lokids}"
           },
           "editorMode": "code",
-          "expr": "sum by(filename,flavor)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_start\" | json flavor=\"flavor\",repo=\"repo\" | repo=~\"$repository\"[$__range]))",
-          "legendFormat": "{{flavor}}",
-          "queryType": "range",
+          "expr": "sum by(flavor)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_start\" | json flavor=\"flavor\",repo=\"repo\" | repo=~\"$repository\"[$__range]))",
+          "legendFormat": "",
+          "queryType": "instant",
           "refId": "A"
         }
       ],
@@ -990,6 +993,7 @@
         "y": 34
       },
       "id": 15,
+      "maxDataPoints": 1,
       "options": {
         "legend": {
           "displayMode": "list",
@@ -1005,7 +1009,7 @@
             "lastNotNull"
           ],
           "fields": "",
-          "values": false
+          "values": true
         },
         "tooltip": {
           "mode": "single",
@@ -1019,9 +1023,9 @@
             "uid": "${lokids}"
           },
           "editorMode": "code",
-          "expr": "sum by(filename,http_code)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_stop\" | json status=\"status\",repo=\"repo\" | status=\"repo-policy-check-failure\" | repo=~\"$repository\" | json http_code=\"status_info.code\"[$__range]))",
-          "legendFormat": "{{http_code}}",
-          "queryType": "range",
+          "expr": "sum by(http_code)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_stop\" | json status=\"status\",repo=\"repo\" | status=\"repo-policy-check-failure\" | repo=~\"$repository\" | json http_code=\"status_info.code\"[$__range]))",
+          "legendFormat": "",
+          "queryType": "instant",
           "refId": "A"
         }
       ],
@@ -1057,6 +1061,7 @@
         "y": 42
       },
       "id": 19,
+      "maxDataPoints": 1,
       "options": {
         "legend": {
           "displayMode": "list",
@@ -1072,7 +1077,7 @@
             "lastNotNull"
           ],
           "fields": "",
-          "values": false
+          "values": true
         },
         "tooltip": {
           "mode": "single",
@@ -1086,9 +1091,9 @@
             "uid": "${lokids}"
           },
           "editorMode": "code",
-          "expr": "sum by(filename,github_event)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_start\" | json github_event=\"github_event\",repo=\"repo\" | repo=~\"$repository\"[$__range]))",
-          "legendFormat": "{{github_event}}",
-          "queryType": "range",
+          "expr": "sum by(github_event)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_start\" | json github_event=\"github_event\",repo=\"repo\" | repo=~\"$repository\"[$__range]))",
+          "legendFormat": "",
+          "queryType": "instant",
           "refId": "A"
         }
       ],
@@ -1249,6 +1254,7 @@
         "y": 50
       },
       "id": 21,
+      "maxDataPoints": 1,
       "options": {
         "displayMode": "gradient",
         "minVizHeight": 10,
@@ -1259,7 +1265,7 @@
             "lastNotNull"
           ],
           "fields": "",
-          "values": false
+          "values": true
         },
         "showUnfilled": true
       },
@@ -1271,9 +1277,9 @@
             "uid": "${lokids}"
           },
           "editorMode": "code",
-          "expr": "sum by(filename,repo)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_start\" | json repo=\"repo\" | repo=~\"$repository\" [$__range]))",
-          "legendFormat": "{{repo}}",
-          "queryType": "range",
+          "expr": "sum by(filename,repo)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\" | event=\"runner_start\" | json repo=\"repo\" | repo=~\"$repository\"[$__range]))",
+          "legendFormat": "",
+          "queryType": "instant",
           "refId": "A"
         }
       ],
@@ -1511,6 +1517,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "GitHub Self-Hosted Runner Metrics",
-  "version": 6,
+  "version": 7,
   "weekStart": ""
 }

--- a/src/grafana_dashboards/metrics.json
+++ b/src/grafana_dashboards/metrics.json
@@ -788,7 +788,6 @@
         "y": 26
       },
       "id": 14,
-      "maxDataPoints": 1,
       "options": {
         "displayLabels": [],
         "legend": {
@@ -857,7 +856,6 @@
         "y": 26
       },
       "id": 20,
-      "maxDataPoints": 1,
       "options": {
         "legend": {
           "displayMode": "list",
@@ -925,7 +923,6 @@
         "y": 34
       },
       "id": 18,
-      "maxDataPoints": 1,
       "options": {
         "legend": {
           "displayMode": "list",
@@ -993,7 +990,6 @@
         "y": 34
       },
       "id": 15,
-      "maxDataPoints": 1,
       "options": {
         "legend": {
           "displayMode": "list",
@@ -1061,7 +1057,6 @@
         "y": 42
       },
       "id": 19,
-      "maxDataPoints": 1,
       "options": {
         "legend": {
           "displayMode": "list",
@@ -1254,7 +1249,6 @@
         "y": 50
       },
       "id": 21,
-      "maxDataPoints": 1,
       "options": {
         "displayMode": "gradient",
         "minVizHeight": 10,


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Use [instant type](https://grafana.com/docs/grafana/latest/datasources/prometheus/query-editor/#type) for pie charts and bar gauge.

### Rationale

Currently the pie charts take into account the `last` value of the aggregated time series data. This can lead to incorrect visualisation if the data points of a different timeseries aggregation have different timestamps (e.g. last aggregation of jobs without `job_conclusion` from 11:30 and jobs with `job_conclusion` with timestamp 12:00, see screenshot). Using instant ensures that only the last data point in time is taken into account.

![Screenshot from 2024-01-10 12-31-58](https://github.com/canonical/github-runner-operator/assets/4182921/6cd4b8fc-0ae1-4d52-b5fd-558fdf3c25f4)

See also https://community.grafana.com/t/grafana-loki-instant-type-doesnt-work-in-pie-chart/101122 for more info.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->