### PR TITLE
Fix: Crashed runner logs not available

### DIFF
--- a/src-docs/errors.py.md
+++ b/src-docs/errors.py.md
@@ -202,6 +202,15 @@ Error for loading file on runner.
 
 ---
 
+## <kbd>class</kbd> `RunnerLogsError`
+Base class for all runner logs errors. 
+
+
+
+
+
+---
+
 ## <kbd>class</kbd> `RunnerMetricsError`
 Base class for all runner metrics errors. 
 

--- a/src-docs/runner_logs.py.md
+++ b/src-docs/runner_logs.py.md
@@ -11,7 +11,7 @@ Functions to pull and remove the logs of the crashed runners.
 
 ---
 
-<a href="../src/runner_logs.py#L23"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_logs.py#L24"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_crashed`
 
@@ -30,9 +30,15 @@ Expects the runner to have an instance.
  - <b>`runner`</b>:  The runner. 
 
 
+
+**Raises:**
+ 
+ - <b>`RunnerLogsError`</b>:  If the runner logs could not be pulled. 
+
+
 ---
 
-<a href="../src/runner_logs.py#L45"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_logs.py#L51"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `remove_outdated_crashed`
 

--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -46,7 +46,7 @@ Construct RunnerManager object for creating and managing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L643"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L648"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `build_runner_image`
 
@@ -83,7 +83,7 @@ Check if runner binary exists.
 
 ---
 
-<a href="../src/runner_manager.py#L510"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L515"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `flush`
 
@@ -172,7 +172,7 @@ Bring runners in line with target.
 
 ---
 
-<a href="../src/runner_manager.py#L653"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L658"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `schedule_build_runner_image`
 

--- a/src/errors.py
+++ b/src/errors.py
@@ -148,3 +148,7 @@ class GithubClientError(Exception):
 
 class JobNotFoundError(GithubClientError):
     """Represents an error when the job could not be found on GitHub."""
+
+
+class RunnerLogsError(Exception):
+    """Base class for all runner logs errors."""

--- a/src/runner_logs.py
+++ b/src/runner_logs.py
@@ -45,7 +45,7 @@ def get_crashed(runner: Runner) -> None:
         runner.instance.files.pull_file(str(DIAG_DIR_PATH), str(target_log_path), is_dir=True)
         runner.instance.files.pull_file(str(SYSLOG_PATH), str(target_log_path))
     except LxdError as exc:
-        raise RunnerLogsError(str(exc)) from exc
+        raise RunnerLogsError(f"Cannot pull the logs for {runner.config.name}.") from exc
 
 
 def remove_outdated_crashed() -> None:

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -485,7 +485,12 @@ class RunnerManager:
 
             for runner in unhealthy_runners:
                 if self.config.are_metrics_enabled:
-                    runner_logs.get_crashed(runner)
+                    try:
+                        runner_logs.get_crashed(runner)
+                    except errors.RunnerLogsError:
+                        logger.exception(
+                            "Failed to get logs of crashed runner %s", runner.config.name
+                        )
                 runner.remove(remove_token)
                 logger.info(REMOVED_RUNNER_LOG_STR, runner.config.name)
 

--- a/tests/unit/test_runner_logs.py
+++ b/tests/unit/test_runner_logs.py
@@ -74,7 +74,8 @@ def test_get_crashed_lxd_error(log_dir_base_path: Path):
     with pytest.raises(RunnerLogsError) as exc_info:
         get_crashed(runner)
 
-    assert "Cannot pull file" in str(exc_info.value)
+    assert "Cannot pull the logs for test-runner." in str(exc_info.value)
+    assert "Cannot pull file" in str(exc_info.value.__cause__)
 
 
 def test_remove_outdated_crashed(log_dir_base_path: Path, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
### Overview

Catch an `LxdError` that occurs on a file pull to retrieve the logs from crashed runners.


### Rationale

It is possible that the `_diag` directory does not exist if the runner application has been installed but not started and the reconciliation has been stopped (e.g. due to a timeout). The runner application itself does not contain the directory, it has the following contents:

```
ubuntu@juju-3106ff-44:~/tmp$ ls -la
total 52
drwxr-xr-x 4 ubuntu ubuntu  4096 Oct 23 18:17 .
drwxr-x--- 6 ubuntu ubuntu  4096 Jan 11 06:40 ..
drwxr-xr-x 4 ubuntu ubuntu 16384 Oct 23 18:17 bin
-rwxr-xr-x 1 ubuntu ubuntu  2458 Oct 23 18:16 config.sh
-rwxr-xr-x 1 ubuntu ubuntu   646 Oct 23 18:16 env.sh
drwxr-xr-x 6 ubuntu ubuntu  4096 Oct 23 18:16 externals
-rw-r--r-- 1 ubuntu ubuntu  1486 Oct 23 18:16 run-helper.cmd.template
-rwxr-xr-x 1 ubuntu ubuntu  2522 Oct 23 18:16 run-helper.sh.template
-rwxr-xr-x 1 ubuntu ubuntu  2537 Oct 23 18:16 run.sh
-rwxr-xr-x 1 ubuntu ubuntu    65 Oct 23 18:16 safe_sleep.sh
```

We should catch an LxdError, as this is an unrecoverable error and the charm would not be able to finish the reconciliation until the next reboot (which would delete the unhealthy instance).

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->