### PR TITLE
Increase reconcile timeout

### DIFF
--- a/src-docs/event_timer.py.md
+++ b/src-docs/event_timer.py.md
@@ -48,7 +48,7 @@ Construct the timer manager.
 
 ---
 
-<a href="../src/event_timer.py#L99"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L100"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `disable_event_timer`
 
@@ -96,6 +96,7 @@ The timeout is the number of seconds before an event is timed out. If not set or
  
  - <b>`event_name`</b>:  Name of the juju event to schedule. 
  - <b>`interval`</b>:  Number of minutes between emitting each event. 
+ - <b>`timeout`</b>:  Timeout for each event handle in minutes. 
 
 
 

--- a/src-docs/event_timer.py.md
+++ b/src-docs/event_timer.py.md
@@ -48,7 +48,7 @@ Construct the timer manager.
 
 ---
 
-<a href="../src/event_timer.py#L100"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L105"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `disable_event_timer`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -163,7 +163,6 @@ class GithubRunnerCharm(CharmBase):
             path=self.config["path"],  # for detecting changes
             token=self.config["token"],  # for detecting changes
             runner_bin_url=None,
-            runner_image_url=None,
         )
 
         self.proxies: ProxySetting = {}

--- a/src/charm.py
+++ b/src/charm.py
@@ -499,7 +499,9 @@ class GithubRunnerCharm(CharmBase):
         self._refresh_firewall()
         try:
             self._event_timer.ensure_event_timer(
-                "reconcile-runners", self.config["reconcile-interval"]
+                event_name="reconcile-runners",
+                interval=int(self.config["reconcile-interval"]),
+                timeout=int(self.config["reconcile-interval"]) - 1,
             )
         except TimerEnableError as ex:
             logger.exception("Failed to start the event timer")

--- a/src/event_timer.py
+++ b/src/event_timer.py
@@ -74,11 +74,16 @@ class EventTimer:
         Raises:
             TimerEnableError: Timer cannot be started. Events will be not emitted.
         """
+        if timeout is not None:
+            timeout_in_secs = timeout * 60
+        else:
+            timeout_in_secs = interval * 30
+
         context: EventConfig = {
             "event": event_name,
             "interval": interval,
             "random_delay": interval // 4,
-            "timeout": timeout * 60 or (interval * 30),
+            "timeout": timeout_in_secs,
             "unit": self.unit_name,
         }
         self._render_event_template("service", event_name, context)

--- a/src/event_timer.py
+++ b/src/event_timer.py
@@ -69,6 +69,7 @@ class EventTimer:
         Args:
             event_name: Name of the juju event to schedule.
             interval: Number of minutes between emitting each event.
+            timeout: Timeout for each event handle in minutes.
 
         Raises:
             TimerEnableError: Timer cannot be started. Events will be not emitted.
@@ -77,7 +78,7 @@ class EventTimer:
             "event": event_name,
             "interval": interval,
             "random_delay": interval // 4,
-            "timeout": timeout or (interval * 30),
+            "timeout": timeout * 60 or (interval * 30),
             "unit": self.unit_name,
         }
         self._render_event_template("service", event_name, context)


### PR DESCRIPTION
### Overview

Increase reconcile timeout length.

### Rationale

Reconcile event timeout can be longer than the default which was half of the event interval.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->