### PR TITLE
test: add testing workflow yaml

### DIFF
--- a/.github/workflows/workflow_dispatch_ssh_debug.yaml
+++ b/.github/workflows/workflow_dispatch_ssh_debug.yaml
@@ -1,0 +1,17 @@
+name: Workflow Dispatch Tests (ssh-debug/tmate)
+
+on:
+  # Manually dispatched workflow action
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: 'Self hosted gh runner'
+        required: true
+
+jobs:
+  workflow-dispatch-tests:
+    runs-on: [self-hosted, linux, x64, "${{ inputs.runner }}"]
+    steps:
+    - name: Setup tmate session
+      uses: canonical/action-tmate@chore/env_var_change
+      timeout-minutes: 1


### PR DESCRIPTION
Applicable spec: N/A

### Overview

In order to test the tmate action workflow in #193, the workflow must exist in the main branch as per the [documentation](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow#running-a-workflow-using-github-cli)
> To trigger the workflow_dispatch event, your workflow must be in the default branch.

### Rationale

To allow integration testing with ssh-debug integration.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->