### PR TITLE
test: add secondary tokens

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def pytest_addoption(parser: Parser):
     """Add options to pytest parser."""
     parser.addoption("--path", action="store")
     parser.addoption("--token", action="store")
-    # A comma separated GitHub Personal Accesss Tokens, to help reduce rate limiting.
+    # A comma separated GitHub Personal Access Tokens, to help reduce rate limiting.
     parser.addoption("--secondary-tokens", action="store")
     parser.addoption("--charm-file", action="store")
     parser.addoption("--token-alt", action="store")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,11 @@ def pytest_addoption(parser: Parser):
     """Add options to pytest parser."""
     parser.addoption("--path", action="store")
     parser.addoption("--token", action="store")
-    # A comma separated GitHub Personal Access Tokens, to help reduce rate limiting.
-    parser.addoption("--secondary-tokens", action="store")
+    parser.addoption(
+        "--secondary-tokens",
+        action="store",
+        help="A comma separated GitHub Personal Access Tokens, to help reduce rate limiting.",
+    )
     parser.addoption("--charm-file", action="store")
     parser.addoption("--token-alt", action="store")
     parser.addoption("--http-proxy", action="store")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,11 @@ from pytest import Parser
 def pytest_addoption(parser: Parser):
     """Add options to pytest parser."""
     parser.addoption("--path", action="store")
-    parser.addoption("--token", action="store")
     parser.addoption(
-        "--tokens",
+        "--token",
         action="store",
         help=(
-            "A comma separated GitHub Personal Access Token(s). "
+            "An optionally comma separated GitHub Personal Access Token(s). "
             "Add more than one to help reduce rate limiting."
         ),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,14 @@ def pytest_addoption(parser: Parser):
     """Add options to pytest parser."""
     parser.addoption("--path", action="store")
     parser.addoption("--token", action="store")
-    # A comma separated GitHub Personal Access Tokens, to help reduce rate limiting.
-    parser.addoption("--secondary-tokens", action="store")
+    parser.addoption(
+        "--tokens",
+        action="store",
+        help=(
+            "A comma separated GitHub Personal Access Token(s). "
+            "Add more than one to help reduce rate limiting."
+        ),
+    )
     parser.addoption("--charm-file", action="store")
     parser.addoption("--token-alt", action="store")
     parser.addoption("--http-proxy", action="store")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,11 +10,10 @@ from pytest import Parser
 def pytest_addoption(parser: Parser):
     """Add options to pytest parser."""
     parser.addoption("--path", action="store")
-    parser.addoption("--token", action="store")
     parser.addoption(
-        "--secondary-tokens",
+        "--tokens",
         action="store",
-        help="A comma separated GitHub Personal Access Tokens, to help reduce rate limiting.",
+        help="A comma separated GitHub Personal Access Token(s), to help reduce rate limiting.",
     )
     parser.addoption("--charm-file", action="store")
     parser.addoption("--token-alt", action="store")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ def pytest_addoption(parser: Parser):
     """Add options to pytest parser."""
     parser.addoption("--path", action="store")
     parser.addoption("--token", action="store")
+    # A comma separated GitHub Personal Accesss Tokens, to help reduce rate limiting.
+    parser.addoption("--secondary-tokens", action="store")
     parser.addoption("--charm-file", action="store")
     parser.addoption("--token-alt", action="store")
     parser.addoption("--http-proxy", action="store")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,9 +97,7 @@ def token(pytestconfig: pytest.Config) -> str:
     token = pytestconfig.getoption("--token")
     assert token, "Please specify the --token command line option"
     secondary_tokens: str = pytestconfig.getoption("--secondary-tokens", default="")
-    tokens = [
-        token.strip() for token in (secondary_tokens.split(",") if secondary_tokens != "" else [])
-    ]
+    tokens = [token.strip() for token in (secondary_tokens.split(",") if secondary_tokens else [])]
     tokens.append(token)
     random_token = random.choice(tokens)
     return random_token

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,7 +97,7 @@ def token(pytestconfig: pytest.Config) -> str:
     token = pytestconfig.getoption("--token")
     tokens_csv = pytestconfig.getoption("--tokens")
     assert token or tokens_csv, "Please specify the --token or --tokens command line option"
-    tokens = {token.strip() for token in (tokens_csv.split(",") if tokens_csv != "" else [])}
+    tokens = {token.strip() for token in (tokens_csv.split(",") if tokens_csv else [])}
     tokens.add(token)
     random_token = random.choice(list(tokens))
     return random_token

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -95,13 +95,11 @@ def path(pytestconfig: pytest.Config) -> str:
 def token(pytestconfig: pytest.Config) -> str:
     """Configured token setting."""
     token = pytestconfig.getoption("--token")
-    assert token, "Please specify the --token command line option"
-    secondary_tokens: str = pytestconfig.getoption("--secondary-tokens", default="")
-    tokens = [
-        token.strip() for token in (secondary_tokens.split(",") if secondary_tokens != "" else [])
-    ]
-    tokens.append(token)
-    random_token = random.choice(tokens)
+    tokens_csv = pytestconfig.getoption("--tokens")
+    assert token or tokens_csv, "Please specify the --token or --tokens command line option"
+    tokens = {token.strip() for token in (tokens_csv.split(",") if tokens_csv != "" else [])}
+    tokens.add(token)
+    random_token = random.choice(list(tokens))
     return random_token
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,7 +97,9 @@ def token(pytestconfig: pytest.Config) -> str:
     token = pytestconfig.getoption("--token")
     assert token, "Please specify the --token command line option"
     secondary_tokens: str = pytestconfig.getoption("--secondary-tokens", default="")
-    tokens = secondary_tokens.split(",")
+    tokens = [
+        token.strip() for token in (secondary_tokens.split(",") if secondary_tokens != "" else [])
+    ]
     tokens.append(token)
     random_token = random.choice(tokens)
     return random_token

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,7 +97,8 @@ def token(pytestconfig: pytest.Config) -> str:
     token = pytestconfig.getoption("--token")
     assert token, "Please specify the --token command line option"
     secondary_tokens: str = pytestconfig.getoption("--secondary-tokens", default="")
-    tokens = secondary_tokens.split(",").append(token)
+    tokens = secondary_tokens.split(",")
+    tokens.append(token)
     random_token = random.choice(tokens)
     return random_token
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -95,10 +95,8 @@ def path(pytestconfig: pytest.Config) -> str:
 def token(pytestconfig: pytest.Config) -> str:
     """Configured token setting."""
     token = pytestconfig.getoption("--token")
-    tokens_csv = pytestconfig.getoption("--tokens")
-    assert token or tokens_csv, "Please specify the --token or --tokens command line option"
-    tokens = {token.strip() for token in (tokens_csv.split(",") if tokens_csv else [])}
-    tokens.add(token)
+    assert token, "Please specify the --token command line option"
+    tokens = {token.strip() for token in token.split(",")}
     random_token = random.choice(list(tokens))
     return random_token
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,6 +3,7 @@
 
 """Fixtures for github runner charm integration tests."""
 
+import random
 import secrets
 import zipfile
 from pathlib import Path
@@ -95,7 +96,10 @@ def token(pytestconfig: pytest.Config) -> str:
     """Configured token setting."""
     token = pytestconfig.getoption("--token")
     assert token, "Please specify the --token command line option"
-    return token
+    secondary_tokens: str = pytestconfig.getoption("--secondary-tokens", default="")
+    tokens = secondary_tokens.split(",").append(token)
+    random_token = random.choice(tokens)
+    return random_token
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,11 +94,9 @@ def path(pytestconfig: pytest.Config) -> str:
 @pytest.fixture(scope="module")
 def token(pytestconfig: pytest.Config) -> str:
     """Configured token setting."""
-    token = pytestconfig.getoption("--token")
-    assert token, "Please specify the --token command line option"
-    secondary_tokens: str = pytestconfig.getoption("--secondary-tokens", default="")
-    tokens = [token.strip() for token in (secondary_tokens.split(",") if secondary_tokens else [])]
-    tokens.append(token)
+    tokens_csv = pytestconfig.getoption("--tokens")
+    assert tokens_csv, "Please specify the --tokens command line option"
+    tokens = tokens_csv.split(",")
     random_token = random.choice(tokens)
     return random_token
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Adds an option to have secondary tokens (CSV of PATs) to reduce chance of having rate limiting issues.

### Rationale

To reduce test failures due to rate limiting.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->