### PR TITLE
fix: aproxy arm/amd revision fix

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -45,6 +45,9 @@ if not LXD_PROFILE_YAML.exists():
     LXD_PROFILE_YAML = LXD_PROFILE_YAML.parent / "lxd-profile.yml"
 LXDBR_DNSMASQ_LEASES_FILE = Path("/var/snap/lxd/common/lxd/networks/lxdbr0/dnsmasq.leases")
 
+APROXY_ARM_REVISION = 9
+APROXY_AMD_REVISION = 8
+
 
 class Snap(NamedTuple):
     """This class represents a snap installation."""
@@ -151,7 +154,7 @@ class Runner:
             # Wait some initial time for the instance to boot up
             time.sleep(60)
             self._wait_boot_up()
-            self._install_binaries(config.binary_path)
+            self._install_binaries(config.binary_path, config.arch)
             self._configure_runner()
 
             self._register_runner(
@@ -467,7 +470,7 @@ class Runner:
         logger.info("Finished booting up LXD instance for runner: %s", self.config.name)
 
     @retry(tries=10, delay=10, max_delay=120, backoff=2, local_logger=logger)
-    def _install_binaries(self, runner_binary: Path) -> None:
+    def _install_binaries(self, runner_binary: Path, arch: ARCH) -> None:
         """Install runner binary and other binaries.
 
         Args:
@@ -479,7 +482,15 @@ class Runner:
         if self.instance is None:
             raise RunnerError("Runner operation called prior to runner creation.")
 
-        self._snap_install([Snap(name="aproxy", channel="edge", revision=6)])
+        self._snap_install(
+            [
+                Snap(
+                    name="aproxy",
+                    channel="edge",
+                    revision=APROXY_AMD_REVISION if arch == ARCH.X64 else APROXY_ARM_REVISION,
+                )
+            ]
+        )
 
         # The LXD instance is meant to run untrusted workload. Hardcoding the tmp directory should
         # be fine.

--- a/src/runner.py
+++ b/src/runner.py
@@ -487,7 +487,7 @@ class Runner:
                 Snap(
                     name="aproxy",
                     channel="edge",
-                    revision=APROXY_AMD_REVISION if arch == ARCH.X64 else APROXY_ARM_REVISION,
+                    revision=APROXY_ARM_REVISION if arch == ARCH.ARM64 else APROXY_AMD_REVISION,
                 )
             ]
         )


### PR DESCRIPTION
Applicable spec: N/A

### Overview

The revisions of aproxy are separate for each ARM and X84 architectures due to how snap store works.
Separate the two revisions.

Link to successful run: https://github.com/yanksyoon/selfhostedtest/actions/runs/7607632472/job/20717460214

### Rationale

Just tested on ARM deployment, the current revision is fixed to 6, which is broken.
```
unit-github-runner-1: 15:51:47 INFO unit.github-runner/1.juju-log Executing command ['/snap/bin/lxc', 'exec', 'github-runner-1-6c3518b8ba2435e2cba2c6d9', '--', 'snap', 'install', 'aproxy', '--channel=edge', '--revision=6']
unit-github-runner-1: 15:51:48 ERROR unit.github-runner/1.juju-log Unable to install aproxy due to error: cannot install "aproxy": snap "aproxy" supported architectures (amd64)
       are incompatible with this system (arm64)
```

### Juju Events Changes

None.

### Module Changes

`runner.py` now contains revision number constants for different aproxy architectures.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->