### PR TITLE
Use Github token in E2E tests

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -131,7 +131,7 @@ jobs:
             ${{ steps.runner-name.outputs.name }} \
             --base ubuntu@22.04 \
             --config path=${{ secrets.E2E_TESTING_REPO }} \
-            --config token=${{ secrets.E2E_TESTING_TOKEN }} \
+            --config token=${{ secrets.GITHUB_TOKEN }} \
             --config virtual-machines=1 \
             --config denylist=10.0.0.0/8 \
             --config test-mode=insecure

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -227,7 +227,7 @@ jobs:
       - name: Watch github-runner (Workflow Dispatch and Push)
         if: matrix.event.name == 'workflow_dispatch' || matrix.event.name == 'push'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ matrix.event.name == 'workflow_dispatch' && secrets.GITHUB_TOKEN || secrets.E2E_TESTING_TOKEN }}
         run: |
           juju debug-log --replay --tail &
 

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -229,8 +229,6 @@ jobs:
         env:
           GH_TOKEN: ${{ matrix.event.name == 'workflow_dispatch' && secrets.GITHUB_TOKEN || secrets.E2E_TESTING_TOKEN }}
         run: |
-          juju debug-log --replay --tail &
-
           # Base any future branches on the current branch
           REF_SHA=$(gh api \
             -H "Accept: application/vnd.github+json" \
@@ -262,6 +260,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          juju debug-log --replay --tail &
+
           get-workflow-status() {
               # Search recent workflow runs for the one designated by the run-id ref
               output=$(gh run list \

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -224,7 +224,7 @@ jobs:
             exit 1
           fi
 
-      - name: Watch github-runner (Workflow Dispatch and Push)
+      - name: Trigger workflow (Workflow Dispatch and Push)
         if: matrix.event.name == 'workflow_dispatch' || matrix.event.name == 'push'
         env:
           GH_TOKEN: ${{ matrix.event.name == 'workflow_dispatch' && secrets.GITHUB_TOKEN || secrets.E2E_TESTING_TOKEN }}
@@ -257,6 +257,11 @@ jobs:
               -f runner=${{ steps.runner-name.outputs.name }}
           fi
 
+      - name: Watch github-runner (Workflow Dispatch and Push)
+        if: matrix.event.name == 'workflow_dispatch' || matrix.event.name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           get-workflow-status() {
               # Search recent workflow runs for the one designated by the run-id ref
               output=$(gh run list \
@@ -303,7 +308,7 @@ jobs:
             kill $(jobs -p)
           fi
 
-      - name: Watch github-runner (Issues, Schedule)
+      - name: Trigger workflow and watch github-runner (Issues, Schedule)
         if:  matrix.event.name == 'issues' || matrix.event.name == 'schedule'
         env:
           GH_TOKEN: ${{ secrets.E2E_TESTING_TOKEN }}

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -227,6 +227,8 @@ jobs:
       - name: Trigger workflow (Workflow Dispatch and Push)
         if: matrix.event.name == 'workflow_dispatch' || matrix.event.name == 'push'
         env:
+          # push requires E2E_TESTING_TOKEN, because if GITHUB_TOKEN is used, no workflow is triggered for a push.
+          # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
           GH_TOKEN: ${{ matrix.event.name == 'workflow_dispatch' && secrets.GITHUB_TOKEN || secrets.E2E_TESTING_TOKEN }}
         run: |
           # Base any future branches on the current branch

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -201,7 +201,7 @@ jobs:
       - name: Watch github-runner (Pull Request)
         if: matrix.event.name == 'pull_request'
         env:
-          GH_TOKEN: ${{ secrets.E2E_TESTING_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         timeout-minutes: 30
         run: |
           juju debug-log --replay --tail &
@@ -227,7 +227,7 @@ jobs:
       - name: Watch github-runner (Workflow Dispatch and Push)
         if: matrix.event.name == 'workflow_dispatch' || matrix.event.name == 'push'
         env:
-          GH_TOKEN: ${{ secrets.E2E_TESTING_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           juju debug-log --replay --tail &
 
@@ -393,7 +393,7 @@ jobs:
       - name: Clean Up (Workflow Dispatch and Push)
         if: always() && (matrix.event.name == 'workflow_dispatch' || matrix.event.name == 'push')
         env:
-          GH_TOKEN: ${{ secrets.E2E_TESTING_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api \
           --method DELETE \

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -96,6 +96,17 @@ jobs:
       - name: Install GitHub Cli
         run: which gh || sudo apt install gh -y
 
+      - name: Check rate limit
+        env:
+          GH_TOKEN: ${{ (matrix.event.name == 'issues' || matrix.event.name == 'schedule') && secrets.E2E_TESTING_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          # Check rate limit, this check does not count against the primary rate limit:
+          # https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit
+          gh api \
+              --method GET \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" --jq ".resources.core" \
+              /rate_limit
       - name: Create Testing Juju Model
         run: juju add-model testing
 
@@ -227,7 +238,7 @@ jobs:
       - name: Trigger workflow (Workflow Dispatch and Push)
         if: matrix.event.name == 'workflow_dispatch' || matrix.event.name == 'push'
         env:
-          # push requires E2E_TESTING_TOKEN, because if GITHUB_TOKEN is used, no workflow is triggered for a push.
+          # push requires E2E_TESTING_TOKEN, because if GITHUB_TOKEN is used, no workflow is triggered for a push:
           # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
           GH_TOKEN: ${{ matrix.event.name == 'workflow_dispatch' && secrets.GITHUB_TOKEN || secrets.E2E_TESTING_TOKEN }}
         run: |

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -131,7 +131,7 @@ jobs:
             ${{ steps.runner-name.outputs.name }} \
             --base ubuntu@22.04 \
             --config path=${{ secrets.E2E_TESTING_REPO }} \
-            --config token=${{ secrets.GITHUB_TOKEN }} \
+            --config token=${{ secrets.E2E_TESTING_TOKEN }} \
             --config virtual-machines=1 \
             --config denylist=10.0.0.0/8 \
             --config test-mode=insecure

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,28 +1,28 @@
-#name: integration-tests
-#
-#on:
-#  pull_request:
-#
-#jobs:
-#  # test option values defined at test/conftest.py are passed on via repository secret
-#  # INTEGRATION_TEST_ARGS to operator-workflows automatically.
-#  integration-tests-juju2:
-#    name: Integration test with juju 2.9
-#    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-#    secrets: inherit
-#    with:
-#      juju-channel: 2.9/stable
-#      pre-run-script: scripts/pre-integration-test.sh
-#      provider: lxd
-#      test-tox-env: integration-juju2.9
-#      modules: '["test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh"]'
-#  integration-tests-juju3:
-#    name: Integration test with juju 3.1
-#    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-#    secrets: inherit
-#    with:
-#      juju-channel: 3.1/stable
-#      pre-run-script: scripts/pre-integration-test.sh
-#      provider: lxd
-#      test-tox-env: integration-juju3.1
-#      modules: '["test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh"]'
+name: integration-tests
+
+on:
+  pull_request:
+
+jobs:
+  # test option values defined at test/conftest.py are passed on via repository secret
+  # INTEGRATION_TEST_ARGS to operator-workflows automatically.
+  integration-tests-juju2:
+    name: Integration test with juju 2.9
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      juju-channel: 2.9/stable
+      pre-run-script: scripts/pre-integration-test.sh
+      provider: lxd
+      test-tox-env: integration-juju2.9
+      modules: '["test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh"]'
+  integration-tests-juju3:
+    name: Integration test with juju 3.1
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      juju-channel: 3.1/stable
+      pre-run-script: scripts/pre-integration-test.sh
+      provider: lxd
+      test-tox-env: integration-juju3.1
+      modules: '["test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh"]'

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,28 +1,28 @@
-name: integration-tests
-
-on:
-  pull_request:
-
-jobs:
-  # test option values defined at test/conftest.py are passed on via repository secret
-  # INTEGRATION_TEST_ARGS to operator-workflows automatically.
-  integration-tests-juju2:
-    name: Integration test with juju 2.9
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-    secrets: inherit
-    with:
-      juju-channel: 2.9/stable
-      pre-run-script: scripts/pre-integration-test.sh
-      provider: lxd
-      test-tox-env: integration-juju2.9
-      modules: '["test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh"]'
-  integration-tests-juju3:
-    name: Integration test with juju 3.1
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-    secrets: inherit
-    with:
-      juju-channel: 3.1/stable
-      pre-run-script: scripts/pre-integration-test.sh
-      provider: lxd
-      test-tox-env: integration-juju3.1
-      modules: '["test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh"]'
+#name: integration-tests
+#
+#on:
+#  pull_request:
+#
+#jobs:
+#  # test option values defined at test/conftest.py are passed on via repository secret
+#  # INTEGRATION_TEST_ARGS to operator-workflows automatically.
+#  integration-tests-juju2:
+#    name: Integration test with juju 2.9
+#    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+#    secrets: inherit
+#    with:
+#      juju-channel: 2.9/stable
+#      pre-run-script: scripts/pre-integration-test.sh
+#      provider: lxd
+#      test-tox-env: integration-juju2.9
+#      modules: '["test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh"]'
+#  integration-tests-juju3:
+#    name: Integration test with juju 3.1
+#    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+#    secrets: inherit
+#    with:
+#      juju-channel: 3.1/stable
+#      pre-run-script: scripts/pre-integration-test.sh
+#      provider: lxd
+#      test-tox-env: integration-juju3.1
+#      modules: '["test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh"]'

--- a/src-docs/runner.py.md
+++ b/src-docs/runner.py.md
@@ -9,6 +9,10 @@ The `Runner` class stores the information on the runners and manages the lifecyc
 
 The `RunnerManager` class from `runner_manager.py` creates and manages a collection of `Runner` instances. 
 
+**Global Variables**
+---------------
+- **APROXY_ARM_REVISION**
+- **APROXY_AMD_REVISION**
 
 
 ---
@@ -35,7 +39,7 @@ The configuration values for creating a single runner instance.
 ## <kbd>class</kbd> `Runner`
 Single instance of GitHub self-hosted runner. 
 
-<a href="../src/runner.py#L98"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -63,7 +67,7 @@ Construct the runner instance.
 
 ---
 
-<a href="../src/runner.py#L128"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L131"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `create`
 
@@ -87,7 +91,7 @@ Create the runner instance on LXD and register it on GitHub.
 
 ---
 
-<a href="../src/runner.py#L164"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L167"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `remove`
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 """Fixtures for github runner charm integration tests."""
-
+import logging
 import random
 import secrets
 import zipfile
@@ -29,6 +29,8 @@ from tests.integration.helpers import (
     wait_for,
 )
 from tests.status_name import ACTIVE
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
@@ -319,7 +321,9 @@ async def tmate_ssh_server_unit_ip_fixture(
 @pytest.fixture(scope="module")
 def github_client(token: str) -> Github:
     """Returns the github client."""
-    return Github(token)
+    gh = Github(token)
+    rate_limit = gh.get_rate_limit()
+    logger.info("GitHub token rate limit: %s", rate_limit.core)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,8 +30,6 @@ from tests.integration.helpers import (
 )
 from tests.status_name import ACTIVE
 
-logger = logging.getLogger(__name__)
-
 
 @pytest.fixture(scope="module")
 def metadata() -> dict[str, Any]:
@@ -323,7 +321,8 @@ def github_client(token: str) -> Github:
     """Returns the github client."""
     gh = Github(token)
     rate_limit = gh.get_rate_limit()
-    logger.info("GitHub token rate limit: %s", rate_limit.core)
+    logging.info("GitHub token rate limit: %s", rate_limit.core)
+    return gh
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION


### Overview

Use the [GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) in E2E tests wherever possible.

### Rationale

Reduces the effects of the rate limit, as a [different rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-github_token-in-github-actions) applies to this token.


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->