### PR TITLE
Allow root disk as runner-storage

### DIFF
--- a/docs/how-to/configure-runner-storage.md
+++ b/docs/how-to/configure-runner-storage.md
@@ -30,4 +30,3 @@ juju deploy github-runner --constraints="cores=4 mem=6G root-disk=30G virt-type=
 ```
 
 The above example uses `rootfs`, which is using the root disk of the juju machine. Hence the root-disk size was increase to 30G.
-In production environment, a separated storage managed by juju should be used. See [how to manage juju storage](https://juju.is/docs/juju/manage-storage).

--- a/src/charm.py
+++ b/src/charm.py
@@ -232,16 +232,6 @@ class GithubRunnerCharm(CharmBase):
                 logger.info("Cleaned up storage directory")
             raise RunnerError("Failed to configure runner storage") from err
 
-    def _juju_storage_mounted(self) -> bool:
-        """Whether a juju storage is mounted on the runner-storage location.
-
-        Returns:
-            True if a juju storage is mounted on the runner-storage location.
-        """
-        # Use `mount` as Python does not have easy method to get the mount points.
-        stdout, exit_code = execute_command(["mountpoint", str(self.juju_storage_path)], False)
-        return exit_code == 0 and str(self.juju_storage_path) in stdout
-
     @retry(tries=5, delay=15, max_delay=60, backoff=1.5, local_logger=logger)
     def _ensure_runner_storage(self, size: int) -> Path:
         """Ensure the runner storage is setup.
@@ -258,15 +248,7 @@ class GithubRunnerCharm(CharmBase):
                 path = self.ram_pool_path
                 self._create_memory_storage(self.ram_pool_path, size)
             case RunnerStorage.JUJU_STORAGE:
-                logger.info("Verifying juju storage")
                 path = self.juju_storage_path
-                if not self._juju_storage_mounted():
-                    raise ConfigurationError(
-                        (
-                            "Non-root disk storage should be mount on the runner juju storage to "
-                            "be used as the disk for the runners"
-                        )
-                    )
 
         # tmpfs storage is not created if required size is 0.
         if size > 0:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -29,7 +29,6 @@ def mocks(monkeypatch, tmp_path, exec_command):
     monkeypatch.setattr(
         "charm.GithubRunnerCharm.repo_check_systemd_service", Path(tmp_path / "systemd_service")
     )
-    monkeypatch.setattr("charm.GithubRunnerCharm._juju_storage_mounted", lambda self: True)
     monkeypatch.setattr("charm.os", unittest.mock.MagicMock())
     monkeypatch.setattr("charm.shutil", unittest.mock.MagicMock())
     monkeypatch.setattr("charm.shutil.disk_usage", disk_usage_mock(30 * 1024 * 1024 * 1024))


### PR DESCRIPTION


### Overview

The charm no longer warns about using juju machine root disk as runner storage.

### Rationale

Allow juju machine root-disk as the runner-storage.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->