### PR TITLE
Do not check license headers in lib directory

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -24,4 +24,5 @@ header:
     - 'LICENSE'
     - '.pylintrc'
     - '.woke.yaml'
+    - 'lib/**'
   comment: on-failure


### PR DESCRIPTION
Applicable spec: <link> N/A

### Overview

<!-- A high level overview of the change -->
Do not check license headers in lib directory, since those are Juju libs independent from this repository
### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->