### PR TITLE
chore: add build archs

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -18,6 +18,12 @@ bases:
   - build-on:
     - name: "ubuntu"
       channel: "22.04"
+      architectures:
+      - amd64
+      - arm64
     run-on:
     - name: "ubuntu"
       channel: "22.04"
+      architectures:
+      - amd64
+      - arm64


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Adds arch64 to build & run architectures.

### Rationale

To make arm64 github runners available on CharmHub.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->