### PR TITLE
Ensure event timer is active

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Copy github-runner Charm
         run: |
-          cp  github-runner_ubuntu-22.04-amd64-arm64.charm /home/$USER/ github-runner_ubuntu-22.04-amd64-arm64.charm
+          cp  github-runner_ubuntu-22.04-amd64-arm64.charm /home/$USER/github-runner_ubuntu-22.04-amd64-arm64.charm
 
       - name: Deploy github-runner Charm (Pull Request, Workflow Dispatch and Push)
         if: matrix.event.name == 'workflow_dispatch' || matrix.event.name == 'push' || matrix.event.name == 'pull_request'
@@ -200,7 +200,7 @@ jobs:
           git remote add testing https://github.com/${TESTING_REPO}.git
           git push testing ${{ steps.runner-name.outputs.name }}:main
 
-          juju deploy /home/$USER/ github-runner_ubuntu-22.04-amd64-arm64.charm \
+          juju deploy /home/$USER/github-runner_ubuntu-22.04-amd64-arm64.charm \
             ${{ steps.runner-name.outputs.name }} \
             --base ubuntu@22.04 \
             --config path=$TESTING_REPO \

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v4
         id: cache-charm
         with:
-          path: github-runner_ubuntu-22.04-amd64.charm
+          path: github-runner_ubuntu-22.04-amd64-arm64.charm
           key: github-runner-charm-${{ hashFiles('**/*') }}
 
       - name: Setup LXD
@@ -55,8 +55,8 @@ jobs:
       - name: Upload github-runner Charm
         uses: actions/upload-artifact@v4
         with:
-          name: dangerous-test-only-github-runner_ubuntu-22.04-amd64.charm
-          path: github-runner_ubuntu-22.04-amd64.charm
+          name: dangerous-test-only-github-runner_ubuntu-22.04-amd64-arm64.charm
+          path: github-runner_ubuntu-22.04-amd64-arm64.charm
 
   run-id:
     name: Generate Run ID
@@ -122,7 +122,7 @@ jobs:
       - name: Download github-runner Charm
         uses: actions/download-artifact@v4
         with:
-          name: dangerous-test-only-github-runner_ubuntu-22.04-amd64.charm
+          name: dangerous-test-only-github-runner_ubuntu-22.04-amd64-arm64.charm
 
       - name: Enable br_netfilter
         run: sudo modprobe br_netfilter
@@ -133,12 +133,12 @@ jobs:
 
       - name: Copy github-runner Charm
         run: |
-          cp github-runner_ubuntu-22.04-amd64.charm /home/$USER/github-runner_ubuntu-22.04-amd64.charm
+          cp  github-runner_ubuntu-22.04-amd64-arm64.charm /home/$USER/ github-runner_ubuntu-22.04-amd64-arm64.charm
 
       - name: Deploy github-runner Charm (Pull Request, Workflow Dispatch and Push)
         if: matrix.event.name == 'workflow_dispatch' || matrix.event.name == 'push' || matrix.event.name == 'pull_request'
         run: |
-          juju deploy /home/$USER/github-runner_ubuntu-22.04-amd64.charm \
+          juju deploy /home/$USER/github-runner_ubuntu-22.04-amd64-arm64.charm \
             ${{ steps.runner-name.outputs.name }} \
             --base ubuntu@22.04 \
             --config path=${{ secrets.E2E_TESTING_REPO }} \
@@ -200,7 +200,7 @@ jobs:
           git remote add testing https://github.com/${TESTING_REPO}.git
           git push testing ${{ steps.runner-name.outputs.name }}:main
 
-          juju deploy /home/$USER/github-runner_ubuntu-22.04-amd64.charm \
+          juju deploy /home/$USER/ github-runner_ubuntu-22.04-amd64-arm64.charm \
             ${{ steps.runner-name.outputs.name }} \
             --base ubuntu@22.04 \
             --config path=$TESTING_REPO \

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -8,12 +8,11 @@ Charm for creating and managing GitHub self-hosted runner instances.
 **Global Variables**
 ---------------
 - **DEBUG_SSH_INTEGRATION_NAME**
-- **RECONCILE_TIMER_FAILURE_MSG**
 - **RECONCILE_RUNNERS_EVENT**
 
 ---
 
-<a href="../src/charm.py#L70"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L68"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_charm_errors`
 
@@ -39,7 +38,7 @@ Catch common errors in charm.
 
 ---
 
-<a href="../src/charm.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L99"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_action_errors`
 
@@ -68,7 +67,7 @@ Catch common errors in actions.
 ## <kbd>class</kbd> `GithubRunnerCharm`
 Charm for managing GitHub self-hosted runners. 
 
-<a href="../src/charm.py#L144"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -8,11 +8,12 @@ Charm for creating and managing GitHub self-hosted runner instances.
 **Global Variables**
 ---------------
 - **DEBUG_SSH_INTEGRATION_NAME**
+- **RECONCILE_TIMER_FAILURE_MSG**
 - **RECONCILE_RUNNERS_EVENT**
 
 ---
 
-<a href="../src/charm.py#L67"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L69"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_charm_errors`
 
@@ -38,7 +39,7 @@ Catch common errors in charm.
 
 ---
 
-<a href="../src/charm.py#L98"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L100"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_action_errors`
 
@@ -67,7 +68,7 @@ Catch common errors in actions.
 ## <kbd>class</kbd> `GithubRunnerCharm`
 Charm for managing GitHub self-hosted runners. 
 
-<a href="../src/charm.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -8,10 +8,11 @@ Charm for creating and managing GitHub self-hosted runner instances.
 **Global Variables**
 ---------------
 - **DEBUG_SSH_INTEGRATION_NAME**
+- **RECONCILE_RUNNERS_EVENT**
 
 ---
 
-<a href="../src/charm.py#L65"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L67"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_charm_errors`
 
@@ -37,7 +38,7 @@ Catch common errors in charm.
 
 ---
 
-<a href="../src/charm.py#L96"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L98"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_action_errors`
 
@@ -66,7 +67,7 @@ Catch common errors in actions.
 ## <kbd>class</kbd> `GithubRunnerCharm`
 Charm for managing GitHub self-hosted runners. 
 
-<a href="../src/charm.py#L139"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -13,7 +13,7 @@ Charm for creating and managing GitHub self-hosted runner instances.
 
 ---
 
-<a href="../src/charm.py#L69"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L70"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_charm_errors`
 
@@ -39,7 +39,7 @@ Catch common errors in charm.
 
 ---
 
-<a href="../src/charm.py#L100"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_action_errors`
 
@@ -68,7 +68,7 @@ Catch common errors in actions.
 ## <kbd>class</kbd> `GithubRunnerCharm`
 Charm for managing GitHub self-hosted runners. 
 
-<a href="../src/charm.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L144"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/event_timer.py.md
+++ b/src-docs/event_timer.py.md
@@ -30,7 +30,7 @@ Manages the timer to emit juju events at regular intervals.
  
  - <b>`unit_name`</b> (str):  Name of the juju unit to emit events to. 
 
-<a href="../src/event_timer.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L54"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -51,7 +51,7 @@ Construct the timer manager.
 
 ---
 
-<a href="../src/event_timer.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `disable_event_timer`
 
@@ -75,7 +75,7 @@ Disable the systemd timer for the given event.
 
 ---
 
-<a href="../src/event_timer.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L104"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `ensure_event_timer`
 
@@ -109,7 +109,7 @@ The timeout is the number of seconds before an event is timed out. If not set or
 
 ---
 
-<a href="../src/event_timer.py#L75"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L77"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `is_active`
 

--- a/src-docs/event_timer.py.md
+++ b/src-docs/event_timer.py.md
@@ -5,6 +5,9 @@
 # <kbd>module</kbd> `event_timer.py`
 EventTimer for scheduling dispatch of juju event on regular intervals. 
 
+**Global Variables**
+---------------
+- **BIN_SYSTEMCTL**
 
 
 ---
@@ -27,7 +30,7 @@ Manages the timer to emit juju events at regular intervals.
  
  - <b>`unit_name`</b> (str):  Name of the juju unit to emit events to. 
 
-<a href="../src/event_timer.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L44"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -48,7 +51,7 @@ Construct the timer manager.
 
 ---
 
-<a href="../src/event_timer.py#L105"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L104"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `disable_event_timer`
 
@@ -72,7 +75,7 @@ Disable the systemd timer for the given event.
 
 ---
 
-<a href="../src/event_timer.py#L61"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L65"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `ensure_event_timer`
 

--- a/src-docs/event_timer.py.md
+++ b/src-docs/event_timer.py.md
@@ -30,7 +30,7 @@ Manages the timer to emit juju events at regular intervals.
  
  - <b>`unit_name`</b> (str):  Name of the juju unit to emit events to. 
 
-<a href="../src/event_timer.py#L44"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -51,7 +51,7 @@ Construct the timer manager.
 
 ---
 
-<a href="../src/event_timer.py#L104"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L136"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `disable_event_timer`
 
@@ -75,7 +75,7 @@ Disable the systemd timer for the given event.
 
 ---
 
-<a href="../src/event_timer.py#L65"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L97"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `ensure_event_timer`
 
@@ -107,6 +107,35 @@ The timeout is the number of seconds before an event is timed out. If not set or
  
  - <b>`TimerEnableError`</b>:  Timer cannot be started. Events will be not emitted. 
 
+---
+
+<a href="../src/event_timer.py#L75"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `is_active`
+
+```python
+is_active(event_name: str) → bool
+```
+
+Check if the systemd timer is active for the given event. 
+
+
+
+**Args:**
+ 
+ - <b>`event_name`</b>:  Name of the juju event to check. 
+
+
+
+**Returns:**
+ True if the timer is enabled, False otherwise. 
+
+
+
+**Raises:**
+ 
+ - <b>`TimerStatusError`</b>:  Timer status cannot be determined. 
+
 
 ---
 
@@ -121,6 +150,24 @@ Raised when unable to disable a event timer.
 
 ## <kbd>class</kbd> `TimerEnableError`
 Raised when unable to enable a event timer. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `TimerError`
+Generic timer error as base exception. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `TimerStatusError`
+Raised when unable to check status of a event timer. 
 
 
 

--- a/src-docs/event_timer.py.md
+++ b/src-docs/event_timer.py.md
@@ -51,7 +51,7 @@ Construct the timer manager.
 
 ---
 
-<a href="../src/event_timer.py#L144"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L146"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `disable_event_timer`
 

--- a/src-docs/event_timer.py.md
+++ b/src-docs/event_timer.py.md
@@ -51,7 +51,7 @@ Construct the timer manager.
 
 ---
 
-<a href="../src/event_timer.py#L136"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `disable_event_timer`
 
@@ -75,7 +75,7 @@ Disable the systemd timer for the given event.
 
 ---
 
-<a href="../src/event_timer.py#L97"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `ensure_event_timer`
 

--- a/src-docs/event_timer.py.md
+++ b/src-docs/event_timer.py.md
@@ -30,7 +30,7 @@ Manages the timer to emit juju events at regular intervals.
  
  - <b>`unit_name`</b> (str):  Name of the juju unit to emit events to. 
 
-<a href="../src/event_timer.py#L54"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -51,7 +51,7 @@ Construct the timer manager.
 
 ---
 
-<a href="../src/event_timer.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L144"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `disable_event_timer`
 
@@ -75,7 +75,7 @@ Disable the systemd timer for the given event.
 
 ---
 
-<a href="../src/event_timer.py#L104"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L107"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `ensure_event_timer`
 
@@ -109,7 +109,7 @@ The timeout is the number of seconds before an event is timed out. If not set or
 
 ---
 
-<a href="../src/event_timer.py#L77"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L78"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `is_active`
 

--- a/src-docs/utilities.py.md
+++ b/src-docs/utilities.py.md
@@ -94,6 +94,8 @@ Execute a command on a subprocess.
 
 The command is executed with `subprocess.run`, additional arguments can be passed to it as keyword arguments. The following arguments to `subprocess.run` should not be set: `capture_output`, `shell`, `check`. As those arguments are used by this function. 
 
+The output is logged if the log level of the logger is set to debug. 
+
 
 
 **Args:**
@@ -116,7 +118,7 @@ The command is executed with `subprocess.run`, additional arguments can be passe
 
 ---
 
-<a href="../src/utilities.py#L178"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/utilities.py#L180"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `get_env_var`
 
@@ -142,7 +144,7 @@ Looks for all upper-case and all low-case of the `env_var`.
 
 ---
 
-<a href="../src/utilities.py#L192"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/utilities.py#L194"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `set_env_var`
 
@@ -164,7 +166,7 @@ Set the all upper case and all low case of the `env_var`.
 
 ---
 
-<a href="../src/utilities.py#L205"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/utilities.py#L207"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `bytes_with_unit_to_kib`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -680,7 +680,6 @@ class GithubRunnerCharm(CharmBase):
             event: Event of stopping the charm.
         """
         try:
-            self._event_timer.disable_event_timer("update-dependencies")
             self._event_timer.disable_event_timer("reconcile-runners")
         except TimerDisableError as ex:
             logger.exception("Failed to stop the timer")

--- a/src/charm.py
+++ b/src/charm.py
@@ -160,7 +160,8 @@ class GithubRunnerCharm(CharmBase):
         if not self._event_timer.is_active(RECONCILE_RUNNERS_EVENT):
             logger.warning(
                 "Reconciliation event timer is not activated - "
-                "this should only happen after first install"
+                "this should only happen on the first charm execution after a deployment "
+                "on a new machine"
             )
             try:
                 self._set_reconcile_timer()

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,6 +51,8 @@ from runner_manager_type import FlushMode
 from runner_type import GithubOrg, GithubRepo, ProxySetting, VirtualMachineResources
 from utilities import bytes_with_unit_to_kib, execute_command, retry
 
+RECONCILE_TIMER_FAILURE_MSG = "Failed to start the timer for reconciliation event"
+
 RECONCILE_RUNNERS_EVENT = "reconcile-runners"
 
 logger = logging.getLogger(__name__)
@@ -160,7 +162,7 @@ class GithubRunnerCharm(CharmBase):
         try:
             reconcile_timer_is_active = self._event_timer.is_active(RECONCILE_RUNNERS_EVENT)
         except TimerStatusError:
-            logger.exception("Failed to check the timer status")
+            logger.exception("Failed to check the reconciliation event timer status")
         else:
             if not reconcile_timer_is_active:
                 logger.warning(
@@ -171,9 +173,9 @@ class GithubRunnerCharm(CharmBase):
                 try:
                     self._set_reconcile_timer()
                 except TimerEnableError as ex:
-                    logger.exception("Failed to start the event timer")
+                    logger.exception(RECONCILE_TIMER_FAILURE_MSG)
                     self.unit.status = BlockedStatus(
-                        f"Failed to start timer for regular reconciliation checks: {ex}"
+                        f"{RECONCILE_TIMER_FAILURE_MSG}: {ex}"
                     )
                     return
 
@@ -516,9 +518,9 @@ class GithubRunnerCharm(CharmBase):
         try:
             self._set_reconcile_timer()
         except TimerEnableError as ex:
-            logger.exception("Failed to start the event timer")
+            logger.exception(RECONCILE_TIMER_FAILURE_MSG)
             self.unit.status = BlockedStatus(
-                f"Failed to start timer for regular reconciliation checks: {ex}"
+                f"{RECONCILE_TIMER_FAILURE_MSG}: {ex}"
             )
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -158,11 +158,11 @@ class GithubRunnerCharm(CharmBase):
 
         self._event_timer = EventTimer(self.unit.name)
         try:
-            reconcile_evt_timer_is_active = self._event_timer.is_active(RECONCILE_RUNNERS_EVENT)
+            reconcile_timer_is_active = self._event_timer.is_active(RECONCILE_RUNNERS_EVENT)
         except TimerStatusError:
             logger.exception("Failed to check the timer status")
         else:
-            if not reconcile_evt_timer_is_active:
+            if not reconcile_timer_is_active:
                 logger.warning(
                     "Reconciliation event timer is not activated - "
                     "this should only happen on the first charm execution after a deployment "
@@ -173,7 +173,7 @@ class GithubRunnerCharm(CharmBase):
                 except TimerEnableError as ex:
                     logger.exception("Failed to start the event timer")
                     self.unit.status = BlockedStatus(
-                        (f"Failed to start timer for regular reconciliation checks: {ex}")
+                        f"Failed to start timer for regular reconciliation checks: {ex}"
                     )
                     return
 
@@ -518,7 +518,7 @@ class GithubRunnerCharm(CharmBase):
         except TimerEnableError as ex:
             logger.exception("Failed to start the event timer")
             self.unit.status = BlockedStatus(
-                (f"Failed to start timer for regular reconciliation checks: {ex}")
+                f"Failed to start timer for regular reconciliation checks: {ex}"
             )
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -43,7 +43,7 @@ from errors import (
     RunnerError,
     SubprocessError,
 )
-from event_timer import EventTimer, TimerDisableError, TimerStatusError
+from event_timer import EventTimer, TimerStatusError
 from firewall import Firewall, FirewallEntry
 from github_type import GitHubRunnerStatus
 from runner import LXD_PROFILE_YAML
@@ -701,11 +701,7 @@ class GithubRunnerCharm(CharmBase):
         Args:
             event: Event of stopping the charm.
         """
-        try:
-            self._event_timer.disable_event_timer("reconcile-runners")
-        except TimerDisableError as ex:
-            logger.exception("Failed to stop the timer")
-            self.unit.status = BlockedStatus(f"Failed to stop charm event timer: {ex}")
+        self._event_timer.disable_event_timer("reconcile-runners")
 
         runner_manager = self._get_runner_manager()
         runner_manager.flush(FlushMode.FORCE_FLUSH_BUSY)

--- a/src/event_timer.py
+++ b/src/event_timer.py
@@ -10,6 +10,7 @@ from typing import Optional, TypedDict
 import jinja2
 
 from utilities import execute_command
+from utilities import logger as utilities_logger
 
 BIN_SYSTEMCTL = "/usr/bin/systemctl"
 
@@ -93,13 +94,15 @@ class EventTimer:
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
             raise TimerStatusError from ex
 
-        if ret_code != 0:
+        if ret_code == 0:
+            return True
+
+        if utilities_logger.isEnabledFor(logging.DEBUG):
             try:
                 execute_command([BIN_SYSTEMCTL, "list-timers", "--all"], check_exit=False)
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
                 logger.exception("Unable to list systemd timers: %s", ex)
-            return False
-        return True
+        return False
 
     def ensure_event_timer(self, event_name: str, interval: int, timeout: Optional[int] = None):
         """Ensure that a systemd service and timer are registered to dispatch the given event.

--- a/src/event_timer.py
+++ b/src/event_timer.py
@@ -88,11 +88,17 @@ class EventTimer:
             _, ret_code = execute_command(
                 [BIN_SYSTEMCTL, "is-active", f"ghro.{event_name}.timer"], check_exit=False
             )
-            return ret_code == 0
         except subprocess.CalledProcessError as ex:
             raise TimerStatusError from ex
         except subprocess.TimeoutExpired as ex:
             raise TimerStatusError from ex
+
+        if ret_code != 0:
+            execute_command(
+                [BIN_SYSTEMCTL, "list-timers", f"--all"], check_exit=False
+            )
+            return False
+        return True
 
     def ensure_event_timer(self, event_name: str, interval: int, timeout: Optional[int] = None):
         """Ensure that a systemd service and timer are registered to dispatch the given event.

--- a/src/event_timer.py
+++ b/src/event_timer.py
@@ -134,12 +134,14 @@ class EventTimer:
         }
         self._render_event_template("service", event_name, context)
         self._render_event_template("timer", event_name, context)
+
+        systemd_timer = f"ghro.{event_name}.timer"
         try:
             execute_command([BIN_SYSTEMCTL, "daemon-reload"])
-            execute_command([BIN_SYSTEMCTL, "enable", f"ghro.{event_name}.timer"])
-            execute_command([BIN_SYSTEMCTL, "start", f"ghro.{event_name}.timer"])
+            execute_command([BIN_SYSTEMCTL, "enable", systemd_timer])
+            execute_command([BIN_SYSTEMCTL, "start", systemd_timer])
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
-            raise TimerEnableError from ex
+            raise TimerEnableError(f"Unable to enable systemd timer {systemd_timer}") from ex
 
     def disable_event_timer(self, event_name: str):
         """Disable the systemd timer for the given event.

--- a/src/event_timer.py
+++ b/src/event_timer.py
@@ -152,11 +152,10 @@ class EventTimer:
         Raises:
             TimerDisableError: Timer cannot be stopped. Events will be emitted continuously.
         """
+        systemd_timer = f"ghro.{event_name}.timer"
         try:
             # Don't check for errors in case the timer wasn't registered.
-            execute_command([BIN_SYSTEMCTL, "stop", f"ghro.{event_name}.timer"], check_exit=False)
-            execute_command(
-                [BIN_SYSTEMCTL, "disable", f"ghro.{event_name}.timer"], check_exit=False
-            )
+            execute_command([BIN_SYSTEMCTL, "stop", systemd_timer], check_exit=False)
+            execute_command([BIN_SYSTEMCTL, "disable", systemd_timer], check_exit=False)
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
-            raise TimerDisableError from ex
+            raise TimerDisableError(f"Unable to disable systemd timer {systemd_timer}") from ex

--- a/src/event_timer.py
+++ b/src/event_timer.py
@@ -7,19 +7,27 @@ import subprocess  # nosec B404
 from pathlib import Path
 from typing import Optional, TypedDict
 
-from jinja2 import Environment, FileSystemLoader
+import jinja2
 
 from utilities import execute_command
 
 BIN_SYSTEMCTL = "/usr/bin/systemctl"
 
 
-class TimerEnableError(Exception):
+class TimerError(Exception):
+    """Generic timer error as base exception."""
+
+
+class TimerEnableError(TimerError):
     """Raised when unable to enable a event timer."""
 
 
-class TimerDisableError(Exception):
+class TimerDisableError(TimerError):
     """Raised when unable to disable a event timer."""
+
+
+class TimerStatusError(TimerError):
+    """Raised when unable to check status of a event timer."""
 
 
 class EventConfig(TypedDict):
@@ -48,7 +56,9 @@ class EventTimer:
             unit_name: Name of the juju unit to emit events to.
         """
         self.unit_name = unit_name
-        self._jinja = Environment(loader=FileSystemLoader("templates"), autoescape=True)
+        self._jinja = jinja2.Environment(
+            loader=jinja2.FileSystemLoader("templates"), autoescape=True
+        )
 
     def _render_event_template(self, template_type: str, event_name: str, context: EventConfig):
         """Write event configuration files to systemd path.
@@ -61,6 +71,28 @@ class EventTimer:
         template = self._jinja.get_template(f"dispatch-event.{template_type}.j2")
         dest = self._systemd_path / f"ghro.{event_name}.{template_type}"
         dest.write_text(template.render(context))
+
+    def is_active(self, event_name: str) -> bool:
+        """Check if the systemd timer is active for the given event.
+
+        Args:
+            event_name: Name of the juju event to check.
+
+        Returns:
+            True if the timer is enabled, False otherwise.
+
+        Raises:
+            TimerStatusError: Timer status cannot be determined.
+        """
+        try:
+            _, ret_code = execute_command(
+                [BIN_SYSTEMCTL, "is-active", f"ghro.{event_name}.timer"], check_exit=False
+            )
+            return ret_code == 0
+        except subprocess.CalledProcessError as ex:
+            raise TimerStatusError from ex
+        except subprocess.TimeoutExpired as ex:
+            raise TimerStatusError from ex
 
     def ensure_event_timer(self, event_name: str, interval: int, timeout: Optional[int] = None):
         """Ensure that a systemd service and timer are registered to dispatch the given event.
@@ -117,6 +149,6 @@ class EventTimer:
                 [BIN_SYSTEMCTL, "disable", f"ghro.{event_name}.timer"], check_exit=False
             )
         except subprocess.CalledProcessError as ex:
-            raise TimerEnableError from ex
+            raise TimerDisableError from ex
         except subprocess.TimeoutExpired as ex:
-            raise TimerEnableError from ex
+            raise TimerDisableError from ex

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -143,6 +143,8 @@ def execute_command(cmd: Sequence[str], check_exit: bool = True, **kwargs) -> tu
     keyword arguments. The following arguments to `subprocess.run` should not be set:
     `capture_output`, `shell`, `check`. As those arguments are used by this function.
 
+    The output is logged if the log level of the logger is set to debug.
+
     Args:
         cmd: Command in a list.
         check_exit: Whether to check for non-zero exit code and raise exceptions.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -38,6 +38,8 @@ def mocks(monkeypatch, tmp_path, exec_command):
         "charm_state.json.dumps", unittest.mock.MagicMock(return_value="{'fake':'json'}")
     )
     monkeypatch.setattr("charm_state.CHARM_STATE_PATH", Path(tmp_path / "charm_state.json"))
+    monkeypatch.setattr("event_timer.jinja2", unittest.mock.MagicMock())
+    monkeypatch.setattr("event_timer.execute_command", exec_command)
     monkeypatch.setattr(
         "firewall.Firewall.get_host_ip", unittest.mock.MagicMock(return_value="10.0.0.1")
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,6 +7,7 @@ import unittest
 import urllib.error
 from unittest.mock import MagicMock, call, patch
 
+import pytest
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
 
@@ -252,7 +253,7 @@ class TestCharm(unittest.TestCase):
         assert:
             1. ensure_event_timer is not called.
             2. ensure_event_timer is called.
-            3. Charm is in blocked state.
+            3. Charm throws error.
         """
         rm.return_value = mock_rm = MagicMock()
         mock_rm.get_latest_runner_bin_url = mock_get_latest_runner_bin_url
@@ -280,10 +281,8 @@ class TestCharm(unittest.TestCase):
 
         # 3. ensure_event_timer throws error.
         event_timer_mock.ensure_event_timer.side_effect = TimerEnableError("mock error")
-        harness.charm.on.update_status.emit()
-        assert harness.charm.unit.status == BlockedStatus(
-            "Failed to start the timer for reconciliation event: mock error"
-        )
+        with pytest.raises(TimerEnableError):
+            harness.charm.on.update_status.emit()
 
     @patch("charm.RunnerManager")
     @patch("pathlib.Path.mkdir")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -19,6 +19,7 @@ from errors import (
     RunnerError,
     SubprocessError,
 )
+from event_timer import EventTimer, TimerEnableError
 from firewall import FirewallEntry
 from github_type import GitHubRunnerStatus
 from runner_manager import RunnerInfo, RunnerManagerConfig
@@ -236,6 +237,53 @@ class TestCharm(unittest.TestCase):
             5, VirtualMachineResources(cpu=4, memory="7GiB", disk="6GiB")
         )
         mock_rm.reset_mock()
+
+    @patch("charm.RunnerManager")
+    @patch("pathlib.Path.mkdir")
+    @patch("pathlib.Path.write_text")
+    @patch("subprocess.run")
+    def test_on_update_status(self, run, wt, mkdir, rm):
+        """
+        arrange: reconciliation event timer mocked to be
+          1. active
+          2. inactive
+          3. inactive with error thrown for ensure_event_timer
+        act: Emit update_status
+        assert:
+            1. ensure_event_timer is not called.
+            2. ensure_event_timer is called.
+            3. Charm is in blocked state.
+        """
+        rm.return_value = mock_rm = MagicMock()
+        mock_rm.get_latest_runner_bin_url = mock_get_latest_runner_bin_url
+        mock_rm.download_latest_runner_image = mock_download_latest_runner_image
+
+        harness = Harness(GithubRunnerCharm)
+
+        harness.update_config({"path": "mockorg/repo", "token": "mocktoken"})
+        harness.begin()
+
+        event_timer_mock = MagicMock(spec=EventTimer)
+        harness.charm._event_timer = event_timer_mock
+        event_timer_mock.is_active.return_value = True
+
+        # 1. event timer is active
+        harness.charm.on.update_status.emit()
+        assert event_timer_mock.ensure_event_timer.call_count == 0
+        assert not isinstance(harness.charm.unit.status, BlockedStatus)
+
+        # 2. event timer is not active
+        event_timer_mock.is_active.return_value = False
+        harness.charm.on.update_status.emit()
+        event_timer_mock.ensure_event_timer.assert_called_once()
+        assert not isinstance(harness.charm.unit.status, BlockedStatus)
+
+        # 3. ensure_event_timer throws error.
+        event_timer_mock.ensure_event_timer.side_effect = TimerEnableError("mock error")
+        harness.charm.on.update_status.emit()
+        assert harness.charm.unit.status == BlockedStatus(
+            "Failed to start the timer for reconciliation event: mock error"
+        )
 
     @patch("charm.RunnerManager")
     @patch("pathlib.Path.mkdir")

--- a/tests/unit/test_event_timer.py
+++ b/tests/unit/test_event_timer.py
@@ -20,9 +20,11 @@ def test_is_active_false(exec_command):
     """
     arrange: create an EventTimer object and exec command is mocked to return non-zero exit code
     act: call is_active
-    assert: return False
+    assert: return False and list-timers is called
     """
     exec_command.return_value = ("", 1)
 
     evt = EventTimer(secrets.token_hex(16))
     assert not evt.is_active(secrets.token_hex(16))
+    assert exec_command.call_count == 2
+    assert "list-timers" in exec_command.call_args_list[1][0][0]

--- a/tests/unit/test_event_timer.py
+++ b/tests/unit/test_event_timer.py
@@ -12,8 +12,8 @@ def test_is_active_true():
     act: call is_active
     assert: return True
     """
-    evt = EventTimer(secrets.token_hex(16))
-    assert evt.is_active(secrets.token_hex(16))
+    event = EventTimer(unit_name=secrets.token_hex(16))
+    assert event.is_active(event_name=secrets.token_hex(16))
 
 
 def test_is_active_false(exec_command):
@@ -24,8 +24,8 @@ def test_is_active_false(exec_command):
     """
     exec_command.return_value = ("", 1)
 
-    evt = EventTimer(secrets.token_hex(16))
-    assert not evt.is_active(secrets.token_hex(16))
+    event = EventTimer(unit_name=secrets.token_hex(16))
+    assert not event.is_active(event_name=secrets.token_hex(16))
 
 
 def test_is_active_false_list_timers(exec_command, caplog):
@@ -38,7 +38,7 @@ def test_is_active_false_list_timers(exec_command, caplog):
     exec_command.return_value = ("", 1)
     caplog.set_level(logging.DEBUG)
 
-    evt = EventTimer(secrets.token_hex(16))
-    assert not evt.is_active(secrets.token_hex(16))
+    event = EventTimer(unit_name=secrets.token_hex(16))
+    assert not event.is_active(event_name=secrets.token_hex(16))
     assert exec_command.call_count == 2
     assert "list-timers" in exec_command.call_args_list[1][0][0]

--- a/tests/unit/test_event_timer.py
+++ b/tests/unit/test_event_timer.py
@@ -1,6 +1,6 @@
 #  Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
-
+import logging
 import secrets
 
 from event_timer import EventTimer
@@ -8,7 +8,7 @@ from event_timer import EventTimer
 
 def test_is_active_true():
     """
-    arrange: create an EventTimer object and exec command is mocked to return zero exit code
+    arrange: create an EventTimer object and mock exec command to return zero exit code
     act: call is_active
     assert: return True
     """
@@ -18,11 +18,25 @@ def test_is_active_true():
 
 def test_is_active_false(exec_command):
     """
-    arrange: create an EventTimer object and exec command is mocked to return non-zero exit code
+    arrange: create an EventTimer object and mock exec command to return non-zero exit code
     act: call is_active
-    assert: return False and list-timers is called
+    assert: return False
     """
     exec_command.return_value = ("", 1)
+
+    evt = EventTimer(secrets.token_hex(16))
+    assert not evt.is_active(secrets.token_hex(16))
+
+
+def test_is_active_false_list_timers(exec_command, caplog):
+    """
+    arrange: create an EventTimer object and mock exec command to return non-zero exit code
+     and set log level to debug
+    act: call is_active
+    assert: list-timers is called
+    """
+    exec_command.return_value = ("", 1)
+    caplog.set_level(logging.DEBUG)
 
     evt = EventTimer(secrets.token_hex(16))
     assert not evt.is_active(secrets.token_hex(16))

--- a/tests/unit/test_event_timer.py
+++ b/tests/unit/test_event_timer.py
@@ -1,0 +1,28 @@
+#  Copyright 2024 Canonical Ltd.
+#  See LICENSE file for licensing details.
+
+import secrets
+
+from event_timer import EventTimer
+
+
+def test_is_active_true():
+    """
+    arrange: create an EventTimer object and exec command is mocked to return zero exit code
+    act: call is_active
+    assert: return True
+    """
+    evt = EventTimer(secrets.token_hex(16))
+    assert evt.is_active(secrets.token_hex(16))
+
+
+def test_is_active_false(exec_command):
+    """
+    arrange: create an EventTimer object and exec command is mocked to return non-zero exit code
+    act: call is_active
+    assert: return False
+    """
+    exec_command.return_value = ("", 1)
+
+    evt = EventTimer(secrets.token_hex(16))
+    assert not evt.is_active(secrets.token_hex(16))


### PR DESCRIPTION
### Overview

Ensure that the event timer is active on update_status. Add a log if the timer is not active.

### Rationale

We found on one deployment that the event timer was not active / could not be reactivated, resulting in only update status being run and no reconciliation.

### Juju Events Changes
The `update_status` hook now checks for the timer. There is a major refactoring going on in https://github.com/canonical/github-runner-operator/pull/199, the location of the check may be adjusted.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->