### PR TITLE
Use previous token to flush runners

### DIFF
--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -69,6 +69,9 @@ The charm requires a GitHub personal access token for the [`token` configuration
 
 The token is also passed to [repo-policy-compliance](https://github.com/canonical/repo-policy-compliance) to access GitHub API for the service.
 
+Note that the GitHub API uses a [rate-limiting mechanism](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28). When this is reached, the charm may not be able to perform the necessary operations and may go into
+BlockedStatus. The charm will automatically recover from this state once the rate limit is reset, but using a different token with a higher rate limit may be a better solution depending on your deployment requirements.
+
 ## GitHub repository setting check
 
 The [repo-policy-compliance](https://github.com/canonical/repo-policy-compliance) is a [Flask application](https://flask.palletsprojects.com/) hosted on [Gunicorn](https://gunicorn.org/) that provides a RESTful HTTP API to check the settings of GitHub repositories. This ensures the GitHub repository settings do not allow the execution of code not reviewed by maintainers on the self-hosted runners.

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -12,7 +12,7 @@ Charm for creating and managing GitHub self-hosted runner instances.
 
 ---
 
-<a href="../src/charm.py#L68"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L69"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_charm_errors`
 
@@ -38,7 +38,7 @@ Catch common errors in charm.
 
 ---
 
-<a href="../src/charm.py#L99"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_action_errors`
 
@@ -67,7 +67,7 @@ Catch common errors in actions.
 ## <kbd>class</kbd> `GithubRunnerCharm`
 Charm for managing GitHub self-hosted runners. 
 
-<a href="../src/charm.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L146"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/errors.py.md
+++ b/src-docs/errors.py.md
@@ -54,6 +54,15 @@ Represents an error when the shared filesystem could not be retrieved.
 
 ---
 
+## <kbd>class</kbd> `GithubApiError`
+Represents an error when the GitHub API returns an error. 
+
+
+
+
+
+---
+
 ## <kbd>class</kbd> `GithubClientError`
 Base class for all github client errors. 
 
@@ -300,6 +309,15 @@ Construct the subprocess error.
  - <b>`return_code`</b>:  Return code of the subprocess. 
  - <b>`stdout`</b>:  Content of stdout of the subprocess. 
  - <b>`stderr`</b>:  Content of stderr of the subprocess. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `TokenError`
+Represents an error when the token is invalid. 
 
 
 

--- a/src-docs/errors.py.md
+++ b/src-docs/errors.py.md
@@ -317,7 +317,7 @@ Construct the subprocess error.
 ---
 
 ## <kbd>class</kbd> `TokenError`
-Represents an error when the token is invalid. 
+Represents an error when the token is invalid or has not enough permissions. 
 
 
 

--- a/src-docs/github_client.py.md
+++ b/src-docs/github_client.py.md
@@ -8,13 +8,25 @@ GitHub API client.
 Migrate to PyGithub in the future. PyGithub is still lacking some API such as remove token for runner. 
 
 
+---
+
+<a href="../src/github_client.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `catch_http_errors`
+
+```python
+catch_http_errors(func)
+```
+
+Catch HTTP errors and raise custom exceptions. 
+
 
 ---
 
 ## <kbd>class</kbd> `GithubClient`
 GitHub API client. 
 
-<a href="../src/github_client.py#L34"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -36,7 +48,7 @@ Instantiate the GiHub API client.
 
 ---
 
-<a href="../src/github_client.py#L150"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L169"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `delete_runner`
 
@@ -55,7 +67,7 @@ Delete the self-hosted runner from GitHub.
 
 ---
 
-<a href="../src/github_client.py#L170"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_job_info`
 
@@ -84,7 +96,7 @@ Get information about a job for a specific workflow run.
 
 ---
 
-<a href="../src/github_client.py#L44"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L59"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_runner_applications`
 
@@ -107,7 +119,7 @@ Get list of runner applications available for download.
 
 ---
 
-<a href="../src/github_client.py#L63"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L79"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_runner_github_info`
 
@@ -132,7 +144,7 @@ Get runner information on GitHub under a repo or org.
 
 ---
 
-<a href="../src/github_client.py#L128"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L146"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_runner_registration_token`
 
@@ -155,7 +167,7 @@ Get token from GitHub used for registering runners.
 
 ---
 
-<a href="../src/github_client.py#L110"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L127"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_runner_remove_token`
 

--- a/src-docs/github_client.py.md
+++ b/src-docs/github_client.py.md
@@ -26,7 +26,7 @@ Catch HTTP errors and raise custom exceptions.
 ## <kbd>class</kbd> `GithubClient`
 GitHub API client. 
 
-<a href="../src/github_client.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L53"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -48,7 +48,7 @@ Instantiate the GiHub API client.
 
 ---
 
-<a href="../src/github_client.py#L169"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L173"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `delete_runner`
 
@@ -67,7 +67,7 @@ Delete the self-hosted runner from GitHub.
 
 ---
 
-<a href="../src/github_client.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L194"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_job_info`
 
@@ -96,7 +96,7 @@ Get information about a job for a specific workflow run.
 
 ---
 
-<a href="../src/github_client.py#L59"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L63"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_runner_applications`
 
@@ -119,7 +119,7 @@ Get list of runner applications available for download.
 
 ---
 
-<a href="../src/github_client.py#L79"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L83"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_runner_github_info`
 
@@ -144,7 +144,7 @@ Get runner information on GitHub under a repo or org.
 
 ---
 
-<a href="../src/github_client.py#L146"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L150"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_runner_registration_token`
 
@@ -167,7 +167,7 @@ Get token from GitHub used for registering runners.
 
 ---
 
-<a href="../src/github_client.py#L127"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/github_client.py#L131"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_runner_remove_token`
 

--- a/src-docs/runner.py.md
+++ b/src-docs/runner.py.md
@@ -96,7 +96,7 @@ Create the runner instance on LXD and register it on GitHub.
 ### <kbd>function</kbd> `remove`
 
 ```python
-remove(remove_token: str) → None
+remove(remove_token: Optional[str]) → None
 ```
 
 Remove this runner instance from LXD and GitHub. 

--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -46,7 +46,7 @@ Construct RunnerManager object for creating and managing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L721"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L726"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `build_runner_image`
 
@@ -172,7 +172,7 @@ Bring runners in line with target.
 
 ---
 
-<a href="../src/runner_manager.py#L731"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L736"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `schedule_build_runner_image`
 

--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -46,7 +46,7 @@ Construct RunnerManager object for creating and managing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L714"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L718"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `build_runner_image`
 
@@ -172,7 +172,7 @@ Bring runners in line with target.
 
 ---
 
-<a href="../src/runner_manager.py#L724"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L728"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `schedule_build_runner_image`
 

--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -46,7 +46,7 @@ Construct RunnerManager object for creating and managing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L718"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L721"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `build_runner_image`
 
@@ -172,7 +172,7 @@ Bring runners in line with target.
 
 ---
 
-<a href="../src/runner_manager.py#L728"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L731"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `schedule_build_runner_image`
 

--- a/src-docs/runner_manager_type.py.md
+++ b/src-docs/runner_manager_type.py.md
@@ -18,8 +18,9 @@ Strategy for flushing runners.
  
  - <b>`FLUSH_IDLE`</b>:  Flush only idle runners. 
  - <b>`FLUSH_IDLE_WAIT_REPO_CHECK`</b>:  Flush only idle runners, then wait until repo-policy-check is  completed for the busy runners. 
- - <b>`FORCE_FLUSH_BUSY`</b>:  Force flush busy runners. 
- - <b>`FORCE_FLUSH_BUSY_WAIT_REPO_CHECK`</b>:  Wait until the repo-policy-check is completed before  force flush of busy runners. 
+ - <b>`FLUSH_BUSY`</b>:  Flush busy runners. 
+ - <b>`FLUSH_BUSY_WAIT_REPO_CHECK`</b>:  Wait until the repo-policy-check is completed before  flush of busy runners. 
+ - <b>`FORCE_FLUSH_WAIT_REPO_CHECK`</b>:  Force flush the runners (remove lxd instances even on  gh api issues, like invalid token).  Wait until repo-policy-check is completed before force flush of busy runners. 
 
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -496,7 +496,7 @@ class GithubRunnerCharm(CharmBase):
         if not runner_manager:
             return
 
-        runner_manager.flush(FlushMode.FORCE_FLUSH_BUSY_WAIT_REPO_CHECK)
+        runner_manager.flush(FlushMode.FLUSH_BUSY_WAIT_REPO_CHECK)
         self._reconcile_runners(runner_manager)
 
     @catch_charm_errors
@@ -523,7 +523,8 @@ class GithubRunnerCharm(CharmBase):
             prev_runner_manager = self._get_runner_manager(**prev_config_for_flush)
             if prev_runner_manager:
                 self.unit.status = MaintenanceStatus("Removing runners due to config change")
-                prev_runner_manager.flush(FlushMode.FORCE_FLUSH_BUSY_WAIT_REPO_CHECK)
+                # it may be the case that the prev token has expired, so we need to use force flush
+                prev_runner_manager.flush(FlushMode.FORCE_FLUSH_WAIT_REPO_CHECK)
 
         self._refresh_firewall()
 
@@ -680,7 +681,7 @@ class GithubRunnerCharm(CharmBase):
         """
         runner_manager = self._get_runner_manager()
 
-        runner_manager.flush(FlushMode.FORCE_FLUSH_BUSY_WAIT_REPO_CHECK)
+        runner_manager.flush(FlushMode.FLUSH_BUSY_WAIT_REPO_CHECK)
         delta = self._reconcile_runners(runner_manager)
 
         self._on_check_runners_action(event)
@@ -715,7 +716,7 @@ class GithubRunnerCharm(CharmBase):
         self._event_timer.disable_event_timer("reconcile-runners")
 
         runner_manager = self._get_runner_manager()
-        runner_manager.flush(FlushMode.FORCE_FLUSH_BUSY)
+        runner_manager.flush(FlushMode.FLUSH_BUSY)
 
     def _reconcile_runners(self, runner_manager: RunnerManager) -> Dict[str, Any]:
         """Reconcile the current runners state and intended runner state.

--- a/src/errors.py
+++ b/src/errors.py
@@ -150,6 +150,14 @@ class GithubClientError(Exception):
     """Base class for all github client errors."""
 
 
+class GithubApiError(GithubClientError):
+    """Represents an error when the GitHub API returns an error."""
+
+
+class TokenError(GithubClientError):
+    """Represents an error when the token is invalid."""
+
+
 class JobNotFoundError(GithubClientError):
     """Represents an error when the job could not be found on GitHub."""
 

--- a/src/errors.py
+++ b/src/errors.py
@@ -155,7 +155,7 @@ class GithubApiError(GithubClientError):
 
 
 class TokenError(GithubClientError):
-    """Represents an error when the token is invalid."""
+    """Represents an error when the token is invalid or has not enough permissions."""
 
 
 class JobNotFoundError(GithubClientError):

--- a/src/github_client.py
+++ b/src/github_client.py
@@ -37,7 +37,11 @@ def catch_http_errors(func):
             return func(*args, **kwargs)
         except HTTPError as exc:
             if exc.code in (401, 403):
-                raise errors.TokenError from exc
+                if exc.code == 401:
+                    msg = "Invalid token."
+                else:
+                    msg = "Provided token has not enough permissions."
+                raise errors.TokenError(msg) from exc
             raise errors.GithubApiError from exc
 
     return wrapper

--- a/src/github_client.py
+++ b/src/github_client.py
@@ -40,7 +40,7 @@ def catch_http_errors(func):
                 if exc.code == 401:
                     msg = "Invalid token."
                 else:
-                    msg = "Provided token has not enough permissions."
+                    msg = "Provided token has not enough permissions or has reached rate-limit."
                 raise errors.TokenError(msg) from exc
             raise errors.GithubApiError from exc
 

--- a/src/github_client.py
+++ b/src/github_client.py
@@ -6,7 +6,7 @@
 Migrate to PyGithub in the future. PyGithub is still lacking some API such as
 remove token for runner.
 """
-
+import functools
 import logging
 from datetime import datetime
 from urllib.error import HTTPError
@@ -28,6 +28,21 @@ from runner_type import GithubOrg, GithubPath, GithubRepo
 logger = logging.getLogger(__name__)
 
 
+def catch_http_errors(func):
+    """Catch HTTP errors and raise custom exceptions."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except HTTPError as exc:
+            if exc.code in (401, 403):
+                raise errors.TokenError from exc
+            raise errors.GithubApiError from exc
+
+    return wrapper
+
+
 class GithubClient:
     """GitHub API client."""
 
@@ -41,6 +56,7 @@ class GithubClient:
         self._token = token
         self._client = GhApi(token=self._token)
 
+    @catch_http_errors
     def get_runner_applications(self, path: GithubPath) -> RunnerApplicationList:
         """Get list of runner applications available for download.
 
@@ -60,6 +76,7 @@ class GithubClient:
 
         return runner_bins
 
+    @catch_http_errors
     def get_runner_github_info(self, path: GithubPath) -> list[SelfHostedRunner]:
         """Get runner information on GitHub under a repo or org.
 
@@ -107,6 +124,7 @@ class GithubClient:
             ]
         return remote_runners_list
 
+    @catch_http_errors
     def get_runner_remove_token(self, path: GithubPath) -> str:
         """Get token from GitHub used for removing runners.
 
@@ -125,6 +143,7 @@ class GithubClient:
 
         return token["token"]
 
+    @catch_http_errors
     def get_runner_registration_token(self, path: GithubPath) -> str:
         """Get token from GitHub used for registering runners.
 
@@ -147,6 +166,7 @@ class GithubClient:
 
         return token["token"]
 
+    @catch_http_errors
     def delete_runner(self, path: GithubPath, runner_id: int) -> None:
         """Delete the self-hosted runner from GitHub.
 
@@ -208,6 +228,8 @@ class GithubClient:
                         )
 
         except HTTPError as exc:
+            if exc.code in (401, 403):
+                raise errors.TokenError from exc
             raise errors.JobNotFoundError(
                 f"Could not find job for runner {runner_name}. "
                 f"Could not list jobs for workflow run {workflow_run_id}"

--- a/src/runner.py
+++ b/src/runner.py
@@ -166,7 +166,7 @@ class Runner:
         except (RunnerError, LxdError) as err:
             raise RunnerCreateError(f"Unable to create runner {self.config.name}") from err
 
-    def remove(self, remove_token: str) -> None:
+    def remove(self, remove_token: Optional[str]) -> None:
         """Remove this runner instance from LXD and GitHub.
 
         Args:
@@ -179,18 +179,20 @@ class Runner:
 
         if self.instance:
             logger.info("Executing command to removal of runner and clean up...")
-            self.instance.execute(
-                [
-                    "/usr/bin/sudo",
-                    "-u",
-                    "ubuntu",
-                    str(self.config_script),
-                    "remove",
-                    "--token",
-                    remove_token,
-                ],
-                hide_cmd=True,
-            )
+
+            if remove_token:
+                self.instance.execute(
+                    [
+                        "/usr/bin/sudo",
+                        "-u",
+                        "ubuntu",
+                        str(self.config_script),
+                        "remove",
+                        "--token",
+                        remove_token,
+                    ],
+                    hide_cmd=True,
+                )
 
             if self.instance.status == "Running":
                 logger.info("Removing LXD instance of runner: %s", self.config.name)

--- a/src/runner.py
+++ b/src/runner.py
@@ -19,7 +19,6 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, NamedTuple, Optional, Sequence
-from urllib.error import HTTPError
 
 import yaml
 
@@ -27,6 +26,7 @@ import shared_fs
 from charm_state import ARCH, SSHDebugConnection
 from errors import (
     CreateSharedFilesystemError,
+    GithubClientError,
     LxdError,
     RunnerAproxyError,
     RunnerCreateError,
@@ -232,7 +232,7 @@ class Runner:
         )
         try:
             self._clients.github.delete_runner(self.config.path, self.status.runner_id)
-        except HTTPError:
+        except GithubClientError:
             logger.exception("Unable the remove runner on GitHub: %s", self.config.name)
             # This can occur when attempting to remove a busy runner.
             # The caller should retry later, after GitHub mark the runner as offline.

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -587,6 +587,7 @@ class RunnerManager:
         if mode in (
             FlushMode.FLUSH_IDLE_WAIT_REPO_CHECK,
             FlushMode.FLUSH_BUSY_WAIT_REPO_CHECK,
+            FlushMode.FORCE_FLUSH_WAIT_REPO_CHECK,
         ):
             for _ in range(5):
                 if not self._runners_in_pre_job():
@@ -600,7 +601,11 @@ class RunnerManager:
                     )
                 )
 
-        if mode in {FlushMode.FLUSH_BUSY_WAIT_REPO_CHECK, FlushMode.FLUSH_BUSY}:
+        if mode in {
+            FlushMode.FLUSH_BUSY_WAIT_REPO_CHECK,
+            FlushMode.FLUSH_BUSY,
+            FlushMode.FORCE_FLUSH_WAIT_REPO_CHECK,
+        }:
             busy_runners = [runner for runner in self._get_runners() if runner.status.exist]
 
             logger.info("Removing existing %i busy local runners", len(runners))

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -561,7 +561,14 @@ class RunnerManager:
         Returns:
             Number of runners removed.
         """
-        remove_token = self._clients.github.get_runner_remove_token(self.config.path)
+        try:
+            remove_token = self._clients.github.get_runner_remove_token(self.config.path)
+        except errors.GithubClientError:
+            logger.exception("Failed to get remove-token to unregister runners from GitHub.")
+            if mode != FlushMode.FORCE_FLUSH_WAIT_REPO_CHECK:
+                raise
+            logger.info("Proceeding with flush without remove-token.")
+            remove_token = None
 
         # Removing non-busy runners
         runners = [
@@ -579,7 +586,7 @@ class RunnerManager:
 
         if mode in (
             FlushMode.FLUSH_IDLE_WAIT_REPO_CHECK,
-            FlushMode.FORCE_FLUSH_BUSY_WAIT_REPO_CHECK,
+            FlushMode.FLUSH_BUSY_WAIT_REPO_CHECK,
         ):
             for _ in range(5):
                 if not self._runners_in_pre_job():
@@ -593,7 +600,7 @@ class RunnerManager:
                     )
                 )
 
-        if mode in {FlushMode.FORCE_FLUSH_BUSY_WAIT_REPO_CHECK, FlushMode.FORCE_FLUSH_BUSY}:
+        if mode in {FlushMode.FLUSH_BUSY_WAIT_REPO_CHECK, FlushMode.FLUSH_BUSY}:
             busy_runners = [runner for runner in self._get_runners() if runner.status.exist]
 
             logger.info("Removing existing %i busy local runners", len(runners))

--- a/src/runner_manager_type.py
+++ b/src/runner_manager_type.py
@@ -24,15 +24,19 @@ class FlushMode(Enum):
         FLUSH_IDLE: Flush only idle runners.
         FLUSH_IDLE_WAIT_REPO_CHECK: Flush only idle runners, then wait until repo-policy-check is
             completed for the busy runners.
-        FORCE_FLUSH_BUSY: Force flush busy runners.
-        FORCE_FLUSH_BUSY_WAIT_REPO_CHECK: Wait until the repo-policy-check is completed before
-            force flush of busy runners.
+        FLUSH_BUSY: Flush busy runners.
+        FLUSH_BUSY_WAIT_REPO_CHECK: Wait until the repo-policy-check is completed before
+            flush of busy runners.
+        FORCE_FLUSH_WAIT_REPO_CHECK: Force flush the runners (remove lxd instances even on
+            gh api issues, like invalid token).
+            Wait until repo-policy-check is completed before force flush of busy runners.
     """
 
     FLUSH_IDLE = auto()
     FLUSH_IDLE_WAIT_REPO_CHECK = auto()
-    FORCE_FLUSH_BUSY = auto()
-    FORCE_FLUSH_BUSY_WAIT_REPO_CHECK = auto()
+    FLUSH_BUSY = auto()
+    FLUSH_BUSY_WAIT_REPO_CHECK = auto()
+    FORCE_FLUSH_WAIT_REPO_CHECK = auto()
 
 
 @dataclass

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -185,7 +185,7 @@ async def app_no_runner(
 
 
 @pytest_asyncio.fixture(scope="module")
-async def app(model: Model, app_no_runner: Application) -> AsyncIterator[Application]:
+async def app_one_runner(model: Model, app_no_runner: Application) -> AsyncIterator[Application]:
     """Application with a single runner.
 
     Test should ensure it returns with the application in a good state and has

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -457,6 +457,7 @@ def test_random_ssh_connection_choice(
     runner._configure_runner()
     second_call_args = runner._clients.jinja.get_template("env.j2").render.call_args.kwargs
 
-    assert (
-        first_call_args["ssh_debug_info"] != second_call_args["ssh_debug_info"]
-    ), "Same ssh debug info found, this may have occurred with a very low priority."
+    assert first_call_args["ssh_debug_info"] != second_call_args["ssh_debug_info"], (
+        "Same ssh debug info found, this may have occurred with a very low priority. "
+        "Just try again."
+    )


### PR DESCRIPTION
### Overview

Use the previously saved token to remove existing runners. If the previous token has expired, use a force removal (ignoring gh api errors and just removing lxd instances).

In addition, any invalid token errors in the charm code will be caught and the charm will go into `BlockedStatus`, requiring an operator to update the token. A message is included in the `BlockedStatus`, so this PR should fix https://github.com/canonical/github-runner-operator/issues/89.

### Rationale

If the new token on config changed is no longer valid for the current organisation/repo, the removal of existing runners may fail (due to HTTP 403 Forbidden).

```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-github-runner-1/charm/./src/charm.py", line 926, in <module>
    main(GithubRunnerCharm)
  File "/var/lib/juju/agents/unit-github-runner-1/charm/venv/ops/main.py", line 456, in main
    _emit_charm_event(charm, dispatcher.event_name)
  File "/var/lib/juju/agents/unit-github-runner-1/charm/venv/ops/main.py", line 144, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-github-runner-1/charm/venv/ops/framework.py", line 351, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-github-runner-1/charm/venv/ops/framework.py", line 853, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-github-runner-1/charm/venv/ops/framework.py", line 943, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-github-runner-1/charm/./src/charm.py", line 78, in func_with_catch_errors
    func(self, event)
  File "/var/lib/juju/agents/unit-github-runner-1/charm/./src/charm.py", line 505, in _on_config_changed
    prev_runner_manager.flush(FlushMode.FORCE_FLUSH_BUSY_WAIT_REPO_CHECK)
  File "/var/lib/juju/agents/unit-github-runner-1/charm/src/runner_manager.py", line 564, in flush
    remove_token = self._clients.github.get_runner_remove_token(self.config.path)
  File "/var/lib/juju/agents/unit-github-runner-1/charm/src/github_client.py", line 118, in get_runner_remove_token
    token = self._client.actions.create_remove_token_for_repo(
  File "/var/lib/juju/agents/unit-github-runner-1/charm/venv/ghapi/core.py", line 62, in __call__
    return self.client(self.path, self.verb, headers=headers, route=route_p, query=query_p, data=data_p)
  File "/var/lib/juju/agents/unit-github-runner-1/charm/venv/ghapi/core.py", line 121, in __call__
    res,self.recv_hdrs = urlsend(path, verb, headers=headers or None, debug=debug, return_headers=True,
  File "/var/lib/juju/agents/unit-github-runner-1/charm/venv/fastcore/net.py", line 218, in urlsend
    return urlread(req, return_json=return_json, return_headers=return_headers)
  File "/var/lib/juju/agents/unit-github-runner-1/charm/venv/fastcore/net.py", line 119, in urlread
    if 400 <= e.code < 500: raise ExceptionsHTTP[e.code](e.url, e.hdrs, e.fp, msg=e.msg) from None
fastcore.net.HTTP403ForbiddenError: HTTP Error 403: Forbidden
====Error Body====
{
  "message": "Must have admin rights to Repository.",
  "documentation_url": "https://docs.github.com/rest/actions/self-hosted-runners#create-a-remove-token-for-a-repository"
}
```

### Juju Events Changes

`config_changed` event is adapted

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->