### PR TITLE
Remove proxy vars when using aproxy

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -85,10 +85,10 @@ options:
     type: boolean
     default: false
     description: |
-      (Experimental, may be removed) When set to true, aproxy (https://github.com/canonical/aproxy) 
-      will  be installed inside the runners and will forward all http/s traffic to a proxy server
-      configured by the juju model config 'juju-http-proxy' 
-      (or if this is not set, 'juju-https-proxy' will be used).
+      (Experimental, may be removed) When set to true, aproxy (https://github.com/canonical/aproxy)
+      will be installed within the runners. It will forward all HTTP(S) traffic to standard ports 
+      (80, 443) to a proxy server configured by the juju model config 'juju-http-proxy' 
+      (or, if this is not set, 'juju-https-proxy' will be used).
       This is useful when the charm is deployed in a network that requires a proxy to access the 
       internet.
       Note that you should not specify a proxy server listening on port 80 or 443, as all traffic

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -51,9 +51,28 @@ The configurations applied in the image include:
 
 ## Network configuration
 
-The charm respects the HTTP(S) proxy configuration of the model configuration of Juju. The configuration can be set with [`juju model-config`](https://juju.is/docs/juju/juju-model-config) using the following keys: `juju-http-proxy`, `juju-https-proxy`, `juju-no-proxy`. The GitHub self-hosted runner applications are configured to use the proxy configuration.
+The charm respects the HTTP(S) proxy configuration of the model configuration of Juju. The configuration can be set with [`juju model-config`](https://juju.is/docs/juju/juju-model-config) using the following keys: `juju-http-proxy`, `juju-https-proxy`, `juju-no-proxy`. 
+The GitHub self-hosted runner applications will be configured to utilise the proxy configuration. 
+This involves setting environment variables such as `http_proxy`, `https_proxy`, `no_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
+in various locations within the runner environment, such as `/etc/environment`.
 
-If an HTTP(S) proxy is used, all HTTP(S) requests in the GitHub workflow will be transparently routed to the proxy with [aproxy](https://github.com/canonical/aproxy). Iptables are set up to route network traffic to the destination on ports 80 and 443 to the aproxy. The aproxy will route received packets to the configured HTTP(S) proxy. The service is installed on each runner virtual machine and configured according to the proxy configuration from the Juju model.
+However, employing this approach with environment variables has its drawbacks. 
+Not all applications within a workflow may adhere to these variables as they 
+[lack standardisation](https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/). 
+This inconsistency can result in failed workflows, prompting the introduction of aproxy, as detailed in the subsection below.
+
+### aproxy
+If the proxy configuration is utilised and [aproxy](https://github.com/canonical/aproxy) is specified through the charm's configuration option,
+all HTTP(S) requests to standard ports (80, 443) within the GitHub workflow will be automatically directed 
+to the specified HTTP(s) proxy. Network traffic destined for ports 80 and 443 is redirected to aproxy using iptables.
+aproxy then forwards received packets to the designated HTTP(S) proxy. 
+Beyond that, the environment variables (`http_proxy`, `https_proxy`, `no_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`)
+will no longer be defined  in the runner environment. 
+It's worth noting that this setup deviates from the behaviour when not using aproxy, 
+where these variables are set in the runner environment. In that scenario, traffic to non-standard ports 
+would also be directed to the HTTP(s) proxy, unlike when using aproxy.
+
+### denylist
 
 The nftables on the Juju machine are configured to deny traffic from the runner virtual machine to IPs on the [`denylist` configuration](https://charmhub.io/github-runner/configure#denylist). The runner will always have access to essential services such as DHCP and DNS, regardless of the denylist configuration.
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -178,7 +178,7 @@ SSH connection information for debug workflow.
 
 ---
 
-<a href="../src/charm_state.py#L219"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L217"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -215,7 +215,7 @@ The charm state.
 
 ---
 
-<a href="../src/charm_state.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L269"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -248,7 +248,7 @@ Raised when given machine charm architecture is unsupported.
  
  - <b>`arch`</b>:  The current machine architecture. 
 
-<a href="../src/charm_state.py#L176"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L174"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -100,10 +100,10 @@ Proxy configuration.
 
 **Attributes:**
  
- - <b>`http_proxy`</b>:  HTTP proxy address. 
- - <b>`https_proxy`</b>:  HTTPS proxy address. 
+ - <b>`http`</b>:  HTTP proxy address. 
+ - <b>`https`</b>:  HTTPS proxy address. 
  - <b>`no_proxy`</b>:  Comma-separated list of hosts that should not be proxied. 
- - <b>`use_aproxy`</b>:  Whether aproxy should be used. 
+ - <b>`use_aproxy`</b>:  Whether aproxy should be used for the runners. 
 
 
 ---
@@ -116,7 +116,7 @@ Return the aproxy address.
 
 ---
 
-<a href="../src/charm_state.py#L140"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L144"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_fields`
 
@@ -178,7 +178,7 @@ SSH connection information for debug workflow.
 
 ---
 
-<a href="../src/charm_state.py#L202"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L219"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -215,7 +215,7 @@ The charm state.
 
 ---
 
-<a href="../src/charm_state.py#L254"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -248,7 +248,7 @@ Raised when given machine charm architecture is unsupported.
  
  - <b>`arch`</b>:  The current machine architecture. 
 
-<a href="../src/charm_state.py#L159"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L176"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/runner.py.md
+++ b/src-docs/runner.py.md
@@ -39,7 +39,7 @@ The configuration values for creating a single runner instance.
 ## <kbd>class</kbd> `Runner`
 Single instance of GitHub self-hosted runner. 
 
-<a href="../src/runner.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L109"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -67,7 +67,7 @@ Construct the runner instance.
 
 ---
 
-<a href="../src/runner.py#L133"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `create`
 
@@ -91,7 +91,7 @@ Create the runner instance on LXD and register it on GitHub.
 
 ---
 
-<a href="../src/runner.py#L169"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L179"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `remove`
 

--- a/src-docs/runner.py.md
+++ b/src-docs/runner.py.md
@@ -39,7 +39,7 @@ The configuration values for creating a single runner instance.
 ## <kbd>class</kbd> `Runner`
 Single instance of GitHub self-hosted runner. 
 
-<a href="../src/runner.py#L109"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -67,7 +67,7 @@ Construct the runner instance.
 
 ---
 
-<a href="../src/runner.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `create`
 
@@ -91,7 +91,7 @@ Create the runner instance on LXD and register it on GitHub.
 
 ---
 
-<a href="../src/runner.py#L179"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L161"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `remove`
 

--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -44,7 +44,7 @@ Construct RunnerManager object for creating and managing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L745"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L756"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `build_runner_image`
 
@@ -81,7 +81,7 @@ Check if runner binary exists.
 
 ---
 
-<a href="../src/runner_manager.py#L583"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L594"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `flush`
 
@@ -146,7 +146,7 @@ The runner binary URL changes when a new version is available.
 
 ---
 
-<a href="../src/runner_manager.py#L478"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L489"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 
@@ -170,7 +170,7 @@ Bring runners in line with target.
 
 ---
 
-<a href="../src/runner_manager.py#L755"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L766"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `schedule_build_runner_image`
 

--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -17,7 +17,7 @@ Runner Manager manages the runners on LXD and GitHub.
 ## <kbd>class</kbd> `RunnerManager`
 Manage a group of runners according to configuration. 
 
-<a href="../src/runner_manager.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L57"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -25,8 +25,7 @@ Manage a group of runners according to configuration.
 __init__(
     app_name: str,
     unit: int,
-    runner_manager_config: RunnerManagerConfig,
-    proxies: Optional[ProxySetting] = None
+    runner_manager_config: RunnerManagerConfig
 ) → None
 ```
 
@@ -39,14 +38,13 @@ Construct RunnerManager object for creating and managing runners.
  - <b>`app_name`</b>:  An name for the set of runners. 
  - <b>`unit`</b>:  Unit number of the set of runners. 
  - <b>`runner_manager_config`</b>:  Configuration for the runner manager. 
- - <b>`proxies`</b>:  HTTP proxy settings. 
 
 
 
 
 ---
 
-<a href="../src/runner_manager.py#L726"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L745"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `build_runner_image`
 
@@ -66,7 +64,7 @@ Build container image in test mode, else virtual machine image.
 
 ---
 
-<a href="../src/runner_manager.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L121"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `check_runner_bin`
 
@@ -83,7 +81,7 @@ Check if runner binary exists.
 
 ---
 
-<a href="../src/runner_manager.py#L555"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L583"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `flush`
 
@@ -106,7 +104,7 @@ Remove existing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L218"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L222"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_github_info`
 
@@ -123,7 +121,7 @@ Get information on the runners from GitHub.
 
 ---
 
-<a href="../src/utilities.py#L125"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/utilities.py#L129"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_latest_runner_bin_url`
 
@@ -148,7 +146,7 @@ The runner binary URL changes when a new version is available.
 
 ---
 
-<a href="../src/runner_manager.py#L450"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L478"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 
@@ -172,7 +170,7 @@ Bring runners in line with target.
 
 ---
 
-<a href="../src/runner_manager.py#L736"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L755"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `schedule_build_runner_image`
 
@@ -184,7 +182,7 @@ Install cron job for building runner image.
 
 ---
 
-<a href="../src/utilities.py#L151"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/utilities.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_runner_bin`
 

--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -17,7 +17,7 @@ Runner Manager manages the runners on LXD and GitHub.
 ## <kbd>class</kbd> `RunnerManager`
 Manage a group of runners according to configuration. 
 
-<a href="../src/runner_manager.py#L57"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -44,7 +44,7 @@ Construct RunnerManager object for creating and managing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L756"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L742"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `build_runner_image`
 
@@ -64,7 +64,7 @@ Build container image in test mode, else virtual machine image.
 
 ---
 
-<a href="../src/runner_manager.py#L121"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L107"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `check_runner_bin`
 
@@ -81,7 +81,7 @@ Check if runner binary exists.
 
 ---
 
-<a href="../src/runner_manager.py#L594"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L580"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `flush`
 
@@ -104,7 +104,7 @@ Remove existing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L222"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L208"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_github_info`
 
@@ -121,7 +121,7 @@ Get information on the runners from GitHub.
 
 ---
 
-<a href="../src/utilities.py#L129"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/utilities.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_latest_runner_bin_url`
 
@@ -146,7 +146,7 @@ The runner binary URL changes when a new version is available.
 
 ---
 
-<a href="../src/runner_manager.py#L489"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L475"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 
@@ -170,7 +170,7 @@ Bring runners in line with target.
 
 ---
 
-<a href="../src/runner_manager.py#L766"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L752"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `schedule_build_runner_image`
 
@@ -182,7 +182,7 @@ Install cron job for building runner image.
 
 ---
 
-<a href="../src/utilities.py#L155"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/utilities.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_runner_bin`
 

--- a/src-docs/runner_type.py.md
+++ b/src-docs/runner_type.py.md
@@ -17,7 +17,7 @@ Represent GitHub organization.
 
 ---
 
-<a href="../src/runner_type.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_type.py#L51"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `path`
 
@@ -38,7 +38,7 @@ Represent GitHub repository.
 
 ---
 
-<a href="../src/runner_type.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_type.py#L39"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `path`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -50,7 +50,7 @@ from github_type import GitHubRunnerStatus
 from runner import LXD_PROFILE_YAML
 from runner_manager import RunnerManager, RunnerManagerConfig
 from runner_manager_type import FlushMode
-from runner_type import GithubOrg, GithubRepo, ProxySetting, VirtualMachineResources
+from runner_type import GithubOrg, GithubRepo, VirtualMachineResources
 from utilities import bytes_with_unit_to_kib, execute_command, retry
 
 RECONCILE_RUNNERS_EVENT = "reconcile-runners"
@@ -173,19 +173,6 @@ class GithubRunnerCharm(CharmBase):
             token=self.config["token"],  # for detecting changes
             runner_bin_url=None,
         )
-
-        self.proxies: ProxySetting = {}
-        if proxy_config := self._state.proxy_config:
-            if http_proxy := proxy_config.http_proxy:
-                self.proxies["http"] = str(http_proxy)
-            if https_proxy := proxy_config.https_proxy:
-                self.proxies["https"] = str(https_proxy)
-            # there's no need for no_proxy if there's no http_proxy or https_proxy
-            no_proxy = proxy_config.no_proxy
-            if (https_proxy or http_proxy) and no_proxy:
-                self.proxies["no_proxy"] = no_proxy
-            if proxy_config.use_aproxy:
-                self.proxies["aproxy_address"] = proxy_config.aproxy_address
 
         self.service_token = None
 
@@ -359,7 +346,6 @@ class GithubRunnerCharm(CharmBase):
                 charm_state=self._state,
                 dockerhub_mirror=dockerhub_mirror,
             ),
-            proxies=self.proxies,
         )
 
     @catch_charm_errors
@@ -756,15 +742,16 @@ class GithubRunnerCharm(CharmBase):
         """
         # Prepare environment for pip subprocess
         env = {}
-        if "http" in self.proxies:
-            env["HTTP_PROXY"] = self.proxies["http"]
-            env["http_proxy"] = self.proxies["http"]
-        if "https" in self.proxies:
-            env["HTTPS_PROXY"] = self.proxies["https"]
-            env["https_proxy"] = self.proxies["https"]
-        if "no_proxy" in self.proxies:
-            env["NO_PROXY"] = self.proxies["no_proxy"]
-            env["no_proxy"] = self.proxies["no_proxy"]
+        proxy_config = self._state.proxy_config
+        if http_proxy := proxy_config.http:
+            env["HTTP_PROXY"] = http_proxy
+            env["http_proxy"] = http_proxy
+        if https_proxy := proxy_config.https:
+            env["HTTPS_PROXY"] = https_proxy
+            env["https_proxy"] = https_proxy
+        if no_proxy := proxy_config.no_proxy:
+            env["NO_PROXY"] = no_proxy
+            env["no_proxy"] = no_proxy
 
         old_version = execute_command(
             [
@@ -883,7 +870,7 @@ class GithubRunnerCharm(CharmBase):
             working_directory=str(self.repo_check_web_service_path),
             charm_token=self.service_token,
             github_token=self.config["token"],
-            proxies=self.proxies,
+            proxies=self._state.proxy_config,
         )
         self.repo_check_systemd_service.write_text(service_content, encoding="utf-8")
 

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -145,9 +145,7 @@ class ProxyConfig(BaseModel):
     @classmethod
     def check_fields(cls, values: dict) -> dict:
         """Validate the proxy configuration."""
-        if values.get("use_aproxy") and not (
-            values.get("http") or values.get("https")
-        ):
+        if values.get("use_aproxy") and not (values.get("http") or values.get("https")):
             raise ValueError("aproxy requires http or https to be set")
 
         return values

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -92,16 +92,16 @@ class ProxyConfig(BaseModel):
     """Proxy configuration.
 
     Attributes:
-        http_proxy: HTTP proxy address.
-        https_proxy: HTTPS proxy address.
+        http: HTTP proxy address.
+        https: HTTPS proxy address.
         no_proxy: Comma-separated list of hosts that should not be proxied.
-        use_aproxy: Whether aproxy should be used.
+        use_aproxy: Whether aproxy should be used for the runners.
     """
 
-    http_proxy: Optional[AnyHttpUrl]
-    https_proxy: Optional[AnyHttpUrl]
+    http: Optional[AnyHttpUrl]
+    https: Optional[AnyHttpUrl]
     no_proxy: Optional[str]
-    use_aproxy: bool
+    use_aproxy: bool = False
 
     @classmethod
     def from_charm(cls, charm: CharmBase) -> "ProxyConfig":
@@ -118,9 +118,13 @@ class ProxyConfig(BaseModel):
         https_proxy = get_env_var("JUJU_CHARM_HTTPS_PROXY") or None
         no_proxy = get_env_var("JUJU_CHARM_NO_PROXY") or None
 
+        # there's no need for no_proxy if there's no http_proxy or https_proxy
+        if not (https_proxy or http_proxy) and no_proxy:
+            no_proxy = None
+
         return cls(
-            http_proxy=http_proxy,
-            https_proxy=https_proxy,
+            http=http_proxy,
+            https=https_proxy,
             no_proxy=no_proxy,
             use_aproxy=use_aproxy,
         )
@@ -129,7 +133,7 @@ class ProxyConfig(BaseModel):
     def aproxy_address(self) -> Optional[str]:
         """Return the aproxy address."""
         if self.use_aproxy:
-            proxy_address = self.http_proxy or self.https_proxy
+            proxy_address = self.http or self.https
             # assert is only used to make mypy happy
             assert proxy_address is not None  # nosec for [B101:assert_used]
             aproxy_address = f"{proxy_address.host}:{proxy_address.port}"
@@ -147,6 +151,19 @@ class ProxyConfig(BaseModel):
             raise ValueError("aproxy requires http_proxy or https_proxy to be set")
 
         return values
+
+    def __bool__(self):
+        """Return whether we have a proxy config."""
+        return bool(self.http or self.https)
+
+    class Config:  # pylint: disable=too-few-public-methods
+        """Pydantic model configuration.
+
+        Attributes:
+            allow_mutation: Whether the model is mutable.
+        """
+
+        allow_mutation = False
 
 
 class UnsupportedArchitectureError(Exception):

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -146,9 +146,9 @@ class ProxyConfig(BaseModel):
     def check_fields(cls, values: dict) -> dict:
         """Validate the proxy configuration."""
         if values.get("use_aproxy") and not (
-            values.get("http_proxy") or values.get("https_proxy")
+            values.get("http") or values.get("https")
         ):
-            raise ValueError("aproxy requires http_proxy or https_proxy to be set")
+            raise ValueError("aproxy requires http or https to be set")
 
         return values
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -38,7 +38,13 @@ from errors import (
 from lxd import LxdInstance
 from lxd_type import LxdInstanceConfig
 from runner_manager_type import RunnerManagerClients
-from runner_type import GithubOrg, RunnerConfig, RunnerStatus, VirtualMachineResources
+from runner_type import (
+    GithubOrg,
+    ProxySetting,
+    RunnerConfig,
+    RunnerStatus,
+    VirtualMachineResources,
+)
 from utilities import execute_command, retry
 
 logger = logging.getLogger(__name__)
@@ -121,6 +127,10 @@ class Runner:
         self.instance = instance
 
         self._shared_fs: Optional[shared_fs.SharedFilesystem] = None
+
+        if aproxy_address := self.config.proxies.get("aproxy_address"):
+            # If aproxy is used, the proxy environment variables are not necessary.
+            self.config.proxies = ProxySetting(aproxy_address=aproxy_address)
 
         # If the proxy setting are set, then add NO_PROXY local variables.
         if self.config.proxies.get("http") or self.config.proxies.get("https"):

--- a/src/runner.py
+++ b/src/runner.py
@@ -622,9 +622,13 @@ class Runner:
         docker_client_proxy = {
             "proxies": {
                 "default": {
-                    "httpProxy": self.config.proxies.http or "",
-                    "httpsProxy": self.config.proxies.https or "",
-                    "noProxy": self.config.proxies.no_proxy or "",
+                    key: value
+                    for key, value in (
+                        ("httpProxy", self.config.proxies.http),
+                        ("httpsProxy", self.config.proxies.https),
+                        ("noProxy", self.config.proxies.no_proxy),
+                    )
+                    if value
                 }
             }
         }

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -396,7 +396,7 @@ class RunnerManager:
         if self.proxies and not self.proxies.use_aproxy:
             # If the proxy setting are set, then add NO_PROXY local variables.
             if self.proxies.no_proxy:
-                no_proxy = self.config.proxies.no_proxy + ","
+                no_proxy = self.proxies.no_proxy + ","
             else:
                 no_proxy = ""
             no_proxy = no_proxy + f"{name},.svc"

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -9,12 +9,10 @@ import random
 import secrets
 import tarfile
 import time
-import urllib.request
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, Iterator, Optional, Type
 
-import fastcore.net
 import jinja2
 import requests
 import requests.adapters
@@ -88,18 +86,6 @@ class RunnerManager:
         )
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
-        if self.proxies:
-            proxy_dict = {
-                "http_proxy": self.proxies.http,
-                "https_proxy": self.proxies.https,
-                "no_proxy": self.proxies.no_proxy,
-            }
-            # setup proxy for requests
-            self.session.proxies.update(proxy_dict)
-            # add proxy to fastcore which ghapi uses
-            proxy = urllib.request.ProxyHandler(proxy_dict)
-            opener = urllib.request.build_opener(proxy)
-            fastcore.net._opener = opener
 
         # The repo policy compliance service is on localhost and should not have any proxies
         # setting configured. The is a separated requests Session as the other one configured

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -393,6 +393,17 @@ class RunnerManager:
             logger.exception("Failed to issue Reconciliation metric")
 
     def _get_runner_config(self, name: str) -> RunnerConfig:
+        """Get the configuration for a runner.
+
+        Sets the proxy settings for the runner according to the configuration
+        and creates a new runner configuration object.
+
+        Args:
+            name: Name of the runner.
+
+        Returns:
+            Configuration for the runner.
+        """
         if self.proxies and not self.proxies.use_aproxy:
             # If the proxy setting are set, then add NO_PROXY local variables.
             if self.proxies.no_proxy:

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -34,7 +34,8 @@ from repo_policy_compliance_client import RepoPolicyComplianceClient
 from runner import LXD_PROFILE_YAML, CreateRunnerConfig, Runner, RunnerConfig, RunnerStatus
 from runner_manager_type import FlushMode, RunnerInfo, RunnerManagerClients, RunnerManagerConfig
 from runner_metrics import RUNNER_INSTALLED_TS_FILE_NAME
-from runner_type import ProxySetting, RunnerByHealth, VirtualMachineResources
+from runner_type import ProxySetting as RunnerProxySetting
+from runner_type import RunnerByHealth, VirtualMachineResources
 from utilities import execute_command, retry, set_env_var
 
 REMOVED_RUNNER_LOG_STR = "Removed runner: %s"
@@ -58,7 +59,6 @@ class RunnerManager:
         app_name: str,
         unit: int,
         runner_manager_config: RunnerManagerConfig,
-        proxies: Optional[ProxySetting] = None,
     ) -> None:
         """Construct RunnerManager object for creating and managing runners.
 
@@ -66,20 +66,19 @@ class RunnerManager:
             app_name: An name for the set of runners.
             unit: Unit number of the set of runners.
             runner_manager_config: Configuration for the runner manager.
-            proxies: HTTP proxy settings.
         """
         self.app_name = app_name
         self.instance_name = f"{app_name}-{unit}"
         self.config = runner_manager_config
-        self.proxies = proxies if proxies else ProxySetting()
+        self.proxies = runner_manager_config.charm_state.proxy_config
 
         # Setting the env var to this process and any child process spawned.
-        if "no_proxy" in self.proxies:
-            set_env_var("NO_PROXY", self.proxies["no_proxy"])
-        if "http" in self.proxies:
-            set_env_var("HTTP_PROXY", self.proxies["http"])
-        if "https" in self.proxies:
-            set_env_var("HTTPS_PROXY", self.proxies["https"])
+        if no_proxy := self.proxies.no_proxy:
+            set_env_var("NO_PROXY", no_proxy)
+        if http_proxy := self.proxies.http:
+            set_env_var("HTTP_PROXY", http_proxy)
+        if https_proxy := self.proxies.https:
+            set_env_var("HTTPS_PROXY", https_proxy)
 
         self.session = requests.Session()
         adapter = requests.adapters.HTTPAdapter(
@@ -90,10 +89,15 @@ class RunnerManager:
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
         if self.proxies:
+            proxy_dict = {
+                "http_proxy": self.proxies.http,
+                "https_proxy": self.proxies.https,
+                "no_proxy": self.proxies.no_proxy,
+            }
             # setup proxy for requests
-            self.session.proxies.update(self.proxies)
+            self.session.proxies.update(proxy_dict)
             # add proxy to fastcore which ghapi uses
-            proxy = urllib.request.ProxyHandler(self.proxies)
+            proxy = urllib.request.ProxyHandler(proxy_dict)
             opener = urllib.request.build_opener(proxy)
             fastcore.net._opener = opener
 
@@ -388,6 +392,39 @@ class RunnerManager:
         except IssueMetricEventError:
             logger.exception("Failed to issue Reconciliation metric")
 
+    def _get_runner_config(self, name: str) -> RunnerConfig:
+        if self.proxies and not self.proxies.use_aproxy:
+            # If the proxy setting are set, then add NO_PROXY local variables.
+            if self.proxies.no_proxy:
+                no_proxy = self.config.proxies.no_proxy + ","
+            else:
+                no_proxy = ""
+            no_proxy = no_proxy + f"{name},.svc"
+
+            proxies = RunnerProxySetting(
+                no_proxy=no_proxy,
+                http=self.proxies.http,
+                https=self.proxies.https,
+                aproxy_address=None,
+            )
+        elif self.proxies.use_aproxy:
+            proxies = RunnerProxySetting(
+                aproxy_address=self.proxies.aproxy_address, no_proxy=None, http=None, https=None
+            )
+        else:
+            proxies = None
+
+        return RunnerConfig(
+            app_name=self.app_name,
+            dockerhub_mirror=self.config.dockerhub_mirror,
+            issue_metrics=self.config.are_metrics_enabled,
+            lxd_storage_path=self.config.lxd_storage_path,
+            path=self.config.path,
+            proxies=proxies,
+            name=name,
+            ssh_debug_connections=self.config.charm_state.ssh_debug_connections,
+        )
+
     def _spawn_new_runners(self, count: int, resources: VirtualMachineResources):
         """Spawn new runners.
 
@@ -402,16 +439,7 @@ class RunnerManager:
         remove_token = self._clients.github.get_runner_remove_token(self.config.path)
         logger.info("Attempting to add %i runner(s).", count)
         for _ in range(count):
-            config = RunnerConfig(
-                app_name=self.app_name,
-                dockerhub_mirror=self.config.dockerhub_mirror,
-                issue_metrics=self.config.are_metrics_enabled,
-                lxd_storage_path=self.config.lxd_storage_path,
-                path=self.config.path,
-                proxies=self.proxies,
-                name=self._generate_runner_name(),
-                ssh_debug_connections=self.config.charm_state.ssh_debug_connections,
-            )
+            config = self._get_runner_config(self._generate_runner_name())
             runner = Runner(self._clients, config, RunnerStatus())
             try:
                 self._create_runner(registration_token, resources, runner)
@@ -669,16 +697,7 @@ class RunnerManager:
             online = getattr(remote_runner, "status", None) == "online"
             busy = getattr(remote_runner, "busy", None)
 
-            config = RunnerConfig(
-                app_name=self.app_name,
-                dockerhub_mirror=self.config.dockerhub_mirror,
-                issue_metrics=self.config.are_metrics_enabled,
-                lxd_storage_path=self.config.lxd_storage_path,
-                name=name,
-                path=self.config.path,
-                proxies=self.proxies,
-                ssh_debug_connections=self.config.charm_state.ssh_debug_connections,
-            )
+            config = self._get_runner_config(name)
             return Runner(
                 self._clients,
                 config,
@@ -708,9 +727,9 @@ class RunnerManager:
         Returns:
             Command to execute to build runner image.
         """
-        http_proxy = self.proxies.get("http", "")
-        https_proxy = self.proxies.get("https", "")
-        no_proxy = self.proxies.get("no_proxy", "")
+        http_proxy = self.proxies.http or ""
+        https_proxy = self.proxies.https or ""
+        no_proxy = self.proxies.no_proxy or ""
 
         cmd = [
             "/usr/bin/bash",

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -393,10 +393,10 @@ class RunnerManager:
         if self.proxies and not self.proxies.use_aproxy:
             # If the proxy setting are set, then add NO_PROXY local variables.
             if self.proxies.no_proxy:
-                no_proxy = self.proxies.no_proxy + ","
+                no_proxy = f"{self.proxies.no_proxy},"
             else:
                 no_proxy = ""
-            no_proxy = no_proxy + f"{name},.svc"
+            no_proxy = f"{no_proxy}{name},.svc"
 
             proxies = RunnerProxySetting(
                 no_proxy=no_proxy,

--- a/src/runner_type.py
+++ b/src/runner_type.py
@@ -6,7 +6,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple, Optional, TypedDict, Union
+from typing import NamedTuple, Optional, Union
 
 from charm_state import SSHDebugConnection
 
@@ -19,13 +19,14 @@ class RunnerByHealth:
     unhealthy: tuple[str]
 
 
-class ProxySetting(TypedDict, total=False):
+@dataclass
+class ProxySetting:
     """Represent HTTP-related proxy settings."""
 
-    no_proxy: str
-    http: str
-    https: str
-    aproxy_address: str
+    no_proxy: Optional[str]
+    http: Optional[str]
+    https: Optional[str]
+    aproxy_address: Optional[str]
 
 
 @dataclass
@@ -87,7 +88,7 @@ class RunnerConfig:  # pylint: disable=too-many-instance-attributes
     path: GithubPath
     proxies: ProxySetting
     dockerhub_mirror: str | None = None
-    ssh_debug_connections: SSHDebugConnection | None = None
+    ssh_debug_connections: list[SSHDebugConnection] | None = None
 
 
 @dataclass

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,15 +1,17 @@
 PATH=/home/ubuntu/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
-{% if proxies['http'] %}
-HTTP_PROXY={{proxies['http']}}
-http_proxy={{proxies['http']}}
+{% if proxies.http %}
+HTTP_PROXY={{proxies.http}}
+http_proxy={{proxies.http}}
 {% endif %}
-{% if proxies['https'] %}
-HTTPS_PROXY={{proxies['https']}}
-https_proxy={{proxies['https']}}
+{% if proxies.https %}
+HTTPS_PROXY={{proxies.https}}
+https_proxy={{proxies.https}}
 {% endif %}
-{% if proxies['no_proxy'] %}
-NO_PROXY={{proxies['no_proxy']}}
-no_proxy={{proxies['no_proxy']}}
+{% if proxies.ftp_proxy %}
+{% endif %}
+{% if proxies.no_proxy %}
+NO_PROXY={{proxies.no_proxy}}
+no_proxy={{proxies.no_proxy}}
 {% endif %}
 {% if dockerhub_mirror %}
 DOCKERHUB_MIRROR={{dockerhub_mirror}}

--- a/templates/environment.j2
+++ b/templates/environment.j2
@@ -1,10 +1,16 @@
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
-HTTP_PROXY={{proxies['http']}}
-HTTPS_PROXY={{proxies['https']}}
-NO_PROXY={{proxies['no_proxy']}}
-http_proxy={{proxies['http']}}
-https_proxy={{proxies['https']}}
-no_proxy={{proxies['no_proxy']}}
+{% if proxies.http %}
+Environment="HTTP_PROXY={{proxies.http}}
+Environment="http_proxy={{proxies.http}}"
+{% endif %}
+{% if proxies.https %}
+Environment="HTTPS_PROXY={{proxies.https}}
+Environment="https_proxy={{proxies.https}}"
+{% endif %}
+{% if proxies.no_proxy %}
+Environment="NO_PROXY={{proxies.no_proxy}}"
+Environment="no_proxy={{proxies.no_proxy}}"
+{% endif %}
 {% if ssh_debug_info %}
 TMATE_SERVER_HOST={{ssh_debug_info['host']}}
 TMATE_SERVER_PORT={{ssh_debug_info['port']}}

--- a/templates/environment.j2
+++ b/templates/environment.j2
@@ -1,15 +1,15 @@
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
 {% if proxies.http %}
-Environment="HTTP_PROXY={{proxies.http}}
-Environment="http_proxy={{proxies.http}}"
+HTTP_PROXY={{proxies.http}}
+http_proxy={{proxies.http}}
 {% endif %}
 {% if proxies.https %}
-Environment="HTTPS_PROXY={{proxies.https}}
-Environment="https_proxy={{proxies.https}}"
+HTTPS_PROXY={{proxies.https}}
+https_proxy={{proxies.https}}
 {% endif %}
 {% if proxies.no_proxy %}
-Environment="NO_PROXY={{proxies.no_proxy}}"
-Environment="no_proxy={{proxies.no_proxy}}"
+NO_PROXY={{proxies.no_proxy}}
+no_proxy={{proxies.no_proxy}}
 {% endif %}
 {% if ssh_debug_info %}
 TMATE_SERVER_HOST={{ssh_debug_info['host']}}

--- a/templates/repo-policy-compliance.service.j2
+++ b/templates/repo-policy-compliance.service.j2
@@ -9,11 +9,11 @@ WorkingDirectory={{working_directory}}
 Environment="GITHUB_TOKEN={{github_token}}"
 Environment="CHARM_TOKEN={{charm_token}}"
 {% if proxies.http %}
-Environment="HTTP_PROXY={{proxies.http}}
+Environment="HTTP_PROXY={{proxies.http}}"
 Environment="http_proxy={{proxies.http}}"
 {% endif %}
 {% if proxies.https %}
-Environment="HTTPS_PROXY={{proxies.https}}
+Environment="HTTPS_PROXY={{proxies.https}}"
 Environment="https_proxy={{proxies.https}}"
 {% endif %}
 {% if proxies.no_proxy %}

--- a/templates/repo-policy-compliance.service.j2
+++ b/templates/repo-policy-compliance.service.j2
@@ -8,10 +8,16 @@ Group=www-data
 WorkingDirectory={{working_directory}}
 Environment="GITHUB_TOKEN={{github_token}}"
 Environment="CHARM_TOKEN={{charm_token}}"
-Environment="HTTP_PROXY={{proxies['http']}}"
-Environment="HTTPS_PROXY={{proxies['https']}}"
-Environment="NO_PROXY={{proxies['no_proxy']}}"
-Environment="http_proxy={{proxies['http']}}"
-Environment="https_proxy={{proxies['https']}}"
-Environment="no_proxy={{proxies['no_proxy']}}"
+{% if proxies.http %}
+Environment="HTTP_PROXY={{proxies.http}}
+Environment="http_proxy={{proxies.http}}"
+{% endif %}
+{% if proxies.https %}
+Environment="HTTPS_PROXY={{proxies.https}}
+Environment="https_proxy={{proxies.https}}"
+{% endif %}
+{% if proxies.no_proxy %}
+Environment="NO_PROXY={{proxies.no_proxy}}"
+Environment="no_proxy={{proxies.no_proxy}}"
+{% endif %}
 ExecStart=/usr/bin/gunicorn --bind 0.0.0.0:8080 --timeout 60 app:app

--- a/templates/systemd-docker-proxy.j2
+++ b/templates/systemd-docker-proxy.j2
@@ -1,9 +1,9 @@
 [Service]
 {% if proxies.http %}
-Environment="HTTP_PROXY={{proxies.http}}
+Environment="HTTP_PROXY={{proxies.http}}"
 {% endif %}
 {% if proxies.https %}
-Environment="HTTPS_PROXY={{proxies.https}}
+Environment="HTTPS_PROXY={{proxies.https}}"
 {% endif %}
 {% if proxies.no_proxy %}
 Environment="NO_PROXY={{proxies.no_proxy}}"

--- a/templates/systemd-docker-proxy.j2
+++ b/templates/systemd-docker-proxy.j2
@@ -1,4 +1,10 @@
 [Service]
-Environment="HTTP_PROXY={{proxies['http']}}"
-Environment="HTTPS_PROXY={{proxies['https']}}"
-Environment="NO_PROXY={{proxies['no_proxy']}}"
+{% if proxies.http %}
+Environment="HTTP_PROXY={{proxies.http}}
+{% endif %}
+{% if proxies.https %}
+Environment="HTTPS_PROXY={{proxies.https}}
+{% endif %}
+{% if proxies.no_proxy %}
+Environment="NO_PROXY={{proxies.no_proxy}}"
+{% endif %}

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -75,7 +75,8 @@ async def install_repo_policy_compliance_from_git_source(unit: Unit, source: Non
         unit: Unit instance to check for the LXD profile.
         source: The git source to install the package. If none the package is removed.
     """
-    await run_in_unit(unit, "python3 -m pip uninstall --yes repo-policy-compliance")
+    return_code, stdout = await run_in_unit(unit, "python3 -m pip uninstall --yes repo-policy-compliance")
+    assert return_code == 0, f"Failed to uninstall repo-policy-compliance: {stdout}"
 
     if source:
         return_code, _ = await run_in_unit(unit, f"python3 -m pip install {source}")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -75,7 +75,9 @@ async def install_repo_policy_compliance_from_git_source(unit: Unit, source: Non
         unit: Unit instance to check for the LXD profile.
         source: The git source to install the package. If none the package is removed.
     """
-    return_code, stdout = await run_in_unit(unit, "python3 -m pip uninstall --yes repo-policy-compliance")
+    return_code, stdout = await run_in_unit(
+        unit, "python3 -m pip uninstall --yes repo-policy-compliance"
+    )
     assert return_code == 0, f"Failed to uninstall repo-policy-compliance: {stdout}"
 
     if source:

--- a/tests/integration/test_charm_with_proxy.py
+++ b/tests/integration/test_charm_with_proxy.py
@@ -179,7 +179,7 @@ async def app_fixture(app_with_prepared_machine: Application) -> AsyncIterator[A
     yield app_with_prepared_machine
     await app_with_prepared_machine.set_config(
         {
-            "virtual-machines": 0,
+            "virtual-machines": "0",
         }
     )
 

--- a/tests/integration/test_charm_with_proxy.py
+++ b/tests/integration/test_charm_with_proxy.py
@@ -387,7 +387,7 @@ async def test_use_proxy_without_aproxy(
         2. URL with non-standard port
     assert: That the proxy vars are set in the runner, aproxy logs are empty, and that
         the tinyproxy log contains both requests
-        (requests to non-standard ports are forwared using env vars).
+        (requests to non-standard ports will be forwarded when using env vars).
     """
     await app.set_config(
         {

--- a/tests/integration/test_charm_with_proxy.py
+++ b/tests/integration/test_charm_with_proxy.py
@@ -2,17 +2,20 @@
 #  See LICENSE file for licensing details.
 
 """Test the usage of a proxy server."""
+import socketserver
 import subprocess
+import threading
 from asyncio import sleep
+from http.server import SimpleHTTPRequestHandler
 from pathlib import Path
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional
 from urllib.parse import urlparse
 
 import pytest
 import pytest_asyncio
 from juju.application import Application
-from juju.machine import Machine
 from juju.model import Model
+from juju.unit import Unit
 
 from tests.integration.helpers import (
     ensure_charm_has_runner,
@@ -23,11 +26,28 @@ from tests.status_name import ACTIVE
 from utilities import execute_command
 
 NO_PROXY = "127.0.0.1,localhost,::1"
+NON_PRIVATE_IP = "200.100.100.10"
 PROXY_PORT = 8899
+HTTP_SERVER_PORT = 9432
+
+
+@pytest.fixture(scope="module", name="host_ip")
+def host_ip_fixture() -> str:
+    """Get the default ip of the host."""
+    stdout, _ = execute_command(
+        [
+            "/bin/bash",
+            "-c",
+            r"ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') |"
+            r" grep -oP 'src \K\S+'",
+        ],
+        check_exit=True,
+    )
+    return stdout.strip()
 
 
 @pytest_asyncio.fixture(scope="module", name="proxy")
-async def proxy_fixture() -> AsyncIterator[str]:
+async def proxy_fixture(host_ip: str) -> AsyncIterator[str]:
     """Start tinyproxy and return the proxy server address."""
     result = subprocess.run(["which", "tinyproxy"])
     assert (
@@ -39,27 +59,41 @@ async def proxy_fixture() -> AsyncIterator[str]:
 
     process = subprocess.Popen(["tinyproxy", "-d", "-c", str(tinyproxy_config)])
 
-    # Get default ip using following commands
-    stdout, _ = execute_command(
-        [
-            "/bin/bash",
-            "-c",
-            r"ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') |"
-            r" grep -oP 'src \K\S+'",
-        ],
-        check_exit=True,
-    )
-    default_ip = stdout.strip()
-
-    yield f"http://{default_ip}:{PROXY_PORT}"
+    yield f"http://{host_ip}:{PROXY_PORT}"
 
     process.terminate()
     if tinyproxy_config.exists():
         tinyproxy_config.unlink()
 
 
-@pytest_asyncio.fixture(scope="module", name="prepared_machine")
-async def prepared_machine_fixture(model: Model, proxy: str) -> Machine:
+@pytest_asyncio.fixture(scope="module", name="http_server")
+async def http_server(host_ip: str) -> AsyncIterator[str]:
+    """Start a simple http server and return the address."""
+
+    def start_http_server(port):
+        handler = SimpleHTTPRequestHandler
+        httpd = socketserver.TCPServer(("", port), handler)
+        print(f"Serving on port {port}")
+        httpd.serve_forever()
+
+    # Start the server in a separate thread so it doesn't block the main thread
+    t = threading.Thread(target=start_http_server, args=(HTTP_SERVER_PORT,), daemon=True)
+    t.start()
+
+    yield f"http://{host_ip}:{HTTP_SERVER_PORT}"
+
+
+@pytest_asyncio.fixture(scope="module", name="app_with_prepared_machine")
+async def app_with_prepared_machine_fixture(
+    model: Model,
+    charm_file: str,
+    app_name: str,
+    path: str,
+    token: str,
+    proxy: str,
+) -> Application:
+    """Application with proxy setup and firewall to block all other network access."""
+
     await model.set_config(
         {
             "apt-http-proxy": proxy,
@@ -86,7 +120,14 @@ async def prepared_machine_fixture(model: Model, proxy: str) -> Machine:
 
     # Disable external network access for the juju machine.
     proxy_url = urlparse(proxy)
+    # Forbid direct access to http server
+    await machine.ssh(
+        "sudo iptables -A OUTPUT"
+        f" -p tcp -d {proxy_url.hostname} --dport {HTTP_SERVER_PORT} -j DROP"
+    )
+    # Allow other access to the host , e.g. to the proxy
     await machine.ssh(f"sudo iptables -I OUTPUT -d {proxy_url.hostname} -j ACCEPT")
+    # Explicitly allow access to the following networks.
     await machine.ssh("sudo iptables -I OUTPUT -d 0.0.0.0/8 -j ACCEPT")
     await machine.ssh("sudo iptables -I OUTPUT -d 10.0.0.0/8 -j ACCEPT")
     await machine.ssh("sudo iptables -I OUTPUT -d 100.64.0.0/10 -j ACCEPT")
@@ -103,25 +144,11 @@ async def prepared_machine_fixture(model: Model, proxy: str) -> Machine:
     await machine.ssh("sudo iptables -I OUTPUT -d 224.0.0.0/4 -j ACCEPT")
     await machine.ssh("sudo iptables -I OUTPUT -d 233.252.0.0/24 -j ACCEPT")
     await machine.ssh("sudo iptables -I OUTPUT -d 240.0.0.0/4 -j ACCEPT")
+    # Block all other network access.
     await machine.ssh("sudo iptables -P OUTPUT DROP")
     # Test the external network access is disabled.
     await machine.ssh("ping -c1 canonical.com 2>&1 | grep '100% packet loss'")
 
-    return machine
-
-
-@pytest_asyncio.fixture(scope="module", name="app_with_aproxy")
-async def app_with_aproxy_fixture(
-    model: Model,
-    charm_file: str,
-    app_name: str,
-    path: str,
-    token: str,
-    proxy: str,
-    prepared_machine: Machine,
-) -> Application:
-    """Application with aproxy setup and firewall to block all other network access."""
-
     # Deploy the charm in the juju machine with external network access disabled.
     application = await model.deploy(
         charm_file,
@@ -130,52 +157,31 @@ async def app_with_aproxy_fixture(
         config={
             "path": path,
             "token": token,
-            "virtual-machines": 1,
+            "virtual-machines": 0,
             "denylist": "10.10.0.0/16",
             "test-mode": "insecure",
             "reconcile-interval": 60,
-            "experimental-use-aproxy": "true",
         },
         constraints={"root-disk": 15},
-        to=prepared_machine.id,
+        to=machine.id,
     )
     await model.wait_for_idle(status=ACTIVE, timeout=60 * 60)
 
     return application
 
 
-@pytest_asyncio.fixture(scope="module", name="app_without_aproxy")
-async def app_without_aproxy_fixture(
-    model: Model,
-    charm_file: str,
-    app_name: str,
-    path: str,
-    token: str,
-    proxy: str,
-    prepared_machine: Machine,
-) -> Application:
-    """Application with aproxy setup and firewall to block all other network access."""
+@pytest_asyncio.fixture(scope="function", name="app")
+async def app_fixture(app_with_prepared_machine: Application) -> AsyncIterator[Application]:
+    """Setup and teardown the app.
 
-    # Deploy the charm in the juju machine with external network access disabled.
-    application = await model.deploy(
-        charm_file,
-        application_name=app_name,
-        series="jammy",
-        config={
-            "path": path,
-            "token": token,
-            "virtual-machines": 1,
-            "denylist": "10.10.0.0/16",
-            "test-mode": "insecure",
-            "reconcile-interval": 60,
-            "experimental-use-aproxy": "false",
-        },
-        constraints={"root-disk": 15},
-        to=prepared_machine.id,
+    Remove the runner after each test.
+    """
+    yield app_with_prepared_machine
+    await app_with_prepared_machine.set_config(
+        {
+            "virtual-machines": 0,
+        }
     )
-    await model.wait_for_idle(status=ACTIVE, timeout=60 * 60)
-
-    return application
 
 
 def _assert_proxy_var_in(text: str, not_in=False):
@@ -196,7 +202,7 @@ def _assert_proxy_var_in(text: str, not_in=False):
         assert (proxy_var in text) != not_in
 
 
-async def _assert_proxy_vars_in_file(unit, runner_name, file_path, not_set=False):
+async def _assert_proxy_vars_in_file(unit: Unit, runner_name: str, file_path: str, not_set=False):
     """Assert that proxy environment variables are set / not set in a file.
 
     Args:
@@ -207,10 +213,11 @@ async def _assert_proxy_vars_in_file(unit, runner_name, file_path, not_set=False
     """
     return_code, stdout = await run_in_lxd_instance(unit, runner_name, f"cat {file_path}")
     assert return_code == 0, "Failed to read file"
+    assert stdout, "File is empty"
     _assert_proxy_var_in(stdout, not_in=not_set)
 
 
-async def _assert_docker_proxy_vars(unit, runner_name, not_set=False):
+async def _assert_docker_proxy_vars(unit: Unit, runner_name: str, not_set=False):
     """Assert that proxy environment variables are set / not set for docker.
 
     Args:
@@ -224,7 +231,7 @@ async def _assert_docker_proxy_vars(unit, runner_name, not_set=False):
     assert return_code == (1 if not_set else 0)
 
 
-async def _assert_proxy_vars(unit, runner_name, not_set=False):
+async def _assert_proxy_vars(unit: Unit, runner_name: str, not_set=False):
     """Assert that proxy environment variables are set / not set in the runner.
 
     Args:
@@ -239,7 +246,7 @@ async def _assert_proxy_vars(unit, runner_name, not_set=False):
     await _assert_docker_proxy_vars(unit, runner_name, not_set=not_set)
 
 
-async def _assert_proxy_vars_set(unit, runner_name):
+async def _assert_proxy_vars_set(unit: Unit, runner_name: str):
     """Assert that proxy environment variables are set in the runner.
 
     Args:
@@ -249,7 +256,7 @@ async def _assert_proxy_vars_set(unit, runner_name):
     await _assert_proxy_vars(unit, runner_name, not_set=False)
 
 
-async def _assert_proxy_vars_not_set(unit, runner_name):
+async def _assert_proxy_vars_not_set(unit: Unit, runner_name: str):
     """Assert that proxy environment variables are not set in the runner.
 
     Args:
@@ -259,65 +266,138 @@ async def _assert_proxy_vars_not_set(unit, runner_name):
     await _assert_proxy_vars(unit, runner_name, not_set=True)
 
 
+async def _add_translation_of_non_private_ip(unit: Unit, runner_name: str, host_ip: str):
+    """Add dnat rule to translate non-private ip to the host ip.
+
+    Args:
+        host_ip: The host ip.
+        runner_name: The name of the runner.
+        unit: The unit to run the command on.
+    """
+    return_code, stdout = await run_in_lxd_instance(
+        unit,
+        runner_name,
+        "sudo nft add rule nat OUTPUT"
+        f" ip daddr 200.100.100.1 tcp dport {HTTP_SERVER_PORT} dnat to {host_ip}",
+    )
+    assert return_code == 0, f"Failed to add dnat rule: {stdout}"
+
+
+async def _get_aproxy_logs(unit: Unit, runner_name: str) -> Optional[str]:
+    """Get the aproxy logs.
+
+    Args:
+        runner_name: The name of the runner.
+        unit: The unit to run the command on.
+
+    Returns:
+        The aproxy logs if existent, otherwise None.
+    """
+    return_code, stdout = await run_in_lxd_instance(
+        unit, runner_name, "snap logs aproxy.aproxy -n=all"
+    )
+    assert return_code == 0, "Failed to get aproxy logs"
+    return stdout
+
+
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_usage_of_aproxy(model: Model, app_with_aproxy: Application) -> None:
+async def test_usage_of_aproxy(
+    model: Model, app: Application, http_server: str, host_ip: str
+) -> None:
     """
-    arrange: A working application with one runner using aproxy configured for a proxy server.
-    act: Run curl in the runner.
-    assert: Check that no proxy vars are set in the runner and
-        that the aproxy log contains the request.
+    arrange: A working application with a runner using aproxy configured for a proxy server.
+        A non-private IP (X) is translated to the host IP that a web server is listening on,
+        so that aproxy has a chance to intercept the request.
+    act: Run curl in the runner
+        1. URL with standard port
+        2. URL with non-private IP X with non-standard port
+    assert: That no proxy vars are set in the runner and that
+        1. the request is successful and the aproxy log contains the request
+        2. the request is not successful and the aproxy log does not contain the request
     """
-    await ensure_charm_has_runner(app_with_aproxy, model)
-    unit = app_with_aproxy.units[0]
+    await app.set_config(
+        {
+            "experimental-use-aproxy": "true",
+        }
+    )
+    await ensure_charm_has_runner(app, model)
+    unit = app.units[0]
     names = await get_runner_names(unit)
     assert names
     runner_name = names[0]
 
-    await _assert_proxy_vars_not_set(unit, runner_name)
+    await _add_translation_of_non_private_ip(unit, runner_name, host_ip)
+
+    # 1. URL with standard port, should succeed, gets intercepted by aproxy
     return_code, stdout = await run_in_lxd_instance(
         unit,
         runner_name,
         "curl http://canonical.com",
     )
+    assert return_code == 0, f"Expected successful connection to http://canonical.com: {stdout}"
 
-    assert return_code == 0
-
+    # 2. URL with non-private IP X with non-standard port, should fail,
+    # does not get intercepted by aproxy
     return_code, stdout = await run_in_lxd_instance(
-        unit, runner_name, "snap logs aproxy.aproxy -n=all"
+        unit,
+        runner_name,
+        f"curl --connect-timeout 1 {http_server}",
     )
-    assert return_code == 0
-    assert stdout is not None
-    assert "canonical.com" in stdout
+    assert return_code == 28, f"Expected connect timeout to {http_server}: {stdout}"
+
+    aproxy_logs = await _get_aproxy_logs(unit, runner_name)
+    assert aproxy_logs is not None
+    assert "canonical.com" in aproxy_logs
+    assert NON_PRIVATE_IP not in aproxy_logs
 
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_use_proxy_without_aproxy(model: Model, app_without_aproxy: Application) -> None:
+async def test_use_proxy_without_aproxy(
+    model: Model, app: Application, http_server, host_ip
+) -> None:
     """
-    arrange: A working application with one runner configured for a proxy server
-        and not using aproxy.
-    act: Run curl in the runner.
-    assert: Check that proxy vars are set and that the aproxy log does not contain the request.
+    arrange: A working application with a runner not using aproxy configured for a proxy server.
+        A non-private IP (X) is translated to the host IP that a web server is listening on,
+        so that aproxy has a chance to intercept the request.
+    act: Run curl in the runner
+        1. URL with standard port
+        2. URL with non-private IP X with non-standard port
+    assert: That the proxy vars are set in the runner, aproxy logs are empty, and that
+        1. the request is successful
+        2. the request is also successful because
+            when using env vars requests to non-standard ports are also forwarded to the proxy
     """
-    await ensure_charm_has_runner(app_without_aproxy, model)
-    unit = app_without_aproxy.units[0]
+    await app.set_config(
+        {
+            "experimental-use-aproxy": "false",
+        }
+    )
+    await ensure_charm_has_runner(app, model)
+    unit = app.units[0]
     names = await get_runner_names(unit)
     assert names
     runner_name = names[0]
 
     await _assert_proxy_vars_set(unit, runner_name)
+    await _add_translation_of_non_private_ip(unit, runner_name, host_ip)
+
+    # 1. URL with standard port, should succeed
     return_code, stdout = await run_in_lxd_instance(
         unit,
         runner_name,
         "curl http://canonical.com",
     )
+    assert return_code == 0, f"Expected successful connection to http://canonical.com: {stdout}"
 
-    assert return_code == 0
-
+    # 2. URL with non-private IP X with non-standard port, should succeed
     return_code, stdout = await run_in_lxd_instance(
-        unit, runner_name, "snap logs aproxy.aproxy -n=all"
+        unit,
+        runner_name,
+        f"curl --connect-timeout 10 {http_server}",
     )
-    assert return_code == 0
-    assert stdout is not None
-    assert "canonical.com" not in stdout
+    assert return_code == 0, f"Expected successful connection to {http_server}"
+
+    aproxy_logs = await _get_aproxy_logs(unit, runner_name)
+    assert aproxy_logs is None

--- a/tests/integration/test_charm_with_proxy.py
+++ b/tests/integration/test_charm_with_proxy.py
@@ -361,9 +361,10 @@ async def test_usage_of_aproxy(model: Model, app: Application, proxy_logs_filepa
         runner_name,
         f"http://canonical.com:{NON_STANDARD_PORT}",
     )
-    assert (
-        return_code == 7
-    ), f"Expected cannot connect error for http://canonical.com:{NON_STANDARD_PORT}. Error msg: {stdout}"
+    assert return_code == 7, (
+        f"Expected cannot connect error for http://canonical.com:{NON_STANDARD_PORT}. "
+        f"Error msg: {stdout}"
+    )
 
     aproxy_logs = await _get_aproxy_logs(unit, runner_name)
     assert aproxy_logs is not None
@@ -413,7 +414,6 @@ async def test_use_proxy_without_aproxy(
 
     # 2. URL with non-standard port, should return an error message by the proxy like this:
     #
-    #  <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
     # <html>
     # <head><title>500 Unable to connect</title></head>
     # <body>
@@ -428,9 +428,10 @@ async def test_use_proxy_without_aproxy(
         runner_name,
         f"http://canonical.com:{NON_STANDARD_PORT}",
     )
-    assert (
-        return_code == 0
-    ), f"Expected error response from proxy for http://canonical.com:{NON_STANDARD_PORT}. Error msg: {stdout}"
+    assert return_code == 0, (
+        f"Expected error response from proxy for http://canonical.com:{NON_STANDARD_PORT}. "
+        f"Error msg: {stdout}"
+    )
 
     proxy_logs = proxy_logs_filepath.read_text(encoding="utf-8")
     assert "GET http://canonical.com/" in proxy_logs

--- a/tests/integration/test_charm_with_proxy.py
+++ b/tests/integration/test_charm_with_proxy.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 import pytest
 import pytest_asyncio
 from juju.application import Application
+from juju.machine import Machine
 from juju.model import Model
 
 from tests.integration.helpers import (
@@ -21,6 +22,7 @@ from tests.integration.helpers import (
 from tests.status_name import ACTIVE
 from utilities import execute_command
 
+NO_PROXY = "127.0.0.1,localhost,::1"
 PROXY_PORT = 8899
 
 
@@ -56,27 +58,19 @@ async def proxy_fixture() -> AsyncIterator[str]:
         tinyproxy_config.unlink()
 
 
-@pytest_asyncio.fixture(scope="module", name="app_with_aproxy")
-async def app_with_aproxy_fixture(
-    model: Model,
-    charm_file: str,
-    app_name: str,
-    path: str,
-    token: str,
-    proxy: str,
-) -> Application:
-    """Application with aproxy setup and firewall to block all other network access."""
+@pytest_asyncio.fixture(scope="module", name="prepared_machine")
+async def prepared_machine_fixture(model: Model, proxy: str) -> Machine:
     await model.set_config(
         {
             "apt-http-proxy": proxy,
             "apt-https-proxy": proxy,
-            "apt-no-proxy": "127.0.0.1,localhost,::1",
+            "apt-no-proxy": NO_PROXY,
             "juju-http-proxy": proxy,
             "juju-https-proxy": proxy,
-            "juju-no-proxy": "127.0.0.1,localhost,::1",
+            "juju-no-proxy": NO_PROXY,
             "snap-http-proxy": proxy,
             "snap-https-proxy": proxy,
-            "snap-no-proxy": "127.0.0.1,localhost,::1",
+            "snap-no-proxy": NO_PROXY,
             "logging-config": "<root>=INFO;unit=DEBUG",
         }
     )
@@ -113,6 +107,21 @@ async def app_with_aproxy_fixture(
     # Test the external network access is disabled.
     await machine.ssh("ping -c1 canonical.com 2>&1 | grep '100% packet loss'")
 
+    return machine
+
+
+@pytest_asyncio.fixture(scope="module", name="app_with_aproxy")
+async def app_with_aproxy_fixture(
+    model: Model,
+    charm_file: str,
+    app_name: str,
+    path: str,
+    token: str,
+    proxy: str,
+    prepared_machine: Machine,
+) -> Application:
+    """Application with aproxy setup and firewall to block all other network access."""
+
     # Deploy the charm in the juju machine with external network access disabled.
     application = await model.deploy(
         charm_file,
@@ -128,11 +137,126 @@ async def app_with_aproxy_fixture(
             "experimental-use-aproxy": "true",
         },
         constraints={"root-disk": 15},
-        to=machine.id,
+        to=prepared_machine.id,
     )
     await model.wait_for_idle(status=ACTIVE, timeout=60 * 60)
 
     return application
+
+
+@pytest_asyncio.fixture(scope="module", name="app_without_aproxy")
+async def app_without_aproxy_fixture(
+    model: Model,
+    charm_file: str,
+    app_name: str,
+    path: str,
+    token: str,
+    proxy: str,
+    prepared_machine: Machine,
+) -> Application:
+    """Application with aproxy setup and firewall to block all other network access."""
+
+    # Deploy the charm in the juju machine with external network access disabled.
+    application = await model.deploy(
+        charm_file,
+        application_name=app_name,
+        series="jammy",
+        config={
+            "path": path,
+            "token": token,
+            "virtual-machines": 1,
+            "denylist": "10.10.0.0/16",
+            "test-mode": "insecure",
+            "reconcile-interval": 60,
+            "experimental-use-aproxy": "false",
+        },
+        constraints={"root-disk": 15},
+        to=prepared_machine.id,
+    )
+    await model.wait_for_idle(status=ACTIVE, timeout=60 * 60)
+
+    return application
+
+
+def _assert_proxy_var_in(text: str, not_in=False):
+    """Assert that proxy environment variables are set / not set.
+
+    Args:
+        text: The text to search for proxy environment variables.
+        not_in: Whether the proxy environment variables should be set or not.
+    """
+    for proxy_var in (
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+    ):
+        assert (proxy_var in text) != not_in
+
+
+async def _assert_proxy_vars_in_file(unit, runner_name, file_path, not_set=False):
+    """Assert that proxy environment variables are set / not set in a file.
+
+    Args:
+        unit: The unit to run the command on.
+        runner_name: The name of the runner.
+        file_path: The path to the file to check for proxy environment variables.
+        not_set: Whether the proxy environment variables should be set or not.
+    """
+    return_code, stdout = await run_in_lxd_instance(unit, runner_name, f"cat {file_path}")
+    assert return_code == 0, "Failed to read file"
+    _assert_proxy_var_in(stdout, not_in=not_set)
+
+
+async def _assert_docker_proxy_vars(unit, runner_name, not_set=False):
+    """Assert that proxy environment variables are set / not set for docker.
+
+    Args:
+        unit: The unit to run the command on.
+        runner_name: The name of the runner.
+        not_set: Whether the proxy environment variables should be set or not.
+    """
+    return_code, _ = await run_in_lxd_instance(
+        unit, runner_name, "docker run --rm alpine sh -c 'env | grep -i  _PROXY'"
+    )
+    assert return_code == (1 if not_set else 0)
+
+
+async def _assert_proxy_vars(unit, runner_name, not_set=False):
+    """Assert that proxy environment variables are set / not set in the runner.
+
+    Args:
+        unit: The unit to run the command on.
+        runner_name: The name of the runner.
+        not_set: Whether the proxy environment variables should be set or not.
+    """
+    await _assert_proxy_vars_in_file(unit, runner_name, "/etc/environment", not_set=not_set)
+    await _assert_proxy_vars_in_file(
+        unit, runner_name, "/home/ubuntu/github-runner/.env", not_set=not_set
+    )
+    await _assert_docker_proxy_vars(unit, runner_name, not_set=not_set)
+
+
+async def _assert_proxy_vars_set(unit, runner_name):
+    """Assert that proxy environment variables are set in the runner.
+
+    Args:
+        unit: The unit to run the command on.
+        runner_name: The name of the runner.
+    """
+    await _assert_proxy_vars(unit, runner_name, not_set=False)
+
+
+async def _assert_proxy_vars_not_set(unit, runner_name):
+    """Assert that proxy environment variables are not set in the runner.
+
+    Args:
+        unit: The unit to run the command on.
+        runner_name: The name of the runner.
+    """
+    await _assert_proxy_vars(unit, runner_name, not_set=True)
 
 
 @pytest.mark.asyncio
@@ -141,7 +265,8 @@ async def test_usage_of_aproxy(model: Model, app_with_aproxy: Application) -> No
     """
     arrange: A working application with one runner using aproxy configured for a proxy server.
     act: Run curl in the runner.
-    assert: The aproxy log contains the request.
+    assert: Check that no proxy vars are set in the runner and
+        that the aproxy log contains the request.
     """
     await ensure_charm_has_runner(app_with_aproxy, model)
     unit = app_with_aproxy.units[0]
@@ -149,6 +274,7 @@ async def test_usage_of_aproxy(model: Model, app_with_aproxy: Application) -> No
     assert names
     runner_name = names[0]
 
+    await _assert_proxy_vars_not_set(unit, runner_name)
     return_code, stdout = await run_in_lxd_instance(
         unit,
         runner_name,
@@ -163,3 +289,35 @@ async def test_usage_of_aproxy(model: Model, app_with_aproxy: Application) -> No
     assert return_code == 0
     assert stdout is not None
     assert "canonical.com" in stdout
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_use_proxy_without_aproxy(model: Model, app_without_aproxy: Application) -> None:
+    """
+    arrange: A working application with one runner configured for a proxy server
+        and not using aproxy.
+    act: Run curl in the runner.
+    assert: Check that proxy vars are set and that the aproxy log does not contain the request.
+    """
+    await ensure_charm_has_runner(app_without_aproxy, model)
+    unit = app_without_aproxy.units[0]
+    names = await get_runner_names(unit)
+    assert names
+    runner_name = names[0]
+
+    await _assert_proxy_vars_set(unit, runner_name)
+    return_code, stdout = await run_in_lxd_instance(
+        unit,
+        runner_name,
+        "curl http://canonical.com",
+    )
+
+    assert return_code == 0
+
+    return_code, stdout = await run_in_lxd_instance(
+        unit, runner_name, "snap logs aproxy.aproxy -n=all"
+    )
+    assert return_code == 0
+    assert stdout is not None
+    assert "canonical.com" not in stdout

--- a/tests/integration/test_charm_with_proxy.py
+++ b/tests/integration/test_charm_with_proxy.py
@@ -303,7 +303,7 @@ async def _get_aproxy_logs(unit: Unit, runner_name: str) -> Optional[str]:
     return stdout
 
 
-async def _curl_as_ubuntu_user(unit: Unit, runner_name: str, url: str) -> tuple[int, str]:
+async def _curl_as_ubuntu_user(unit: Unit, runner_name: str, url: str) -> tuple[int, str | None]:
     """Run curl as a logged in ubuntu user.
 
     This should simulate the bevahiour of a curl inside the runner with environment variables set.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -76,9 +76,9 @@ class TestCharm(unittest.TestCase):
         harness = Harness(GithubRunnerCharm)
         harness.begin()
 
-        assert harness.charm.proxies["https"] == TEST_PROXY_SERVER_URL
-        assert harness.charm.proxies["http"] == TEST_PROXY_SERVER_URL
-        assert harness.charm.proxies["no_proxy"] == "127.0.0.1,localhost"
+        assert harness.charm._state.proxy_config.https == TEST_PROXY_SERVER_URL
+        assert harness.charm._state.proxy_config.http == TEST_PROXY_SERVER_URL
+        assert harness.charm._state.proxy_config.no_proxy == "127.0.0.1,localhost"
 
     @patch("pathlib.Path.write_text")
     @patch("subprocess.run")
@@ -128,7 +128,6 @@ class TestCharm(unittest.TestCase):
                 lxd_storage_path=GithubRunnerCharm.juju_storage_path,
                 charm_state=harness.charm._state,
             ),
-            proxies={},
         )
 
     @patch("charm.RunnerManager")
@@ -154,7 +153,6 @@ class TestCharm(unittest.TestCase):
                 lxd_storage_path=GithubRunnerCharm.juju_storage_path,
                 charm_state=harness.charm._state,
             ),
-            proxies={},
         )
 
     @patch("charm.RunnerManager")
@@ -212,7 +210,6 @@ class TestCharm(unittest.TestCase):
                 lxd_storage_path=GithubRunnerCharm.juju_storage_path,
                 charm_state=harness.charm._state,
             ),
-            proxies={},
         )
         mock_rm.reconcile.assert_called_with(0, VirtualMachineResources(2, "7GiB", "10GiB")),
         mock_rm.reset_mock()
@@ -232,7 +229,6 @@ class TestCharm(unittest.TestCase):
                 lxd_storage_path=GithubRunnerCharm.juju_storage_path,
                 charm_state=harness.charm._state,
             ),
-            proxies={},
         )
         mock_rm.reconcile.assert_called_with(
             5, VirtualMachineResources(cpu=4, memory="7GiB", disk="6GiB")

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -14,6 +14,7 @@ from charm_state import (
     COS_AGENT_INTEGRATION_NAME,
     DEBUG_SSH_INTEGRATION_NAME,
     CharmConfigInvalidError,
+    ProxyConfig,
     SSHDebugConnection,
     State,
 )
@@ -79,6 +80,27 @@ def test_proxy_invalid_format():
     with patch.dict(os.environ, {"JUJU_CHARM_HTTP_PROXY": url_without_scheme}):
         with pytest.raises(CharmConfigInvalidError):
             State.from_charm(charm)
+
+
+def test_proxy_config_bool():
+    """
+    arrange: Various combinations for ProxyConfig
+    act: Create ProxyConfig object
+    assert: Expected boolean value
+    """
+    proxy_url = "http://proxy.example.com:8080"
+
+    # assert True if http or https is set
+    assert ProxyConfig(http=proxy_url)
+    assert ProxyConfig(https=proxy_url)
+    assert ProxyConfig(http=proxy_url, https=proxy_url)
+    assert ProxyConfig(http=proxy_url, https=proxy_url, no_proxy="localhost")
+
+    # assert False if otherwise
+    assert not ProxyConfig(use_aproxy=False)
+    assert not ProxyConfig(no_proxy="localhost")
+    assert not ProxyConfig(use_aproxy=False, no_proxy="localhost")
+    assert not ProxyConfig()
 
 
 def test_from_charm_invalid_arch(monkeypatch: pytest.MonkeyPatch):

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -16,7 +16,7 @@ from charm_state import SSHDebugConnection
 from errors import CreateSharedFilesystemError, RunnerCreateError, RunnerRemoveError
 from runner import CreateRunnerConfig, Runner, RunnerConfig, RunnerStatus
 from runner_manager_type import RunnerManagerClients
-from runner_type import GithubOrg, GithubRepo, VirtualMachineResources
+from runner_type import GithubOrg, GithubRepo, ProxySetting, VirtualMachineResources
 from shared_fs import SharedFilesystem
 from tests.unit.factories import SSHDebugInfoFactory
 from tests.unit.mock import (
@@ -25,6 +25,8 @@ from tests.unit.mock import (
     mock_lxd_error_func,
     mock_runner_error_func,
 )
+
+TEST_PROXY_SERVER_URL = "http://proxy.server:1234"
 
 
 @pytest.fixture(scope="module", name="vm_resources")
@@ -101,10 +103,18 @@ def ssh_debug_connections_fixture() -> list[SSHDebugConnection]:
     scope="function",
     name="runner",
     params=[
-        (GithubOrg("test_org", "test_group"), {}),
+        (
+            GithubOrg("test_org", "test_group"),
+            ProxySetting(no_proxy=None, http=None, https=None, aproxy_address=None),
+        ),
         (
             GithubRepo("test_owner", "test_repo"),
-            {"no_proxy": "test_no_proxy", "http": "test_http", "https": "test_https"},
+            ProxySetting(
+                no_proxy="test_no_proxy",
+                http=TEST_PROXY_SERVER_URL,
+                https=TEST_PROXY_SERVER_URL,
+                aproxy_address=None,
+            ),
         ),
     ],
 )


### PR DESCRIPTION
### Overview

Remove the proxy vars `http_proxy`, `https_proxy` and `no_proxy` in runner's `/etc/environment` and `.env` files if runner is configured to use aproxy.

Add integration tests that test the different behaviour when using http proxy with aproxy vs http proxy without aproxy.

### Rationale

These variables are no longer needed for the default ports 80 and 443 as aproxy handles the traffic accordingly. Furthermore, I have observed a case where the `no_proxy` setting was not respected as attended (traffic to 10.0.0.0/8 was redirected to squid proxy), resulting in a failed workflow, whereas the workflow would succeed without the env variables set.
 See also [this](https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/) for problems with env variables.  Apparently Python does not respect CIDR blocks in the `no_proxy` setting, according to this blog post.

### Module Changes

- `charm_state.ProxyConfig` is used everywhere now (except in `runners.py`)
- `charm_state.ProxyConfig` also takes care of setting no_proxy accordingly (previously in `charm.py`)
- The `ProxySetting` for the runners is now set in the `RunnerManager`

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->