### PR TITLE
Remove unattended-upgrades

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -99,7 +99,7 @@ retry '/snap/bin/lxc exec builder -- /usr/bin/nslookup github.com' 'Wait for net
 /snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/apt-get install docker.io npm python3-pip shellcheck jq wget unzip gh -yq
 
 # Uninstall unattended-upgrades, to avoid lock errors when unattended-upgrades is active in the runner
-/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/apt-get purge unattended-upgrades
+/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/apt-get purge unattended-upgrades -yq
 
 if [[ -n "$HTTP_PROXY" ]]; then
     /snap/bin/lxc exec builder -- /usr/bin/npm config set proxy "$HTTP_PROXY"

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -99,7 +99,7 @@ retry '/snap/bin/lxc exec builder -- /usr/bin/nslookup github.com' 'Wait for net
 /snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/apt-get install docker.io npm python3-pip shellcheck jq wget unzip gh -yq
 
 # Uninstall unattended-upgrades, to avoid lock errors when unattended-upgrades is active in the runner
-/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- apt-get purge unattended-upgrades
+/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/apt-get purge unattended-upgrades
 
 if [[ -n "$HTTP_PROXY" ]]; then
     /snap/bin/lxc exec builder -- /usr/bin/npm config set proxy "$HTTP_PROXY"

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -97,6 +97,10 @@ retry '/snap/bin/lxc exec builder -- /usr/bin/nslookup github.com' 'Wait for net
 /snap/bin/lxc exec builder -- /usr/bin/apt-get update
 /snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/apt-get upgrade -yq
 /snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/apt-get install docker.io npm python3-pip shellcheck jq wget unzip gh -yq
+
+# Uninstall unattended-upgrades, to avoid lock errors when unattended-upgrades is active in the runner
+/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- apt-get purge unattended-upgrades
+
 if [[ -n "$HTTP_PROXY" ]]; then
     /snap/bin/lxc exec builder -- /usr/bin/npm config set proxy "$HTTP_PROXY"
 fi


### PR DESCRIPTION
### Overview

Remove `unattended-upgrades` inside the runners.

### Rationale

unattended-upgrades can be spawned randomly, holding the dpkg frontend lock and causing workflows to [fail](https://github.com/canonical/github-runner-operator/actions/runs/7896958825/job/21552601610) with

```
  E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 7417 (unattended-upgr)
  E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
  Error: The process '/usr/bin/sudo' failed with exit code 100
```

It also seems to be removed from the Github-hosted images: https://github.com/actions/runner-images/blob/9813840059cb0326f827634de5f1e3b7d92a828e/images/ubuntu/scripts/build/configure-apt.sh#L36


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->