### PR TITLE
Fix build-image cronjob

### DIFF
--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -9,7 +9,6 @@ Runner Manager manages the runners on LXD and GitHub.
 ---------------
 - **RUNNER_INSTALLED_TS_FILE_NAME**
 - **REMOVED_RUNNER_LOG_STR**
-- **BUILD_IMAGE_SCRIPT_FILENAME**
 
 
 ---

--- a/src/charm.py
+++ b/src/charm.py
@@ -850,6 +850,8 @@ class GithubRunnerCharm(CharmBase):
         )
         execute_command(["/usr/bin/snap", "install", "lxd", "--channel=latest/stable"])
         execute_command(["/usr/bin/snap", "refresh", "lxd", "--channel=latest/stable"])
+        # Add ubuntu user to lxd group, to allow building images with ubuntu user
+        execute_command(["/usr/sbin/usermod", "-aG", "lxd", "ubuntu"])
         execute_command(["/snap/bin/lxd", "waitready"])
         execute_command(["/snap/bin/lxd", "init", "--auto"])
         execute_command(["/snap/bin/lxc", "network", "set", "lxdbr0", "ipv6.address", "none"])

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -764,4 +764,4 @@ class RunnerManager:
         minute = random.randint(0, 59)  # nosec B311
         base_hour = random.randint(0, 5)  # nosec B311
         hours = ",".join([str(base_hour + offset) for offset in (0, 6, 12, 18)])
-        cron_file.write_text(f"{minute} {hours} * * * ubuntu {build_image_command}\n")
+        cron_file.write_text(f"{minute} {hours} * * * root {build_image_command}\n")

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -42,7 +42,7 @@ REMOVED_RUNNER_LOG_STR = "Removed runner: %s"
 logger = logging.getLogger(__name__)
 
 
-BUILD_IMAGE_SCRIPT_FILENAME = "scripts/build-image.sh"
+BUILD_IMAGE_SCRIPT_FILENAME = Path("scripts/build-image.sh")
 
 IssuedMetricEventsStats = dict[Type[metrics.Event], int]
 
@@ -731,7 +731,7 @@ class RunnerManager:
 
         cmd = [
             "/usr/bin/bash",
-            BUILD_IMAGE_SCRIPT_FILENAME,
+            str(BUILD_IMAGE_SCRIPT_FILENAME.absolute()),
             http_proxy,
             https_proxy,
             no_proxy,
@@ -764,4 +764,4 @@ class RunnerManager:
         minute = random.randint(0, 59)  # nosec B311
         base_hour = random.randint(0, 5)  # nosec B311
         hours = ",".join([str(base_hour + offset) for offset in (0, 6, 12, 18)])
-        cron_file.write_text(f"{minute} {hours} * * * ubuntu {build_image_command}")
+        cron_file.write_text(f"{minute} {hours} * * * ubuntu {build_image_command}\n")

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -764,4 +764,4 @@ class RunnerManager:
         minute = random.randint(0, 59)  # nosec B311
         base_hour = random.randint(0, 5)  # nosec B311
         hours = ",".join([str(base_hour + offset) for offset in (0, 6, 12, 18)])
-        cron_file.write_text(f"{minute} {hours} * * * root {build_image_command}\n")
+        cron_file.write_text(f"{minute} {hours} * * * ubuntu {build_image_command}\n")

--- a/tests/unit/test_runner_manager.py
+++ b/tests/unit/test_runner_manager.py
@@ -498,4 +498,4 @@ def test_schedule_build_runner_image(
     cmd = f"/usr/bin/bash {BUILD_IMAGE_SCRIPT_FILENAME.absolute()} {http} {https} {no_proxy}"
 
     assert cronfile.exists()
-    assert cronfile.read_text() == f"4 4,10,16,22 * * * ubuntu {cmd}\n"
+    assert cronfile.read_text() == f"4 4,10,16,22 * * * root {cmd}\n"

--- a/tests/unit/test_runner_manager.py
+++ b/tests/unit/test_runner_manager.py
@@ -498,4 +498,4 @@ def test_schedule_build_runner_image(
     cmd = f"/usr/bin/bash {BUILD_IMAGE_SCRIPT_FILENAME.absolute()} {http} {https} {no_proxy}"
 
     assert cronfile.exists()
-    assert cronfile.read_text() == f"4 4,10,16,22 * * * root {cmd}\n"
+    assert cronfile.read_text() == f"4 4,10,16,22 * * * ubuntu {cmd}\n"


### PR DESCRIPTION
### Overview

Fix the cron file by 

- adding a new line at the end
- using the absolute path of the build script

Also, add the `ubuntu` user to the `lxd` group to get the right permissions.

### Rationale

Scheduling the building of images does not work. `/var/log/syslog` contains

```
Feb 26 21:57:01 juju-e239d1-2 cron[483]: (*system*build-runner-image) ERROR (Missing newline before EOF, this crontab file will be ignored)
```

In addition, the `ubuntu` user does not have sufficient privileges to access the lxd socket.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->