### PR TITLE
Fix stuck reconciliation event

### DIFF
--- a/src-docs/event_timer.py.md
+++ b/src-docs/event_timer.py.md
@@ -40,7 +40,7 @@ Manages the timer to emit juju events at regular intervals.
  
  - <b>`unit_name`</b> (str):  Name of the juju unit to emit events to. 
 
-<a href="../src/event_timer.py#L63"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L62"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -61,7 +61,7 @@ Construct the timer manager.
 
 ---
 
-<a href="../src/event_timer.py#L154"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L147"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `disable_event_timer`
 
@@ -85,7 +85,7 @@ Disable the systemd timer for the given event.
 
 ---
 
-<a href="../src/event_timer.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L108"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `ensure_event_timer`
 
@@ -119,7 +119,7 @@ The timeout is the number of seconds before an event is timed out. If not set or
 
 ---
 
-<a href="../src/event_timer.py#L86"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/event_timer.py#L85"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `is_active`
 

--- a/src/event_timer.py
+++ b/src/event_timer.py
@@ -95,8 +95,10 @@ class EventTimer:
             TimerStatusError: Timer status cannot be determined.
         """
         try:
+            # We choose status over is-active here to provide debug logs that show the output of
+            # the timer.
             _, ret_code = execute_command(
-                [BIN_SYSTEMCTL, "is-active", f"ghro.{event_name}.timer"], check_exit=False
+                [BIN_SYSTEMCTL, "status", f"ghro.{event_name}.timer"], check_exit=False
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
             raise TimerStatusError from ex

--- a/src/event_timer.py
+++ b/src/event_timer.py
@@ -10,7 +10,6 @@ from typing import Optional, TypedDict
 import jinja2
 
 from utilities import execute_command
-from utilities import logger as utilities_logger
 
 BIN_SYSTEMCTL = "/usr/bin/systemctl"
 
@@ -102,15 +101,7 @@ class EventTimer:
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
             raise TimerStatusError from ex
 
-        if ret_code == 0:
-            return True
-
-        if utilities_logger.isEnabledFor(logging.DEBUG):
-            try:
-                execute_command([BIN_SYSTEMCTL, "list-timers", "--all"], check_exit=False)
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
-                logger.exception("Unable to list systemd timers: %s", ex)
-        return False
+        return ret_code == 0
 
     def ensure_event_timer(self, event_name: str, interval: int, timeout: Optional[int] = None):
         """Ensure that a systemd service and timer are registered to dispatch the given event.

--- a/templates/dispatch-event.service.j2
+++ b/templates/dispatch-event.service.j2
@@ -4,7 +4,7 @@ Description=Dispatch the {{event}} event on {{unit}}
 [Service]
 Type=oneshot
 # For juju 3 and juju 2 compatibility. The juju-run binary was renamed to juju-exec for juju 3.
-ExecStart=/usr/bin/bash -c '/usr/bin/juju-exec "{{unit}}" "JUJU_DISPATCH_PATH={{event}} timeout {{timeout}} ./dispatch" || /usr/bin/juju-run "{{unit}}" "JUJU_DISPATCH_PATH={{event}} timeout {{timeout}} ./dispatch"'
+ExecStart=/usr/bin/timeout {{timeout}} /usr/bin/bash -c '/usr/bin/juju-exec "{{unit}}" "JUJU_DISPATCH_PATH={{event}} ./dispatch" || /usr/bin/juju-run "{{unit}}" "JUJU_DISPATCH_PATH={{event}} ./dispatch"'
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/unit/test_event_timer.py
+++ b/tests/unit/test_event_timer.py
@@ -26,19 +26,3 @@ def test_is_active_false(exec_command):
 
     event = EventTimer(unit_name=secrets.token_hex(16))
     assert not event.is_active(event_name=secrets.token_hex(16))
-
-
-def test_is_active_false_list_timers(exec_command, caplog):
-    """
-    arrange: create an EventTimer object and mock exec command to return non-zero exit code
-     and set log level to debug
-    act: call is_active
-    assert: list-timers is called
-    """
-    exec_command.return_value = ("", 1)
-    caplog.set_level(logging.DEBUG)
-
-    event = EventTimer(unit_name=secrets.token_hex(16))
-    assert not event.is_active(event_name=secrets.token_hex(16))
-    assert exec_command.call_count == 2
-    assert "list-timers" in exec_command.call_args_list[1][0][0]

--- a/tests/unit/test_event_timer.py
+++ b/tests/unit/test_event_timer.py
@@ -1,6 +1,5 @@
 #  Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
-import logging
 import secrets
 
 from event_timer import EventTimer


### PR DESCRIPTION
### Overview

Move the timout command in the `dispatch-event` service before `juju-exec` or `juju-run`.

Also, improve the output of the timer's is-active check by using `systemctl status` whose output is logged when the log level is set to debug.

### Rationale

There is a bug in juju https://bugs.launchpad.net/juju/+bug/2055184 that occurs when the reconciliation event is triggered at the same time as a charm upgrade, resulting in a stuck reconciliation event that will not be retriggered.


### Module Changes

`event_timer.EventTimer.is_active`: Now uses `systemctl status` to check for is active status. The `list-timers` call is removed as it seems unnecessary.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->