### PR TITLE
Revert remove proxy vars in microstack setup

### DIFF
--- a/scripts/setup-microstack.sh
+++ b/scripts/setup-microstack.sh
@@ -31,9 +31,6 @@ retry() {
         sleep 10
     done
 }
-#  remove proxy vars as we encountered a problem with no_proxy not being interpreted correctly.
-head -n  1 /etc/environment > temp && sudo mv temp /etc/environment
-unset HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy
 # microk8s charm installed by microstack tries to create an alias for kubectl and fails otherwise
 sudo snap remove kubectl
 # Install microstack


### PR DESCRIPTION
### Overview

Revert the removal of proxy vars in the microstack setup.

### Rationale

No longer needed as https://github.com/canonical/github-runner-operator/releases/tag/rev128 is now deployed for two-xlarge runners.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->