### PR TITLE
feat: label config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -42,6 +42,14 @@ options:
     description: |
       The organization runner group to register the self-hosted runner under. This has no effect on
       runners under a repository.
+  labels:
+    type: string
+    default: ""
+    description: |
+      Additional comma separated labels to attach to self-hosted runners. By default, the labels
+      "self-hosted", application name (default: "github-runner"), 
+      architecture (i.e. "x64", "arm64"), os (i.e. "linux"), os-flavor (i.e. "jammy") are set.
+      Any labels provided via this configuration will be appended to the default values.
   path:
     type: string
     default: ""

--- a/docs/how-to/add-custom-labels.md
+++ b/docs/how-to/add-custom-labels.md
@@ -1,0 +1,11 @@
+# How to add custom labels
+
+This charm supports adding custom labels to the runners.
+
+By using [`juju config`](https://juju.is/docs/juju/juju-config) to change the
+[charm configuration labels](https://charmhub.io/github-runner/configure#labels), additional 
+custom labels can be attached to the self-hosted runners.
+
+```shell
+juju config <APP_NAME> labels=<LABELS_CSV>
+```

--- a/docs/how-to/add-custom-labels.md
+++ b/docs/how-to/add-custom-labels.md
@@ -7,5 +7,9 @@ By using [`juju config`](https://juju.is/docs/juju/juju-config) to change the
 custom labels can be attached to the self-hosted runners.
 
 ```shell
-juju config <APP_NAME> labels=<LABELS_CSV>
+juju config <APP_NAME> labels=<COMMA_SEPARATED_LABELS>
 ```
+
+An example of a COMMA_SEPARATED_LABELS value would be "hello,juju", "hello_juju2,hello_juju3".
+Accepted values are alphanumeric values with underscores (_), whitespaces before and after the the
+word will be automatically trimmed.

--- a/docs/how-to/add-custom-labels.md
+++ b/docs/how-to/add-custom-labels.md
@@ -10,6 +10,6 @@ custom labels can be attached to the self-hosted runners.
 juju config <APP_NAME> labels=<COMMA_SEPARATED_LABELS>
 ```
 
-An example of a COMMA_SEPARATED_LABELS value would be "hello,juju", "hello_juju2,hello_juju3".
+An example of a COMMA_SEPARATED_LABELS value would be "large,gpu", "small,arm64".
 Accepted values are alphanumeric values with underscores (_), whitespaces before and after the the
 word will be automatically trimmed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ Thinking about using the GitHub runner charm for your next project? [Get in touc
   1. [ARM64](explanation/arm64.md)
   1. [Charm architecture](explanation/charm-architecture.md)
 1. [How To](how-to)
+  1. [How to add custom labels](how-to/add-custom-labels.md)
   1. [How to change repository or organization](how-to/change-path.md)
   1. [How to change GitHub personal access token](how-to/change-token.md)
   1. [How to comply with security requirements](how-to/comply-security.md)

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -8,11 +8,12 @@ Charm for creating and managing GitHub self-hosted runner instances.
 **Global Variables**
 ---------------
 - **DEBUG_SSH_INTEGRATION_NAME**
+- **LABELS_CONFIG_NAME**
 - **RECONCILE_RUNNERS_EVENT**
 
 ---
 
-<a href="../src/charm.py#L77"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L78"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_charm_errors`
 
@@ -38,7 +39,7 @@ Catch common errors in charm.
 
 ---
 
-<a href="../src/charm.py#L112"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L113"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_action_errors`
 
@@ -67,7 +68,7 @@ Catch common errors in actions.
 ## <kbd>class</kbd> `GithubRunnerCharm`
 Charm for managing GitHub self-hosted runners. 
 
-<a href="../src/charm.py#L157"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L158"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -10,12 +10,13 @@ State of the Charm.
 - **ARCHITECTURES_ARM64**
 - **ARCHITECTURES_X86**
 - **OPENSTACK_CLOUDS_YAML_CONFIG_NAME**
+- **LABELS_CONFIG_NAME**
 - **COS_AGENT_INTEGRATION_NAME**
 - **DEBUG_SSH_INTEGRATION_NAME**
 
 ---
 
-<a href="../src/charm_state.py#L85"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L87"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `parse_github_path`
 
@@ -56,19 +57,20 @@ Some charm configurations are grouped into other configuration models.
 
 **Attributes:**
  
- - <b>`path`</b>:  GitHub repository path in the format '<owner>/<repo>', or the GitHub organization  name. 
- - <b>`token`</b>:  GitHub personal access token for GitHub API. 
- - <b>`reconcile_interval`</b>:  Time between each reconciliation of runners. 
  - <b>`denylist`</b>:  List of IPv4 to block the runners from accessing. 
  - <b>`dockerhub_mirror`</b>:  Private docker registry as dockerhub mirror for the runners to use. 
+ - <b>`labels`</b>:  Additional runner labels to append to default (i.e. os, flavor, architecture). 
  - <b>`openstack_clouds_yaml`</b>:  The openstack clouds.yaml configuration. 
+ - <b>`path`</b>:  GitHub repository path in the format '<owner>/<repo>', or the GitHub organization  name. 
+ - <b>`reconcile_interval`</b>:  Time between each reconciliation of runners. 
+ - <b>`token`</b>:  GitHub personal access token for GitHub API. 
 
 
 
 
 ---
 
-<a href="../src/charm_state.py#L280"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L321"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_fields`
 
@@ -91,7 +93,7 @@ Validate the general charm configuration.
 
 ---
 
-<a href="../src/charm_state.py#L220"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L255"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -124,7 +126,7 @@ Raised when charm config is invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/charm_state.py#L144"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L146"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -164,7 +166,7 @@ The charm state.
 
 ---
 
-<a href="../src/charm_state.py#L573"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L614"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -203,7 +205,7 @@ Represent GitHub organization.
 
 ---
 
-<a href="../src/charm_state.py#L73"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L75"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `path`
 
@@ -236,7 +238,7 @@ Represent GitHub repository.
 
 ---
 
-<a href="../src/charm_state.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L54"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `path`
 
@@ -277,7 +279,7 @@ Return the aproxy address.
 
 ---
 
-<a href="../src/charm_state.py#L440"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L481"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_fields`
 
@@ -300,7 +302,7 @@ Validate the proxy configuration.
 
 ---
 
-<a href="../src/charm_state.py#L402"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L443"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -340,7 +342,7 @@ Runner configurations for the charm.
 
 ---
 
-<a href="../src/charm_state.py#L354"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L395"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_fields`
 
@@ -363,7 +365,7 @@ Validate the runner configuration.
 
 ---
 
-<a href="../src/charm_state.py#L317"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L358"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -413,7 +415,7 @@ SSH connection information for debug workflow.
 
 ---
 
-<a href="../src/charm_state.py#L520"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L561"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -441,7 +443,7 @@ Raised when given machine charm architecture is unsupported.
  
  - <b>`arch`</b>:  The current machine architecture. 
 
-<a href="../src/charm_state.py#L477"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L518"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/runner.py.md
+++ b/src-docs/runner.py.md
@@ -91,7 +91,7 @@ Create the runner instance on LXD and register it on GitHub.
 
 ---
 
-<a href="../src/runner.py#L161"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner.py#L162"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `remove`
 

--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -43,7 +43,7 @@ Construct RunnerManager object for creating and managing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L743"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L744"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `build_runner_image`
 
@@ -80,7 +80,7 @@ Check if runner binary exists.
 
 ---
 
-<a href="../src/runner_manager.py#L581"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L582"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `flush`
 
@@ -145,7 +145,7 @@ The runner binary URL changes when a new version is available.
 
 ---
 
-<a href="../src/runner_manager.py#L476"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L477"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 
@@ -169,7 +169,7 @@ Bring runners in line with target.
 
 ---
 
-<a href="../src/runner_manager.py#L753"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L754"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `schedule_build_runner_image`
 

--- a/src-docs/runner_manager_type.py.md
+++ b/src-docs/runner_manager_type.py.md
@@ -71,13 +71,12 @@ Configuration of runner manager.
 
 **Attributes:**
  
- - <b>`path`</b>:  GitHub repository path in the format '<owner>/<repo>', or the  GitHub organization name. 
- - <b>`token`</b>:  GitHub personal access token to register runner to the  repository or organization. 
- - <b>`image`</b>:  Name of the image for creating LXD instance. 
- - <b>`service_token`</b>:  Token for accessing local service. 
- - <b>`lxd_storage_path`</b>:  Path to be used as LXD storage. 
- - <b>`proxy_config`</b>:  Proxy configuration. 
  - <b>`charm_state`</b>:  The state of the charm. 
+ - <b>`image`</b>:  Name of the image for creating LXD instance. 
+ - <b>`lxd_storage_path`</b>:  Path to be used as LXD storage. 
+ - <b>`path`</b>:  GitHub repository path in the format '<owner>/<repo>', or the  GitHub organization name. 
+ - <b>`service_token`</b>:  Token for accessing local service. 
+ - <b>`token`</b>:  GitHub personal access token to register runner to the  repository or organization. 
  - <b>`dockerhub_mirror`</b>:  URL of dockerhub mirror to use. 
 
 

--- a/src-docs/runner_type.py.md
+++ b/src-docs/runner_type.py.md
@@ -36,6 +36,7 @@ Configuration for runner.
  
  - <b>`app_name`</b>:  Application name of the charm. 
  - <b>`issue_metrics`</b>:  Whether to issue metrics. 
+ - <b>`labels`</b>:  Custom runner labels. 
  - <b>`lxd_storage_path`</b>:  Path to be used as LXD storage. 
  - <b>`name`</b>:  Name of the runner. 
  - <b>`path`</b>:  GitHub repository path in the format '<owner>/<repo>', or the GitHub organization  name. 

--- a/src/charm.py
+++ b/src/charm.py
@@ -325,13 +325,13 @@ class GithubRunnerCharm(CharmBase):
             app_name,
             unit,
             RunnerManagerConfig(
-                path=path,
-                token=token,
-                image="jammy",
-                service_token=self.service_token,
-                lxd_storage_path=lxd_storage_path,
                 charm_state=state,
                 dockerhub_mirror=state.charm_config.dockerhub_mirror,
+                image="jammy",
+                lxd_storage_path=lxd_storage_path,
+                path=path,
+                service_token=self.service_token,
+                token=token,
             ),
         )
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -726,7 +726,7 @@ class Runner:
         if self.instance is None:
             raise RunnerError("Runner operation called prior to runner creation.")
 
-        logger.info("Registering runner %s", self.config.name)
+        logger.info("Registering runner %s, labels: %s", self.config.name, labels)
 
         register_cmd = [
             "/usr/bin/sudo",

--- a/src/runner.py
+++ b/src/runner.py
@@ -152,7 +152,8 @@ class Runner:
             self._configure_runner()
 
             self._register_runner(
-                config.registration_token, labels=[self.config.app_name, config.image]
+                config.registration_token,
+                labels=[self.config.app_name, config.image, *self.config.labels],
             )
             self._start_runner()
         except (RunnerError, LxdError) as err:

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -416,6 +416,7 @@ class RunnerManager:
             app_name=self.app_name,
             dockerhub_mirror=self.config.dockerhub_mirror,
             issue_metrics=self.config.are_metrics_enabled,
+            labels=self.config.charm_state.charm_config.labels,
             lxd_storage_path=self.config.lxd_storage_path,
             path=self.config.path,
             proxies=proxies,

--- a/src/runner_manager_type.py
+++ b/src/runner_manager_type.py
@@ -60,24 +60,23 @@ class RunnerManagerConfig:  # pylint: disable=too-many-instance-attributes
     """Configuration of runner manager.
 
     Attributes:
+        charm_state: The state of the charm.
+        image: Name of the image for creating LXD instance.
+        lxd_storage_path: Path to be used as LXD storage.
         path: GitHub repository path in the format '<owner>/<repo>', or the
             GitHub organization name.
+        service_token: Token for accessing local service.
         token: GitHub personal access token to register runner to the
             repository or organization.
-        image: Name of the image for creating LXD instance.
-        service_token: Token for accessing local service.
-        lxd_storage_path: Path to be used as LXD storage.
-        proxy_config: Proxy configuration.
-        charm_state: The state of the charm.
         dockerhub_mirror: URL of dockerhub mirror to use.
     """
 
-    path: GithubPath
-    token: str
-    image: str
-    service_token: str
-    lxd_storage_path: Path
     charm_state: CharmState
+    image: str
+    lxd_storage_path: Path
+    path: GithubPath
+    service_token: str
+    token: str
     dockerhub_mirror: str | None = None
 
     @property

--- a/src/runner_type.py
+++ b/src/runner_type.py
@@ -37,6 +37,7 @@ class RunnerConfig:  # pylint: disable=too-many-instance-attributes
     Attributes:
         app_name: Application name of the charm.
         issue_metrics: Whether to issue metrics.
+        labels: Custom runner labels.
         lxd_storage_path: Path to be used as LXD storage.
         name: Name of the runner.
         path: GitHub repository path in the format '<owner>/<repo>', or the GitHub organization
@@ -48,6 +49,7 @@ class RunnerConfig:  # pylint: disable=too-many-instance-attributes
 
     app_name: str
     issue_metrics: bool
+    labels: tuple[str]
     lxd_storage_path: Path
     name: str
     path: GithubPath

--- a/tests/integration/test_charm_one_runner.py
+++ b/tests/integration/test_charm_one_runner.py
@@ -248,7 +248,8 @@ async def test_runner_labels(
 
     found = False
     for runner in github_repository.get_self_hosted_runners():
-        if all(label["name"] in test_labels for label in runner.labels()):
+        runner_labels = tuple(label["name"] for label in runner.labels())
+        if all(test_label in runner_labels for test_label in test_labels):
             found = True
 
     assert found, "Runner with testing label not found."

--- a/tests/integration/test_charm_one_runner.py
+++ b/tests/integration/test_charm_one_runner.py
@@ -235,12 +235,12 @@ async def test_runner_labels(
 ) -> None:
     """
     arrange: A working application with one runner.
-    act: Change the token to be invalid and set the number of runners to zero.
-    assert: The active runner should be removed, regardless of the invalid new token.
+    act: Change the runner label.
+    assert: A runner with the testing label is found.
     """
     unit = app.units[0]
 
-    test_labels = ("label_test", "additional_label")
+    test_labels = ("label_test", "additional_label", app.name)
     await app.set_config({"labels": f"{test_labels[0]}, {test_labels[1]}"})
     await model.wait_for_idle()
 

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -103,4 +103,5 @@ class MockGithubRunnerCharmFactory(factory.Factory):
             "dockerhub-mirror": "",
             "runner-storage": "juju-storage",
             "experimental-use-aproxy": False,
+            "labels": "",
         }

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -337,3 +337,48 @@ def test_openstack_config_invalid_format(clouds_yaml: Any, expected_err_msg: str
     with pytest.raises(CharmConfigInvalidError) as exc:
         CharmState.from_charm(mock_charm)
     assert expected_err_msg in str(exc)
+
+
+@pytest.mark.parametrize(
+    "label_str, falsy_labels",
+    [
+        pytest.param("$invalid", ("$invalid",), id="invalid label"),
+        pytest.param("$invalid, valid", ("$invalid",), id="invalid label with valid"),
+        pytest.param(
+            "$invalid, valid, *next", ("$invalid", "*next"), id="invalid labels with valid"
+        ),
+    ],
+)
+def test__parse_labels_invalid_labels(label_str: str, falsy_labels: tuple[str]):
+    """
+    arrange: given labels composed of non-alphanumeric or underscore.
+    act: when _parse_labels is called.
+    assert: ValueError with invalid labels are raised.
+    """
+    with pytest.raises(ValueError) as exc:
+        charm_state._parse_labels(labels=label_str)
+
+    assert all(label in str(exc) for label in falsy_labels)
+
+
+@pytest.mark.parametrize(
+    "label_str, expected_labels",
+    [
+        pytest.param("", tuple(), id="empty"),
+        pytest.param("a", ("a",), id="single label"),
+        pytest.param("a ", ("a",), id="single label with space"),
+        pytest.param("a,b,c", ("a", "b", "c"), id="comma separated labels"),
+        pytest.param(" a, b,   c", ("a", "b", "c"), id="comma separated labels with space"),
+        pytest.param("1234", ("1234",), id="numeric label"),
+        pytest.param("_", ("_",), id="underscore"),
+        pytest.param("_test_", ("_test_",), id="alphabetical with underscore"),
+        pytest.param("_test1234_", ("_test1234_",), id="alphanumeric with underscore"),
+    ],
+)
+def test__parse_labels(label_str: str, expected_labels: tuple[str]):
+    """
+    arrange: given a comma separated label strings.
+    act: when _parse_labels is called.
+    assert: expected labels are returned.
+    """
+    assert charm_state._parse_labels(labels=label_str) == expected_labels

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -469,6 +469,6 @@ def test_random_ssh_connection_choice(
     second_call_args = runner._clients.jinja.get_template("env.j2").render.call_args.kwargs
 
     assert first_call_args["ssh_debug_info"] != second_call_args["ssh_debug_info"], (
-        "Same ssh debug info found, this may have occurred with a very low priority. "
+        "Same ssh debug info found, this may have occurred with a very low probability. "
         "Just try again."
     )

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -139,6 +139,7 @@ def runner_fixture(
         path=request.param[0],
         proxies=request.param[1],
         lxd_storage_path=pool_path,
+        labels=("test", "label"),
         dockerhub_mirror=None,
         issue_metrics=False,
         ssh_debug_connections=ssh_debug_connections,

--- a/tests/unit/test_runner_manager.py
+++ b/tests/unit/test_runner_manager.py
@@ -13,6 +13,7 @@ from _pytest.monkeypatch import MonkeyPatch
 import shared_fs
 from charm_state import (
     Arch,
+    CharmConfig,
     CharmState,
     GithubOrg,
     GithubRepo,
@@ -38,12 +39,21 @@ def token_fixture():
     return secrets.token_hex()
 
 
+@pytest.fixture(scope="function", name="charm_config")
+def charm_config_fixture():
+    """Mock charm config instance."""
+    mock_charm_config = MagicMock(spec=CharmConfig)
+    mock_charm_config.labels = ("test",)
+    return mock_charm_config
+
+
 @pytest.fixture(scope="function", name="charm_state")
-def charm_state_fixture():
+def charm_state_fixture(charm_config: MagicMock):
     mock = MagicMock(spec=CharmState)
     mock.is_metrics_logging_available = False
     mock.arch = Arch.X64
     mock.ssh_debug_connections = None
+    mock.charm_config = charm_config
     return mock
 
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Adds a new `label` configuration option which allows addition of custom labels to the github runner.

### Rationale

This feature lets users define custom labels, such as "gpu" to runners with GPU capabilities. 

### Juju Events Changes

None.

### Module Changes

- `charm_state.py`: adds runner labels parsing.
- `runner_type.py`, `runner_manager.py`: implements label runner configuration value.
- others: sorted arguments alphabetically.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->