### PR TITLE
fix: apt related background service related errors

### DIFF
--- a/scripts/build-lxd-image.sh
+++ b/scripts/build-lxd-image.sh
@@ -99,6 +99,13 @@ retry '/snap/bin/lxc exec builder -- /usr/bin/nslookup github.com' 'Wait for net
 /snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/apt-get install docker.io npm python3-pip shellcheck jq wget unzip gh -yq
 
 # Uninstall unattended-upgrades, to avoid lock errors when unattended-upgrades is active in the runner
+/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/systemctl stop apt-daily.timer
+/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/systemctl disable apt-daily.timer
+/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/systemctl mask apt-daily.service
+/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/systemctl stop apt-daily-upgrade.timer
+/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/systemctl disable apt-daily-upgrade.timer
+/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/systemctl mask apt-daily-upgrade.service
+/snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/systemctl daemon-reload
 /snap/bin/lxc exec builder --env DEBIAN_FRONTEND=noninteractive -- /usr/bin/apt-get purge unattended-upgrades -yq
 
 if [[ -n "$HTTP_PROXY" ]]; then

--- a/scripts/build-openstack-image.sh
+++ b/scripts/build-openstack-image.sh
@@ -146,6 +146,13 @@ DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get install docker.io npm python3-pi
 ln -s /usr/bin/python3 /usr/bin/python
 
 # Uninstall unattended-upgrades, to avoid lock errors when unattended-upgrades is active in the runner
+DEBIAN_FRONTEND=noninteractive /usr/bin/systemctl stop apt-daily.timer
+DEBIAN_FRONTEND=noninteractive /usr/bin/systemctl disable apt-daily.timer
+DEBIAN_FRONTEND=noninteractive /usr/bin/systemctl mask apt-daily.service
+DEBIAN_FRONTEND=noninteractive /usr/bin/systemctl stop apt-daily-upgrade.timer
+DEBIAN_FRONTEND=noninteractive /usr/bin/systemctl disable apt-daily-upgrade.timer
+DEBIAN_FRONTEND=noninteractive /usr/bin/systemctl mask apt-daily-upgrade.service
+DEBIAN_FRONTEND=noninteractive /usr/bin/systemctl daemon-reload
 DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get purge unattended-upgrades -yq
 
 /usr/sbin/useradd -m ubuntu

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -424,51 +424,6 @@ def get_workflow_runs(
             yield run
 
 
-async def _wait_until_runner_is_used_up(runner_name: str, unit: Unit):
-    """Wait until the runner is used up.
-
-    Args:
-        runner_name: The runner name to wait for.
-        unit: The unit which contains the runner.
-    """
-    for _ in range(30):
-        runners = await get_runner_names(unit)
-        if runner_name not in runners:
-            break
-        await sleep(30)
-    else:
-        assert False, "Timeout while waiting for the runner to be used up"
-
-
-async def _assert_workflow_run_conclusion(
-    runner_name: str, conclusion: str, workflow: Workflow, start_time: datetime
-):
-    """Assert that the workflow run has the expected conclusion.
-
-    Args:
-        runner_name: The runner name to assert the workflow run conclusion for.
-        conclusion: The expected workflow run conclusion.
-        workflow: The workflow to assert the workflow run conclusion for.
-        start_time: The start time of the workflow.
-    """
-    log_found = False
-    for run in workflow.get_runs(created=f">={start_time.isoformat()}"):
-        latest_job: WorkflowJob = run.jobs()[0]
-        logs = get_job_logs(job=latest_job)
-
-        if runner_name in logs:
-            log_found = True
-            assert latest_job.conclusion == conclusion, (
-                f"Job {latest_job.name} for {runner_name} expected {conclusion}, "
-                f"got {latest_job.conclusion}"
-            )
-
-    assert log_found, (
-        f"No run with runner({runner_name}) log found for workflow({workflow.name}) "
-        f"starting from {start_time} with conclusion {conclusion}"
-    )
-
-
 def _get_latest_run(
     workflow: Workflow, start_time: datetime, branch: Branch | None = None
 ) -> WorkflowRun | None:

--- a/tests/integration/test_charm_one_runner.py
+++ b/tests/integration/test_charm_one_runner.py
@@ -269,3 +269,24 @@ async def test_token_config_changed_insufficient_perms(
     await model.wait_for_idle()
 
     await wait_till_num_of_runners(unit, num=0)
+
+
+async def test_disabled_apt_daily_upgrades(model: Model, app: Application) -> None:
+    """
+    arrange: Given a github runner running on lxd image.
+    act: When the runner is spawned.
+    assert: No apt related background services are running.
+    """
+    await model.wait_for_idle()
+    unit = app.units[0]
+    await wait_till_num_of_runners(unit, num=1)
+    names = await get_runner_names(unit)
+    assert names, "LXD runners not ready"
+
+    ret_code, stdout = await run_in_lxd_instance(
+        unit, names[0], "sudo systemctl list-units --no-pager"
+    )
+    assert ret_code == 0, "Failed to list systemd units"
+
+    assert "apt-daily" not in stdout  # this also checks for apt-daily-upgrade service
+    assert "unattended-upgrades" not in stdout

--- a/tests/integration/test_charm_one_runner.py
+++ b/tests/integration/test_charm_one_runner.py
@@ -255,22 +255,6 @@ async def test_runner_labels(
     assert found, "Runner with testing label not found."
 
 
-async def test_token_config_changed_insufficient_perms(
-    model: Model, app: Application, token: str
-) -> None:
-    """
-    arrange: A working application with one runner.
-    act: Change the token to be invalid and set the number of runners to zero.
-    assert: The active runner should be removed, regardless of the invalid new token.
-    """
-    unit = app.units[0]
-
-    await app.set_config({"token": "invalid-token", "virtual-machines": "0"})
-    await model.wait_for_idle()
-
-    await wait_till_num_of_runners(unit, num=0)
-
-
 async def test_disabled_apt_daily_upgrades(model: Model, app: Application) -> None:
     """
     arrange: Given a github runner running on lxd image.
@@ -291,3 +275,19 @@ async def test_disabled_apt_daily_upgrades(model: Model, app: Application) -> No
 
     assert "apt-daily" not in stdout  # this also checks for apt-daily-upgrade service
     assert "unattended-upgrades" not in stdout
+
+
+async def test_token_config_changed_insufficient_perms(
+    model: Model, app: Application, token: str
+) -> None:
+    """
+    arrange: A working application with one runner.
+    act: Change the token to be invalid and set the number of runners to zero.
+    assert: The active runner should be removed, regardless of the invalid new token.
+    """
+    unit = app.units[0]
+
+    await app.set_config({"token": "invalid-token", "virtual-machines": "0"})
+    await model.wait_for_idle()
+
+    await wait_till_num_of_runners(unit, num=0)

--- a/tests/integration/test_charm_one_runner.py
+++ b/tests/integration/test_charm_one_runner.py
@@ -287,6 +287,7 @@ async def test_disabled_apt_daily_upgrades(model: Model, app: Application) -> No
         unit, names[0], "sudo systemctl list-units --no-pager"
     )
     assert ret_code == 0, "Failed to list systemd units"
+    assert stdout, "No units listed in stdout"
 
     assert "apt-daily" not in stdout  # this also checks for apt-daily-upgrade service
     assert "unattended-upgrades" not in stdout


### PR DESCRIPTION
Applicable spec: N/A

### Overview

The apt related background services makes user workload fail when involving usage of apt.
This removes automated apt related services to prevent it from happening.

### Rationale

To not fail users workflows.

### Juju Events Changes

None.

### Module Changes

Image build scripts now disable apt-daily.timer, apt-daily.service, apt-daily-upgrade.timer, apt-daily-upgrade.service.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->