### PR TITLE
hotfix: support dash label

### DIFF
--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -166,7 +166,7 @@ def _valid_storage_size_str(size: str) -> bool:
     return size[-3:] in valid_suffixes and size[:-3].isdigit()
 
 
-WORD_ONLY_REGEX = re.compile("^\\w+$")
+WORD_ONLY_REGEX = re.compile("^[\\w\\-]+$")
 
 
 def _parse_labels(labels: str) -> tuple[str, ...]:

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -371,8 +371,14 @@ def test__parse_labels_invalid_labels(label_str: str, falsy_labels: tuple[str]):
         pytest.param(" a, b,   c", ("a", "b", "c"), id="comma separated labels with space"),
         pytest.param("1234", ("1234",), id="numeric label"),
         pytest.param("_", ("_",), id="underscore"),
+        pytest.param("-", ("-",), id="dash only"),
         pytest.param("_test_", ("_test_",), id="alphabetical with underscore"),
         pytest.param("_test1234_", ("_test1234_",), id="alphanumeric with underscore"),
+        pytest.param("x-large", ("x-large",), id="dash word"),
+        pytest.param("x-large, two-xlarge", ("x-large", "two-xlarge"), id="dash words"),
+        pytest.param(
+            "x-large_1, two-xlarge", ("x-large_1", "two-xlarge"), id="dash underscore words"
+        ),
     ],
 )
 def test__parse_labels(label_str: str, expected_labels: tuple[str]):


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Supports dash char to labels

### Rationale

To support labels like two-xlarge

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->