### PR TITLE
chore: e2e test support noble w/ pipx

### DIFF
--- a/.github/workflows/e2e_test_run.yaml
+++ b/.github/workflows/e2e_test_run.yaml
@@ -73,8 +73,12 @@ jobs:
         run: jq --version
       - name: yq version
         run: yq --version
+      - name: apt update
+        run: sudo apt-get update -y
+      - name: install pipx
+        run: sudo apt-get install -y pipx
       - name: install check-jsonschema
-        run: python3 -m pip install check-jsonschema
+        run: python3 -m pip install check-jsonschema || pipx install check-jsonschema
       - name: unzip version
         run: unzip -v
       - name: gh version

--- a/.github/workflows/e2e_test_run.yaml
+++ b/.github/workflows/e2e_test_run.yaml
@@ -75,6 +75,7 @@ jobs:
         run: yq --version
       - name: apt update
         run: sudo apt-get update -y
+      # Use pipx for 24.04 noble, check-jsonschema breaks OS system packages.
       - name: install pipx
         run: sudo apt-get install -y pipx
       - name: install check-jsonschema
@@ -84,6 +85,7 @@ jobs:
       - name: gh version
         run: gh --version
       # `check-jsonschema` is installed using pip. The directory `~/.local/bin` needs to be added to PATH.
+      # ~/.local/bin is added to path runner env through in scripts/env.j2
       - name: test check-jsonschema
         run: check-jsonschema --version
       - name: Test Firewall


### PR DESCRIPTION
Applicable spec: N/A

### Overview

The check-jsonschema python package to be installed through pipx.

### Rationale

jsonschema package is managed by the system, installing it via pip will break system dependencies.
See: https://github.com/canonical/github-runner-operator/actions/runs/8641202182/job/23690331747#step:22:1

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->