### PR TITLE
Add external access reference

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,7 @@ Thinking about using the GitHub runner charm for your next project? [Get in touc
   1. [ARM64](reference/arm64.md)
   1. [Configurations](reference/configurations.md)
   1. [COS Integration](reference/cos.md)
+  1. [External Access](reference/external-access.md)
 1. [Tutorial](tutorial)
   1. [Managing resource usage](tutorial/managing-resource-usage.md)
   1. [Quick start](tutorial/quick-start.md)

--- a/docs/reference/external-access.md
+++ b/docs/reference/external-access.md
@@ -1,0 +1,16 @@
+# External Access
+
+The GitHub Runner Charm itself requires access to the
+
+- GitHub API (e.g. to register and remove runners).
+- GitHub website (e.g. to download the runner binary or other applications like yq)
+- Ubuntu package repositories (e.g. to install packages)
+- Snap store (e.g. to install LXD or aproxy)
+- [Ubuntu Cloud Images](https://cloud-images.ubuntu.com/) (for the image used by a runner)
+- npm registry to download and install specific packages
+
+In addition, access is required depending on the requirements of the workloads that the runners
+will be running (as they will be running on the same machine as the charm).
+
+More details on network configuration can be found in the
+[charm architecture documentation](https://charmhub.io/github-runner/docs/charm-architecture).


### PR DESCRIPTION
### Overview

Add external access reference.

### Rationale

So that the user deploying the charm can configure the firewall/proxy accordingly.


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->