### PR TITLE
fix: aproxy noble message

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -628,7 +628,7 @@ class Runner:
         if (
             exit_code != 0
             or "Started Service for snap application aproxy.aproxy" not in stdout_message
-            or "Service for snap application aproxy.aproxy" not in stdout_message
+            or "Started snap.aproxy.aproxy.service" not in stdout_message
         ):
             raise RunnerAproxyError("Aproxy service did not configure correctly")
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -624,10 +624,11 @@ class Runner:
             ["snap", "set", "aproxy", f"proxy={proxy_address}", f"listen=:{aproxy_port}"]
         )
         exit_code, stdout, _ = self.instance.execute(["snap", "logs", "aproxy.aproxy", "-n=all"])
+        stdout_message = stdout.read().decode("utf-8")
         if (
             exit_code != 0
-            or "Started Service for snap application aproxy.aproxy"
-            not in stdout.read().decode("utf-8")
+            or "Started Service for snap application aproxy.aproxy" not in stdout_message
+            or "Service for snap application aproxy.aproxy" not in stdout_message
         ):
             raise RunnerAproxyError("Aproxy service did not configure correctly")
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -625,10 +625,9 @@ class Runner:
         )
         exit_code, stdout, _ = self.instance.execute(["snap", "logs", "aproxy.aproxy", "-n=all"])
         stdout_message = stdout.read().decode("utf-8")
-        if (
-            exit_code != 0
-            or "Started Service for snap application aproxy.aproxy" not in stdout_message
-            or "Started snap.aproxy.aproxy.service" not in stdout_message
+        if exit_code != 0 or (
+            "Started Service for snap application aproxy.aproxy" not in stdout_message
+            and "Started snap.aproxy.aproxy.service" not in stdout_message
         ):
             raise RunnerAproxyError("Aproxy service did not configure correctly")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -543,7 +543,7 @@ async def app_with_grafana_agent_integrated_fixture(
     model: Model, app_no_runner: Application
 ) -> AsyncIterator[Application]:
     """Setup the charm to be integrated with grafana-agent using the cos-agent integration."""
-    grafana_agent = await model.deploy("grafana-agent", channel="latest/edge")
+    grafana_agent = await model.deploy("grafana-agent", channel="latest/edge", revision=105)
     await model.relate(f"{app_no_runner.name}:cos-agent", f"{grafana_agent.name}:cos-agent")
     await model.wait_for_idle(apps=[app_no_runner.name], status=ACTIVE)
     await model.wait_for_idle(apps=[grafana_agent.name])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -545,7 +545,12 @@ async def app_with_grafana_agent_integrated_fixture(
     """Setup the charm to be integrated with grafana-agent using the cos-agent integration."""
     # Pin grafana agent revisions since the recent releases are not compatible with juju 2.9
     # (due to usage of juju secrets)
-    grafana_agent = await model.deploy("grafana-agent", channel="latest/edge", revision=105)
+    grafana_agent = await model.deploy(
+        "grafana-agent",
+        channel="latest/edge",
+        revision=105,
+        series="jammy",
+    )
     await model.relate(f"{app_no_runner.name}:cos-agent", f"{grafana_agent.name}:cos-agent")
     await model.wait_for_idle(apps=[app_no_runner.name], status=ACTIVE)
     await model.wait_for_idle(apps=[grafana_agent.name])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -543,6 +543,8 @@ async def app_with_grafana_agent_integrated_fixture(
     model: Model, app_no_runner: Application
 ) -> AsyncIterator[Application]:
     """Setup the charm to be integrated with grafana-agent using the cos-agent integration."""
+    # Pin grafana agent revisions since the recent releases are not compatible with juju 2.9
+    # (due to usage of juju secrets)
     grafana_agent = await model.deploy("grafana-agent", channel="latest/edge", revision=105)
     await model.relate(f"{app_no_runner.name}:cos-agent", f"{grafana_agent.name}:cos-agent")
     await model.wait_for_idle(apps=[app_no_runner.name], status=ACTIVE)

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,9 @@ description = Run integration tests
 pass_env =
     PYTEST_ADDOPTS
 deps =
-    pytest
+    # Pin pytest version until the following issue is resolved.
+    # https://github.com/charmed-kubernetes/pytest-operator/issues/131
+    pytest==8.1.1
     juju3.2: juju==3.2.*
     juju3.1: juju==3.1.*
     juju2.9: juju==2.9.*


### PR DESCRIPTION
Applicable spec: None

### Overview

Fixes the bug with noble aproxy snap message output being different:
Jammy: `Started Service for snap application aproxy.aproxy`
Noble: `Started snap.aproxy.aproxy.service - Service for snap application aproxy.aproxy.`

### Rationale

To support aproxy with Noble.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->