### PR TITLE
Repo-policy-compliance checks for OpenStack

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,8 +1,6 @@
 name: integration-tests
 
 on:
-  # TODO: Re-enable
-  # pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,6 +1,7 @@
 name: integration-tests
 
 on:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,7 +1,6 @@
 name: integration-tests
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,6 +1,8 @@
 name: integration-tests
 
 on:
+  # TODO: Re-enable
+  # pull_request:
   workflow_dispatch:
 
 jobs:

--- a/config.yaml
+++ b/config.yaml
@@ -86,6 +86,20 @@ options:
       random delay of 25% is added. Changes to this time interval will apply when next interval is
       triggered. Prior to reconciliation, any packages, and services used by the software will be
       updated.
+  repo-policy-compliance-url:
+    type: string
+    default: ""
+    description: >-
+      The URL to the repository-policy-compliance service. This option requires the 
+      repo-policy-compliance-token to be set. If not set, the repository-policy-compliance service
+      will not be used.
+  repo-policy-compliance-token:
+    type: string
+    default: ""
+    description: >-
+      The token to authenticate with the repository-policy-compliance service in order to 
+      generate one-time-tokens. This option requires the repo-policy-compliance-url to be set.
+      If not set, the repository-policy-compliance service will not be used.
   runner-storage:
     type: string
     default: "juju-storage"

--- a/config.yaml
+++ b/config.yaml
@@ -97,7 +97,7 @@ options:
     description: >-
       The URL to the repository-policy-compliance service. This option requires the 
       repo-policy-compliance-token to be set. If not set, the repository-policy-compliance service
-      will not be used. This option is currently only effective when using OpenStack Cloud.
+      will not be used. This option is only supported when using OpenStack Cloud.
   runner-storage:
     type: string
     default: "juju-storage"

--- a/config.yaml
+++ b/config.yaml
@@ -86,20 +86,18 @@ options:
       random delay of 25% is added. Changes to this time interval will apply when next interval is
       triggered. Prior to reconciliation, any packages, and services used by the software will be
       updated.
-  repo-policy-compliance-url:
-    type: string
-    default: ""
-    description: >-
-      The URL to the repository-policy-compliance service. This option requires the 
-      repo-policy-compliance-token to be set. If not set, the repository-policy-compliance service
-      will not be used.
   repo-policy-compliance-token:
     type: string
-    default: ""
     description: >-
       The token to authenticate with the repository-policy-compliance service in order to 
       generate one-time-tokens. This option requires the repo-policy-compliance-url to be set.
       If not set, the repository-policy-compliance service will not be used.
+  repo-policy-compliance-url:
+    type: string
+    description: >-
+      The URL to the repository-policy-compliance service. This option requires the 
+      repo-policy-compliance-token to be set. If not set, the repository-policy-compliance service
+      will not be used.
   runner-storage:
     type: string
     default: "juju-storage"

--- a/config.yaml
+++ b/config.yaml
@@ -13,9 +13,9 @@ options:
     type: string
     default: ""
     description: >-
-      The private docker registry configured as dockerhub mirror to be used by the runners. If set
-      a message will be displayed prior to job execution on self-hosted runner informing users to
-      use the provided registry.
+      The URL to the private docker registry configured as the dockerhub mirror to be used by the 
+      runners. If set a message will be displayed prior to job execution on self-hosted runner 
+      informing users to use the provided registry. You must use https:// as the protocol.
   experimental-openstack-clouds-yaml:
     type: string
     default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -97,7 +97,7 @@ options:
     description: >-
       The URL to the repository-policy-compliance service. This option requires the 
       repo-policy-compliance-token to be set. If not set, the repository-policy-compliance service
-      will not be used.
+      will not be used. This option is currently only effective when using OpenStack Cloud.
   runner-storage:
     type: string
     default: "juju-storage"

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -104,7 +104,7 @@ Some charm configurations are grouped into other configuration models.
 
 ---
 
-<a href="../src/charm_state.py#L485"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L489"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_reconcile_interval`
 
@@ -214,7 +214,7 @@ The charm state.
 
 ---
 
-<a href="../src/charm_state.py#L935"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L939"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -387,7 +387,7 @@ Runner configurations for local LXD instances.
 
 ---
 
-<a href="../src/charm_state.py#L676"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L680"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_virtual_machine_resources`
 
@@ -418,7 +418,7 @@ Validate the virtual_machine_resources field values.
 
 ---
 
-<a href="../src/charm_state.py#L654"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L658"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_virtual_machines`
 
@@ -447,7 +447,7 @@ Validate the virtual machines configuration value.
 
 ---
 
-<a href="../src/charm_state.py#L607"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L611"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -494,7 +494,7 @@ Runner configuration for OpenStack Instances.
 
 ---
 
-<a href="../src/charm_state.py#L528"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L532"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -548,7 +548,7 @@ Return the aproxy address.
 
 ---
 
-<a href="../src/charm_state.py#L766"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L770"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_use_aproxy`
 
@@ -578,7 +578,7 @@ Validate the proxy configuration.
 
 ---
 
-<a href="../src/charm_state.py#L728"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L732"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -680,7 +680,7 @@ SSH connection information for debug workflow.
 
 ---
 
-<a href="../src/charm_state.py#L854"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L858"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -713,7 +713,7 @@ Raised when given machine charm architecture is unsupported.
  
  - <b>`arch`</b>:  The current machine architecture. 
 
-<a href="../src/charm_state.py#L811"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L815"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -34,7 +34,7 @@ State of the Charm.
 
 ---
 
-<a href="../src/charm_state.py#L106"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `parse_github_path`
 
@@ -61,6 +61,21 @@ Parse GitHub path.
 
 **Returns:**
  GithubPath object representing the GitHub repository, or the GitHub organization with runner group information. 
+
+
+---
+
+## <kbd>class</kbd> `AnyHttpsUrl`
+Represents an HTTPS URL. 
+
+
+
+**Attributes:**
+ 
+ - <b>`allowed_schemes`</b>:  Allowed schemes for the URL. 
+
+
+
 
 
 ---
@@ -104,7 +119,7 @@ Some charm configurations are grouped into other configuration models.
 
 ---
 
-<a href="../src/charm_state.py#L489"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L469"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_reconcile_interval`
 
@@ -133,7 +148,7 @@ Validate the general charm configuration.
 
 ---
 
-<a href="../src/charm_state.py#L434"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L413"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -172,7 +187,7 @@ Raised when charm config is invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/charm_state.py#L230"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L239"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -214,7 +229,7 @@ The charm state.
 
 ---
 
-<a href="../src/charm_state.py#L939"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L919"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -259,7 +274,7 @@ Charm configuration related to GitHub.
 
 ---
 
-<a href="../src/charm_state.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L151"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -304,7 +319,7 @@ Represent GitHub organization.
 
 ---
 
-<a href="../src/charm_state.py#L94"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `path`
 
@@ -337,7 +352,7 @@ Represent GitHub repository.
 
 ---
 
-<a href="../src/charm_state.py#L73"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L82"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `path`
 
@@ -387,7 +402,7 @@ Runner configurations for local LXD instances.
 
 ---
 
-<a href="../src/charm_state.py#L680"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L660"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_virtual_machine_resources`
 
@@ -418,7 +433,7 @@ Validate the virtual_machine_resources field values.
 
 ---
 
-<a href="../src/charm_state.py#L658"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L638"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_virtual_machines`
 
@@ -447,7 +462,7 @@ Validate the virtual machines configuration value.
 
 ---
 
-<a href="../src/charm_state.py#L611"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L591"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -494,7 +509,7 @@ Runner configuration for OpenStack Instances.
 
 ---
 
-<a href="../src/charm_state.py#L532"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L512"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -548,7 +563,7 @@ Return the aproxy address.
 
 ---
 
-<a href="../src/charm_state.py#L770"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L750"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_use_aproxy`
 
@@ -578,7 +593,7 @@ Validate the proxy configuration.
 
 ---
 
-<a href="../src/charm_state.py#L732"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L712"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -617,7 +632,7 @@ Configuration for the repo policy compliance service.
 
 ---
 
-<a href="../src/charm_state.py#L296"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L305"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -680,7 +695,7 @@ SSH connection information for debug workflow.
 
 ---
 
-<a href="../src/charm_state.py#L858"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L838"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -713,7 +728,7 @@ Raised when given machine charm architecture is unsupported.
  
  - <b>`arch`</b>:  The current machine architecture. 
 
-<a href="../src/charm_state.py#L815"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L795"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -34,7 +34,7 @@ State of the Charm.
 
 ---
 
-<a href="../src/charm_state.py#L105"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L106"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `parse_github_path`
 
@@ -104,7 +104,7 @@ Some charm configurations are grouped into other configuration models.
 
 ---
 
-<a href="../src/charm_state.py#L483"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L485"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_reconcile_interval`
 
@@ -133,7 +133,7 @@ Validate the general charm configuration.
 
 ---
 
-<a href="../src/charm_state.py#L433"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L434"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -172,7 +172,7 @@ Raised when charm config is invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/charm_state.py#L229"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L230"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -214,7 +214,7 @@ The charm state.
 
 ---
 
-<a href="../src/charm_state.py#L933"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L935"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -259,7 +259,7 @@ Charm configuration related to GitHub.
 
 ---
 
-<a href="../src/charm_state.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -304,7 +304,7 @@ Represent GitHub organization.
 
 ---
 
-<a href="../src/charm_state.py#L93"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L94"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `path`
 
@@ -337,7 +337,7 @@ Represent GitHub repository.
 
 ---
 
-<a href="../src/charm_state.py#L72"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L73"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `path`
 
@@ -387,7 +387,7 @@ Runner configurations for local LXD instances.
 
 ---
 
-<a href="../src/charm_state.py#L674"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L676"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_virtual_machine_resources`
 
@@ -418,7 +418,7 @@ Validate the virtual_machine_resources field values.
 
 ---
 
-<a href="../src/charm_state.py#L652"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L654"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_virtual_machines`
 
@@ -447,7 +447,7 @@ Validate the virtual machines configuration value.
 
 ---
 
-<a href="../src/charm_state.py#L605"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L607"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -494,7 +494,7 @@ Runner configuration for OpenStack Instances.
 
 ---
 
-<a href="../src/charm_state.py#L526"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L528"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -548,7 +548,7 @@ Return the aproxy address.
 
 ---
 
-<a href="../src/charm_state.py#L764"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L766"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_use_aproxy`
 
@@ -578,7 +578,7 @@ Validate the proxy configuration.
 
 ---
 
-<a href="../src/charm_state.py#L726"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L728"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -617,7 +617,7 @@ Configuration for the repo policy compliance service.
 
 ---
 
-<a href="../src/charm_state.py#L295"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L296"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -680,7 +680,7 @@ SSH connection information for debug workflow.
 
 ---
 
-<a href="../src/charm_state.py#L852"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L854"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -713,7 +713,7 @@ Raised when given machine charm architecture is unsupported.
  
  - <b>`arch`</b>:  The current machine architecture. 
 
-<a href="../src/charm_state.py#L809"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L811"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -19,6 +19,8 @@ State of the Charm.
 - **OPENSTACK_IMAGE_BUILD_UNIT_CONFIG_NAME**
 - **PATH_CONFIG_NAME**
 - **RECONCILE_INTERVAL_CONFIG_NAME**
+- **REPO_POLICY_COMPLIANCE_TOKEN_CONFIG_NAME**
+- **REPO_POLICY_COMPLIANCE_URL_CONFIG_NAME**
 - **RUNNER_STORAGE_CONFIG_NAME**
 - **TEST_MODE_CONFIG_NAME**
 - **TOKEN_CONFIG_NAME**
@@ -32,7 +34,7 @@ State of the Charm.
 
 ---
 
-<a href="../src/charm_state.py#L103"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L105"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `parse_github_path`
 
@@ -94,6 +96,7 @@ Some charm configurations are grouped into other configuration models.
  - <b>`openstack_clouds_yaml`</b>:  The openstack clouds.yaml configuration. 
  - <b>`path`</b>:  GitHub repository path in the format '<owner>/<repo>', or the GitHub organization  name. 
  - <b>`reconcile_interval`</b>:  Time between each reconciliation of runners in minutes. 
+ - <b>`repo_policy_compliance`</b>:  Configuration for the repo policy compliance service. 
  - <b>`token`</b>:  GitHub personal access token for GitHub API. 
 
 
@@ -101,7 +104,7 @@ Some charm configurations are grouped into other configuration models.
 
 ---
 
-<a href="../src/charm_state.py#L433"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L482"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_reconcile_interval`
 
@@ -130,7 +133,7 @@ Validate the general charm configuration.
 
 ---
 
-<a href="../src/charm_state.py#L389"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L432"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -169,7 +172,7 @@ Raised when charm config is invalid.
  
  - <b>`msg`</b>:  Explanation of the error. 
 
-<a href="../src/charm_state.py#L227"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L229"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -211,7 +214,7 @@ The charm state.
 
 ---
 
-<a href="../src/charm_state.py#L879"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L928"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -256,7 +259,7 @@ Charm configuration related to GitHub.
 
 ---
 
-<a href="../src/charm_state.py#L139"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -301,7 +304,7 @@ Represent GitHub organization.
 
 ---
 
-<a href="../src/charm_state.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L93"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `path`
 
@@ -334,7 +337,7 @@ Represent GitHub repository.
 
 ---
 
-<a href="../src/charm_state.py#L70"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L72"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `path`
 
@@ -384,7 +387,7 @@ Runner configurations for local LXD instances.
 
 ---
 
-<a href="../src/charm_state.py#L622"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L671"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_virtual_machine_resources`
 
@@ -415,7 +418,7 @@ Validate the virtual_machine_resources field values.
 
 ---
 
-<a href="../src/charm_state.py#L600"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L649"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_virtual_machines`
 
@@ -444,7 +447,7 @@ Validate the virtual machines configuration value.
 
 ---
 
-<a href="../src/charm_state.py#L555"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L604"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -491,7 +494,7 @@ Runner configuration for OpenStack Instances.
 
 ---
 
-<a href="../src/charm_state.py#L476"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L525"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -545,7 +548,7 @@ Return the aproxy address.
 
 ---
 
-<a href="../src/charm_state.py#L712"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L761"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_use_aproxy`
 
@@ -575,7 +578,7 @@ Validate the proxy configuration.
 
 ---
 
-<a href="../src/charm_state.py#L674"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L723"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -595,6 +598,51 @@ Initialize the proxy config from charm.
 
 **Returns:**
  Current proxy config of the charm. 
+
+
+---
+
+## <kbd>class</kbd> `RepoPolicyComplianceConfig`
+Configuration for the repo policy compliance service. 
+
+
+
+**Attributes:**
+ 
+ - <b>`token`</b>:  Token for the repo policy compliance service. 
+ - <b>`url`</b>:  URL of the repo policy compliance service. 
+
+
+
+
+---
+
+<a href="../src/charm_state.py#L295"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>classmethod</kbd> `from_charm`
+
+```python
+from_charm(charm: CharmBase) → RepoPolicyComplianceConfig
+```
+
+Initialize the config from charm. 
+
+
+
+**Args:**
+ 
+ - <b>`charm`</b>:  The charm instance. 
+
+
+
+**Raises:**
+ 
+ - <b>`CharmConfigInvalidError`</b>:  If an invalid configuration was set. 
+
+
+
+**Returns:**
+ Current repo-policy-compliance config. 
 
 
 ---
@@ -632,7 +680,7 @@ SSH connection information for debug workflow.
 
 ---
 
-<a href="../src/charm_state.py#L800"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L849"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -665,7 +713,7 @@ Raised when given machine charm architecture is unsupported.
  
  - <b>`arch`</b>:  The current machine architecture. 
 
-<a href="../src/charm_state.py#L757"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L806"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -104,7 +104,7 @@ Some charm configurations are grouped into other configuration models.
 
 ---
 
-<a href="../src/charm_state.py#L482"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L483"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_reconcile_interval`
 
@@ -133,7 +133,7 @@ Validate the general charm configuration.
 
 ---
 
-<a href="../src/charm_state.py#L432"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L433"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -214,7 +214,7 @@ The charm state.
 
 ---
 
-<a href="../src/charm_state.py#L928"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L933"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -387,7 +387,7 @@ Runner configurations for local LXD instances.
 
 ---
 
-<a href="../src/charm_state.py#L671"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L674"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_virtual_machine_resources`
 
@@ -418,7 +418,7 @@ Validate the virtual_machine_resources field values.
 
 ---
 
-<a href="../src/charm_state.py#L649"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L652"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_virtual_machines`
 
@@ -447,7 +447,7 @@ Validate the virtual machines configuration value.
 
 ---
 
-<a href="../src/charm_state.py#L604"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L605"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -494,7 +494,7 @@ Runner configuration for OpenStack Instances.
 
 ---
 
-<a href="../src/charm_state.py#L525"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L526"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -548,7 +548,7 @@ Return the aproxy address.
 
 ---
 
-<a href="../src/charm_state.py#L761"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L764"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `check_use_aproxy`
 
@@ -578,7 +578,7 @@ Validate the proxy configuration.
 
 ---
 
-<a href="../src/charm_state.py#L723"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L726"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -680,7 +680,7 @@ SSH connection information for debug workflow.
 
 ---
 
-<a href="../src/charm_state.py#L849"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L852"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -713,7 +713,7 @@ Raised when given machine charm architecture is unsupported.
  
  - <b>`arch`</b>:  The current machine architecture. 
 
-<a href="../src/charm_state.py#L806"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L809"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -16,7 +16,7 @@ Module for handling interactions with OpenStack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L341"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L342"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `build_image`
 
@@ -56,7 +56,7 @@ Build and upload an image to OpenStack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L400"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L401"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `create_instance_config`
 
@@ -92,7 +92,7 @@ Create an instance config from charm data.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L114"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `InstanceConfig`
 The configuration values for creating a single runner instance. 
@@ -131,7 +131,7 @@ __init__(
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L189"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `ProxyStringValues`
 Wrapper class to proxy values to string. 
@@ -150,7 +150,7 @@ Wrapper class to proxy values to string.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L297"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L298"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackUpdateImageError`
 Represents an error while updating image on Openstack. 
@@ -161,7 +161,7 @@ Represents an error while updating image on Openstack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L494"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L495"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GithubRunnerRemoveError`
 Represents an error removing registered runner from Github. 
@@ -172,7 +172,7 @@ Represents an error removing registered runner from Github.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L502"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L503"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackRunnerManager`
 Runner manager for OpenStack-based instances. 
@@ -185,7 +185,7 @@ Runner manager for OpenStack-based instances.
  - <b>`unit_num`</b>:  The juju unit number. 
  - <b>`instance_name`</b>:  Prefix of the name for the set of runners. 
 
-<a href="../src/openstack_cloud/openstack_manager.py#L511"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L512"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1239"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1257"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -231,7 +231,7 @@ Flush Openstack servers.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L822"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L837"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_github_runner_info`
 
@@ -248,7 +248,7 @@ Get information on GitHub for the runners.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1145"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1160"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -16,7 +16,7 @@ Module for handling interactions with OpenStack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L342"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L343"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `build_image`
 
@@ -56,7 +56,7 @@ Build and upload an image to OpenStack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L401"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L402"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `create_instance_config`
 
@@ -92,7 +92,7 @@ Create an instance config from charm data.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L116"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `InstanceConfig`
 The configuration values for creating a single runner instance. 
@@ -131,7 +131,7 @@ __init__(
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L191"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `ProxyStringValues`
 Wrapper class to proxy values to string. 
@@ -150,7 +150,7 @@ Wrapper class to proxy values to string.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L298"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L299"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackUpdateImageError`
 Represents an error while updating image on Openstack. 
@@ -161,7 +161,7 @@ Represents an error while updating image on Openstack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L495"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L496"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GithubRunnerRemoveError`
 Represents an error removing registered runner from Github. 
@@ -172,7 +172,7 @@ Represents an error removing registered runner from Github.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L503"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L504"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackRunnerManager`
 Runner manager for OpenStack-based instances. 
@@ -185,7 +185,7 @@ Runner manager for OpenStack-based instances.
  - <b>`unit_num`</b>:  The juju unit number. 
  - <b>`instance_name`</b>:  Prefix of the name for the set of runners. 
 
-<a href="../src/openstack_cloud/openstack_manager.py#L512"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L513"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1257"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1276"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -231,7 +231,7 @@ Flush Openstack servers.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L837"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L856"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_github_runner_info`
 
@@ -248,7 +248,7 @@ Get information on GitHub for the runners.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1160"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1179"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src-docs/repo_policy_compliance_client.py.md
+++ b/src-docs/repo_policy_compliance_client.py.md
@@ -19,12 +19,12 @@ Client for repo policy compliance service.
  - <b>`base_url`</b>:  Base url to the repo policy compliance service. 
  - <b>`token`</b>:  Charm token configured for the repo policy compliance service. 
 
-<a href="../src/repo_policy_compliance_client.py#L23"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/repo_policy_compliance_client.py#L24"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
 ```python
-__init__(session: Session, url: str, charm_token: str) → None
+__init__(url: str, charm_token: str) → None
 ```
 
 Construct the RepoPolicyComplianceClient. 
@@ -33,7 +33,6 @@ Construct the RepoPolicyComplianceClient.
 
 **Args:**
  
- - <b>`session`</b>:  The request Session object for making HTTP requests. 
  - <b>`url`</b>:  Base URL to the repo policy compliance service. 
  - <b>`charm_token`</b>:  Charm token configured for the repo policy compliance service. 
 

--- a/src-docs/runner_manager.py.md
+++ b/src-docs/runner_manager.py.md
@@ -50,7 +50,7 @@ Construct RunnerManager object for creating and managing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L799"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L789"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `build_runner_image`
 
@@ -70,7 +70,7 @@ Build container image in test mode, else virtual machine image.
 
 ---
 
-<a href="../src/runner_manager.py#L121"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L111"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `check_runner_bin`
 
@@ -87,7 +87,7 @@ Check if runner binary exists.
 
 ---
 
-<a href="../src/runner_manager.py#L611"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L601"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `flush`
 
@@ -116,7 +116,7 @@ Remove existing runners.
 
 ---
 
-<a href="../src/runner_manager.py#L222"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L212"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_github_info`
 
@@ -133,7 +133,7 @@ Get information on the runners from GitHub.
 
 ---
 
-<a href="../src/utilities.py#L129"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/utilities.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `get_latest_runner_bin_url`
 
@@ -164,7 +164,7 @@ The runner binary URL changes when a new version is available.
 
 ---
 
-<a href="../src/runner_manager.py#L791"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L781"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `has_runner_image`
 
@@ -181,7 +181,7 @@ Check if the runner image exists.
 
 ---
 
-<a href="../src/runner_manager.py#L529"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L519"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 
@@ -205,7 +205,7 @@ Bring runners in line with target.
 
 ---
 
-<a href="../src/runner_manager.py#L813"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/runner_manager.py#L803"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `schedule_build_runner_image`
 
@@ -217,7 +217,7 @@ Install cron job for building runner image.
 
 ---
 
-<a href="../src/utilities.py#L152"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/utilities.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `update_runner_bin`
 

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -40,7 +40,8 @@ OPENSTACK_FLAVOR_CONFIG_NAME = "experimental-openstack-flavor"
 OPENSTACK_IMAGE_BUILD_UNIT_CONFIG_NAME = "experiential-openstack-image-build-unit"
 PATH_CONFIG_NAME = "path"
 RECONCILE_INTERVAL_CONFIG_NAME = "reconcile-interval"
-REPO_POLICY_COMPLIANCE_TOKEN_CONFIG_NAME = "repo-policy-compliance-token"
+# bandit thinks this is a hardcoded password
+REPO_POLICY_COMPLIANCE_TOKEN_CONFIG_NAME = "repo-policy-compliance-token"  # nosec
 REPO_POLICY_COMPLIANCE_URL_CONFIG_NAME = "repo-policy-compliance-url"
 RUNNER_STORAGE_CONFIG_NAME = "runner-storage"
 TEST_MODE_CONFIG_NAME = "test-mode"
@@ -464,6 +465,7 @@ class CharmConfig(BaseModel):
         except ValueError as exc:
             raise CharmConfigInvalidError(f"Invalid {LABELS_CONFIG_NAME} config: {exc}") from exc
 
+        repo_policy_compliance = None
         if charm.config.get(REPO_POLICY_COMPLIANCE_TOKEN_CONFIG_NAME) or charm.config.get(
             REPO_POLICY_COMPLIANCE_URL_CONFIG_NAME
         ):

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -469,6 +469,10 @@ class CharmConfig(BaseModel):
         if charm.config.get(REPO_POLICY_COMPLIANCE_TOKEN_CONFIG_NAME) or charm.config.get(
             REPO_POLICY_COMPLIANCE_URL_CONFIG_NAME
         ):
+            if not openstack_clouds_yaml:
+                raise CharmConfigInvalidError(
+                    "Cannot use repo-policy-compliance config without using OpenStack."
+                )
             repo_policy_compliance = RepoPolicyComplianceConfig.from_charm(charm)
 
         return cls(

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -316,7 +316,8 @@ class RepoPolicyComplianceConfig(BaseModel):
                 f"Missing {REPO_POLICY_COMPLIANCE_URL_CONFIG_NAME} configuration"
             )
 
-        return cls(url=url, token=token)
+        # pydantic allows string to be passed as AnyHttpUrl, mypy complains about it
+        return cls(url=url, token=token)  # type: ignore
 
 
 class CharmConfig(BaseModel):
@@ -332,6 +333,7 @@ class CharmConfig(BaseModel):
         path: GitHub repository path in the format '<owner>/<repo>', or the GitHub organization
             name.
         reconcile_interval: Time between each reconciliation of runners in minutes.
+        repo_policy_compliance: Configuration for the repo policy compliance service.
         token: GitHub personal access token for GitHub API.
     """
 

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -938,12 +938,12 @@ class CharmState:
         """
         try:
             proxy_config = ProxyConfig.from_charm(charm)
-        except (ValidationError, ValueError) as exc:
+        except ValueError as exc:
             raise CharmConfigInvalidError(f"Invalid proxy configuration: {str(exc)}") from exc
 
         try:
             charm_config = CharmConfig.from_charm(charm)
-        except (ValidationError, ValueError) as exc:
+        except ValueError as exc:
             logger.error("Invalid charm config: %s", exc)
             raise CharmConfigInvalidError(f"Invalid configuration: {str(exc)}") from exc
 
@@ -955,7 +955,7 @@ class CharmState:
             else:
                 instance_type = InstanceType.LOCAL_LXD
                 runner_config = LocalLxdRunnerConfig.from_charm(charm)
-        except (ValidationError, ValueError) as exc:
+        except ValueError as exc:
             raise CharmConfigInvalidError(f"Invalid configuration: {str(exc)}") from exc
 
         try:

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -39,6 +39,7 @@ from paramiko.ssh_exception import NoValidConnectionsError
 
 from charm_state import (
     Arch,
+    CharmState,
     GithubOrg,
     ProxyConfig,
     SSHDebugConnection,
@@ -751,23 +752,9 @@ class OpenstackRunnerManager:
             ssh_debug_connections=args.config.charm_state.ssh_debug_connections,
         )
 
-        pre_job_contents_dict = {
-            "issue_metrics": True,
-            "metrics_exchange_path": str(METRICS_EXCHANGE_PATH),
-            "do_repo_policy_check": False,
-        }
-        if repo_policy_config := args.config.charm_state.charm_config.repo_policy_compliance:
-            repo_policy_client = RepoPolicyComplianceClient(
-                url=repo_policy_config.url, charm_token=repo_policy_config.token
-            )
-            pre_job_contents_dict.update(
-                {
-                    "repo_policy_base_url": repo_policy_client.base_url,
-                    "repo_policy_one_time_token": repo_policy_client.get_one_time_token(),
-                    "do_repo_policy_check": True,
-                }
-            )
-        pre_job_contents = environment.get_template("pre-job.j2").render(pre_job_contents_dict)
+        pre_job_contents = OpenstackRunnerManager._render_pre_job_contents(
+            charm_state=args.config.charm_state, templates_env=environment
+        )
         instance_config = create_instance_config(
             args.app_name,
             args.unit_num,
@@ -833,6 +820,38 @@ class OpenstackRunnerManager:
             install_end_ts=ts_after,
             install_start_ts=ts_now,
         )
+
+    @staticmethod
+    def _render_pre_job_contents(
+        charm_state: CharmState, templates_env: jinja2.Environment
+    ) -> str:
+        """Render the pre-job script contents.
+
+        Args:
+            charm_state: The charm state object.
+            templates_env: The jinja template environment.
+
+        Returns:
+            The rendered pre-job script contents.
+        """
+        pre_job_contents_dict = {
+            "issue_metrics": True,
+            "metrics_exchange_path": str(METRICS_EXCHANGE_PATH),
+            "do_repo_policy_check": False,
+        }
+        if repo_policy_config := charm_state.charm_config.repo_policy_compliance:
+            repo_policy_client = RepoPolicyComplianceClient(
+                url=repo_policy_config.url, charm_token=repo_policy_config.token
+            )
+            pre_job_contents_dict.update(
+                {
+                    "repo_policy_base_url": repo_policy_client.base_url,
+                    "repo_policy_one_time_token": repo_policy_client.get_one_time_token(),
+                    "do_repo_policy_check": True,
+                }
+            )
+        pre_job_contents = templates_env.get_template("pre-job.j2").render(pre_job_contents_dict)
+        return pre_job_contents
 
     def get_github_runner_info(self) -> tuple[RunnerGithubInfo, ...]:
         """Get information on GitHub for the runners.

--- a/src/repo_policy_compliance_client.py
+++ b/src/repo_policy_compliance_client.py
@@ -57,8 +57,9 @@ class RepoPolicyComplianceClient:  # pylint: disable=too-few-public-methods
         Returns:
             A new requests session with retries and no proxy settings.
         """
-        # The repo policy compliance service is on localhost and should not have any proxies
-        # setting configured.
+        # The repo policy compliance service might be on localhost and should not have any proxies
+        # setting configured. This can be changed in the future when we also rely on an
+        # external service for LXD cloud.
         adapter = requests.adapters.HTTPAdapter(
             max_retries=urllib3.Retry(
                 total=3, backoff_factor=0.3, status_forcelist=[500, 502, 503, 504]

--- a/src/repo_policy_compliance_client.py
+++ b/src/repo_policy_compliance_client.py
@@ -57,7 +57,6 @@ class RepoPolicyComplianceClient:  # pylint: disable=too-few-public-methods
         Returns:
             A new requests session with retries and no proxy settings.
         """
-
         # The repo policy compliance service is on localhost and should not have any proxies
         # setting configured.
         adapter = requests.adapters.HTTPAdapter(

--- a/src/repo_policy_compliance_client.py
+++ b/src/repo_policy_compliance_client.py
@@ -7,6 +7,7 @@ import logging
 from urllib.parse import urljoin
 
 import requests
+import urllib3
 
 logger = logging.getLogger(__name__)
 
@@ -20,15 +21,14 @@ class RepoPolicyComplianceClient:  # pylint: disable=too-few-public-methods
         token: Charm token configured for the repo policy compliance service.
     """
 
-    def __init__(self, session: requests.Session, url: str, charm_token: str) -> None:
+    def __init__(self, url: str, charm_token: str) -> None:
         """Construct the RepoPolicyComplianceClient.
 
         Args:
-            session: The request Session object for making HTTP requests.
             url: Base URL to the repo policy compliance service.
             charm_token: Charm token configured for the repo policy compliance service.
         """
-        self._session = session
+        self._session = self._create_session()
         self.base_url = url
         self.token = charm_token
 
@@ -50,3 +50,24 @@ class RepoPolicyComplianceClient:  # pylint: disable=too-few-public-methods
         except requests.HTTPError:
             logger.exception("Unable to get one time token from repo policy compliance service.")
             raise
+
+    def _create_session(self) -> requests.Session:
+        """Create a new requests session.
+
+        Returns:
+            A new requests session with retries and no proxy settings.
+        """
+
+        # The repo policy compliance service is on localhost and should not have any proxies
+        # setting configured.
+        adapter = requests.adapters.HTTPAdapter(
+            max_retries=urllib3.Retry(
+                total=3, backoff_factor=0.3, status_forcelist=[500, 502, 503, 504]
+            )
+        )
+
+        session = requests.Session()
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        session.trust_env = False
+        return session

--- a/src/runner.py
+++ b/src/runner.py
@@ -750,8 +750,8 @@ class Runner:
         host_ip, _ = bridge_address_range.split("/")
         one_time_token = self._clients.repo.get_one_time_token()
         pre_job_contents = self._clients.jinja.get_template("pre-job.j2").render(
-            host_ip=host_ip,
-            one_time_token=one_time_token,
+            repo_policy_base_url=f"http://{host_ip}:8080",
+            repo_policy_one_time_token=one_time_token,
             issue_metrics=self._should_render_templates_with_metrics(),
             metrics_exchange_path=str(METRICS_EXCHANGE_PATH),
             do_repo_policy_check=True,

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -101,21 +101,11 @@ class RunnerManager:
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
 
-        # The repo policy compliance service is on localhost and should not have any proxies
-        # setting configured. The is a separated requests Session as the other one configured
-        # according proxies setting provided by user.
-        local_session = requests.Session()
-        local_session.mount("http://", adapter)
-        local_session.mount("https://", adapter)
-        local_session.trust_env = False
-
         self._clients = RunnerManagerClients(
             GithubClient(token=self.config.token),
             jinja2.Environment(loader=jinja2.FileSystemLoader("templates"), autoescape=True),
             LxdClient(),
-            RepoPolicyComplianceClient(
-                local_session, "http://127.0.0.1:8080", self.config.service_token
-            ),
+            RepoPolicyComplianceClient("http://127.0.0.1:8080", self.config.service_token),
         )
 
     def check_runner_bin(self) -> bool:

--- a/templates/pre-job.j2
+++ b/templates/pre-job.j2
@@ -38,7 +38,7 @@ jq -n \
       -o repo_check_output.txt
       --stderr repo_check_error.txt
       --write-out "%{http_code}"
-      -H 'Authorization: Bearer {{one_time_token}}'
+      -H 'Authorization: Bearer {{repo_policy_one_time_token}}'
       -H 'Content-Type: application/json'
     )
 
@@ -51,7 +51,7 @@ jq -n \
 
       REPO_CHECK_HTTP_CODE=$(curl "${CURL_ARGS[@]}" \
           -X POST \
-          http://{{host_ip}}:8080/always-fail/check-run)
+          {{repo_policy_base_url}}/always-fail/check-run)
       REPO_CHECK=$?
 
     # Pull request - Request repo-policy-compliance service check:
@@ -68,7 +68,7 @@ jq -n \
 
       REPO_CHECK_HTTP_CODE=$(curl "${CURL_ARGS[@]}" \
           -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\", \"source_repository_name\": \"${GITHUB_SOURCE_REPOSITORY}\", \"target_branch_name\": \"${GITHUB_BASE_REF}\", \"source_branch_name\": \"${GITHUB_HEAD_REF}\", \"commit_sha\": \"${COMMIT_SHA}\"}" \
-          http://{{host_ip}}:8080/pull_request/check-run)
+          {{repo_policy_base_url}}/pull_request/check-run)
       REPO_CHECK=$?
 
     else
@@ -82,7 +82,7 @@ jq -n \
 
       REPO_CHECK_HTTP_CODE=$(curl "${CURL_ARGS[@]}" \
           -d "{\"repository_name\": \"${GITHUB_REPOSITORY}\"}" \
-          http://{{host_ip}}:8080/${CHECK_NAME}/check-run)
+          {{repo_policy_base_url}}/${CHECK_NAME}/check-run)
       REPO_CHECK=$?
 
     fi

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -466,3 +466,18 @@ def test_repo_policy_config_without_openstack():
         CharmState.from_charm(mock_charm)
 
     assert "Cannot use repo-policy-compliance config without using OpenStack." in str(exc)
+
+
+def test_dockerhub_mirror_without_https():
+    """
+    arrange: Setup mocked charm with dockerhub-mirror-url config without https.
+    act: Retrieve state from charm.
+    assert: CharmConfigInvalidError is raised with expected error message.
+    """
+    mock_charm = get_mock_github_runner_charm()
+    mock_charm.config[charm_state.DOCKERHUB_MIRROR_CONFIG_NAME] = "http://example.com"
+
+    with pytest.raises(CharmConfigInvalidError) as exc:
+        CharmState.from_charm(mock_charm)
+
+    assert "URL scheme not permitted" in str(exc)


### PR DESCRIPTION
### Overview

Add support for an external repo policy compliance web service via the config option. This is currently only used for the Openstack cloud.

Integration tests will be added in a subsequent PR.

### Rationale

Repo policy compliance checks are currently missing for Openstack Cloud.

### Juju Events Changes

n/a

### Module Changes

`charm_state`: Add `RepoPolicyComplianceConfig` and validity checks
`repo_policy_compliance_client`: Move session creation to this module
`runner`: Small adaption to pass url instead of host-ip to pre-job content
`runner_manager`: Remove session creation
`pre-job.j2`: Use url instead of host-ip parameter

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
Documentation on charmhub will be added once openstack feature is ready.
<!-- Explanation for any unchecked items above -->