### PR TITLE
Fix: Add ubuntu user to adm group for OpenStack runners.

### DIFF
--- a/templates/openstack-userdata.sh.j2
+++ b/templates/openstack-userdata.sh.j2
@@ -30,6 +30,7 @@ nft -f /etc/nftables.conf
 {% endif %}
 
 adduser ubuntu lxd
+adduser ubuntu adm
 
 {% if dockerhub_mirror %}
 echo "{\"registry-mirrors\": [\"{{ dockerhub_mirror }}\"]}" > /etc/docker/daemon.json


### PR DESCRIPTION
### Overview

Add `ubuntu` user to the `adm` group.

### Rationale

Needed for GitHub Actions such as `canonical/setup-lxd` to work correctly.

A sample run showing the `canonical/setup-lxd` working correctly with this change:
https://github.com/canonical/github-runner-operator/actions/runs/8933687099/job/24539429422

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->