### PR TITLE
Fix dockerhub mirror not used by runner by default

### DIFF
--- a/templates/openstack-userdata.sh.j2
+++ b/templates/openstack-userdata.sh.j2
@@ -34,6 +34,8 @@ adduser ubuntu adm
 
 {% if dockerhub_mirror %}
 echo "{\"registry-mirrors\": [\"{{ dockerhub_mirror }}\"]}" > /etc/docker/daemon.json
+sudo systemctl daemon-reload
+sudo systemctl restart docker
 {% endif %}
 
 # Prepare metrics


### PR DESCRIPTION
### Overview

Reload the docker daemon after modifying the registry-mirror configuration.

### Rationale

Without the reload, the docker daemon would use the old settings.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->