### PR TITLE
Not removing busy runner with health check failure

### DIFF
--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1276"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1287"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -248,7 +248,7 @@ Get information on GitHub for the runners.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1179"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1183"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1301"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1318"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -248,7 +248,7 @@ Get information on GitHub for the runners.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1201"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1290"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1301"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -248,7 +248,7 @@ Get information on GitHub for the runners.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1186"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1190"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1060,11 +1060,15 @@ class OpenstackRunnerManager:
         server: Server | None = conn.get_server(name_or_id=instance_name)
 
         if server is not None:
-            logger.info("Pulling metrics and deleting server for OpenStack runner %s", instance_name)
+            logger.info(
+                "Pulling metrics and deleting server for OpenStack runner %s", instance_name
+            )
             self._pull_metrics(server, instance_name)
             self._remove_openstack_runner(conn, server, remove_token)
         else:
-            logger.info("Not found server for OpenStack runner %s marked for deletion", instance_name)
+            logger.info(
+                "Not found server for OpenStack runner %s marked for deletion", instance_name
+            )
 
         if github_id is not None:
             try:
@@ -1201,7 +1205,12 @@ class OpenstackRunnerManager:
         online_runners = [runner.runner_name for runner in github_info if runner.online]
         offline_runners = [runner.runner_name for runner in github_info if not runner.online]
         busy_runners = [runner.runner_name for runner in github_info if runner.busy]
-        logger.info("Found %s online and %s offline openstack runners, %s of the runners are busy", len(online_runners), len(offline_runners), len(busy_runners))
+        logger.info(
+            "Found %s online and %s offline openstack runners, %s of the runners are busy",
+            len(online_runners),
+            len(offline_runners),
+            len(busy_runners),
+        )
         logger.debug("Online runner: %s", online_runners)
         logger.debug("Offline runner: %s", offline_runners)
         logger.debug("Busy runner: %s", busy_runners)
@@ -1225,7 +1234,9 @@ class OpenstackRunnerManager:
             )
             # For busy runners let GitHub decide whether the runner should be removed.
             busy_runners_set = set(busy_runners)
-            instance_to_remove = (runner for runner in instance_to_remove if runner not in busy_runners_set)
+            instance_to_remove = (
+                runner for runner in instance_to_remove if runner not in busy_runners_set
+            )
             logger.debug("Removing following runners with issues %s", instance_to_remove)
             self._remove_runners(
                 conn=conn, instance_names=instance_to_remove, remove_token=remove_token

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1198,9 +1198,9 @@ class OpenstackRunnerManager:
         start_ts = time.time()
 
         github_info = self.get_github_runner_info()
-        online_runners = [runner for runner in github_info if runner.online]
-        offline_runners = [runner for runner in github_info if not runner.online]
-        busy_runners = [runner for runner in github_info if runner.busy]
+        online_runners = [runner.runner_name for runner in github_info if runner.online]
+        offline_runners = [runner.runner_name for runner in github_info if not runner.online]
+        busy_runners = [runner.runner_name for runner in github_info if runner.busy]
         logger.info("Found %s online and %s offline openstack runners, %s of the runners are busy", len(online_runners), len(offline_runners), len(busy_runners))
         logger.debug("Online runner: %s", online_runners)
         logger.debug("Offline runner: %s", offline_runners)
@@ -1221,7 +1221,7 @@ class OpenstackRunnerManager:
             remove_token = self._github.get_runner_remove_token(path=self._config.path)
             instance_to_remove = (
                 *runner_by_health.unhealthy,
-                *(runner.runner_name for runner in offline_runners),
+                *offline_runners,
             )
             # For busy runners let GitHub decide whether the runner should be removed.
             busy_runners_set = set(busy_runners)


### PR DESCRIPTION

### Overview

No longer deleting runners that are busy and failed the health check.
Add more debug logging for the runner status, e.g., names of busy runners.

### Rationale

For busy runners, GitHub will decide whether to stop the job or not.
GitHub does health checks on the runner as well. Failed runners are marked as `offline`.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->