### PR TITLE
Fix: Not removing offline runners that are healthy

### DIFF
--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1324"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1319"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 

--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1318"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1324"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1249,7 +1249,7 @@ class OpenstackRunnerManager:
                 *offline_runners,
             )
             # For busy runners let GitHub decide whether the runner should be removed.
-            instance_to_remove = (
+            instance_to_remove = tuple(
                 runner for runner in instance_to_remove if runner not in busy_runners_set
             )
             logger.debug("Removing following runners with issues %s", instance_to_remove)

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1238,7 +1238,7 @@ class OpenstackRunnerManager:
 
             healthy_runners_set = set(runner_by_health.healthy)
             busy_runners_set = set(busy_runners)
-            busy_unhealthy_runners = set(runner_by_health.unhealthy).union(busy_runners_set)
+            busy_unhealthy_runners = set(runner_by_health.unhealthy).intersection(busy_runners_set)
             if busy_unhealthy_runners:
                 logger.warning("Found unhealthy busy runners %s", busy_unhealthy_runners)
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1236,6 +1236,7 @@ class OpenstackRunnerManager:
             logger.debug("Healthy runner: %s", runner_by_health.healthy)
             logger.debug("Unhealthy runner: %s", runner_by_health.unhealthy)
 
+            healthy_runners_set =set(runner_by_health.healthy)
             busy_runners_set = set(busy_runners)
             busy_unhealthy_runners = set(runner_by_health.unhealthy).union(busy_runners_set)
             if busy_unhealthy_runners:
@@ -1247,6 +1248,11 @@ class OpenstackRunnerManager:
             instance_to_remove = (
                 *runner_by_health.unhealthy,
                 *offline_runners,
+            )
+            # Possible for a healthy runner to be appear as offline for sometime as GitHub can be
+            # slow to update the status.
+            instance_to_remove = tuple(
+                runner for runner in instance_to_remove if runner not in healthy_runners_set
             )
             # For busy runners let GitHub decide whether the runner should be removed.
             instance_to_remove = tuple(

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1236,7 +1236,7 @@ class OpenstackRunnerManager:
             logger.debug("Healthy runner: %s", runner_by_health.healthy)
             logger.debug("Unhealthy runner: %s", runner_by_health.unhealthy)
 
-            healthy_runners_set =set(runner_by_health.healthy)
+            healthy_runners_set = set(runner_by_health.healthy)
             busy_runners_set = set(busy_runners)
             busy_unhealthy_runners = set(runner_by_health.unhealthy).union(busy_runners_set)
             if busy_unhealthy_runners:
@@ -1245,18 +1245,13 @@ class OpenstackRunnerManager:
             # Clean up offline (SHUTOFF) runners or unhealthy (no connection/cloud-init script)
             # runners.
             remove_token = self._github.get_runner_remove_token(path=self._config.path)
-            instance_to_remove = (
-                *runner_by_health.unhealthy,
-                *offline_runners,
-            )
             # Possible for a healthy runner to be appear as offline for sometime as GitHub can be
             # slow to update the status.
-            instance_to_remove = tuple(
-                runner for runner in instance_to_remove if runner not in healthy_runners_set
-            )
             # For busy runners let GitHub decide whether the runner should be removed.
             instance_to_remove = tuple(
-                runner for runner in instance_to_remove if runner not in busy_runners_set
+                runner
+                for runner in (*runner_by_health.unhealthy, *offline_runners)
+                if runner not in healthy_runners_set and runner not in busy_runners_set
             )
             logger.debug("Removing following runners with issues %s", instance_to_remove)
             self._remove_runners(


### PR DESCRIPTION


### Overview

As title.

### Rationale

GitHub takes sometime to update. 
Self-hosted runner status life cycle:
- register: offline
- run: online
- take job: busy
- complete job: delete (for ephemeral)

Observed a healthy runner that appear as offline and got delete due to delay between starting the `run.sh` and updating the status on GitHub to online.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->