### PR TITLE
OpenStack COS: Ignore online runners when extracting metrics

### DIFF
--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -16,7 +16,7 @@ Module for handling interactions with OpenStack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L344"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L345"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `build_image`
 
@@ -56,7 +56,7 @@ Build and upload an image to OpenStack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L403"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L404"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `create_instance_config`
 
@@ -92,7 +92,7 @@ Create an instance config from charm data.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L118"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `InstanceConfig`
 The configuration values for creating a single runner instance. 
@@ -131,7 +131,7 @@ __init__(
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L192"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L193"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `ProxyStringValues`
 Wrapper class to proxy values to string. 
@@ -150,7 +150,7 @@ Wrapper class to proxy values to string.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L300"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L301"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackUpdateImageError`
 Represents an error while updating image on Openstack. 
@@ -161,7 +161,7 @@ Represents an error while updating image on Openstack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L497"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L498"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GithubRunnerRemoveError`
 Represents an error removing registered runner from Github. 
@@ -172,7 +172,7 @@ Represents an error removing registered runner from Github.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L505"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L506"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackRunnerManager`
 Runner manager for OpenStack-based instances. 
@@ -185,7 +185,7 @@ Runner manager for OpenStack-based instances.
  - <b>`unit_num`</b>:  The juju unit number. 
  - <b>`instance_name`</b>:  Prefix of the name for the set of runners. 
 
-<a href="../src/openstack_cloud/openstack_manager.py#L514"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L515"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1320"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1321"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -231,7 +231,7 @@ Flush Openstack servers.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L859"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L860"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_github_runner_info`
 
@@ -248,7 +248,7 @@ Get information on GitHub for the runners.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1201"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1202"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1509,8 +1509,15 @@ class OpenstackRunnerManager:
             The stats of issued metric events.
         """
         total_stats: IssuedMetricEventsStats = {}
+        online_runners = {
+            runner_info.runner_name
+            for runner_info in self.get_github_runner_info()
+            if runner_info.online
+        }
+
         for extracted_metrics in runner_metrics.extract(
-            metrics_storage_manager=metrics_storage, ignore_runners=set(runner_states.healthy)
+            metrics_storage_manager=metrics_storage,
+            ignore_runners=set(runner_states.healthy) | online_runners,
         ):
             try:
                 job_metrics = github_metrics.job(

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -49,6 +49,7 @@ from charm_state import (
 from errors import (
     CreateMetricsStorageError,
     GetMetricsStorageError,
+    GithubApiError,
     GithubClientError,
     GithubMetricsError,
     IssueMetricEventError,
@@ -1509,11 +1510,17 @@ class OpenstackRunnerManager:
             The stats of issued metric events.
         """
         total_stats: IssuedMetricEventsStats = {}
-        online_runners = {
-            runner_info.runner_name
-            for runner_info in self.get_github_runner_info()
-            if runner_info.online
-        }
+        try:
+            online_runners = {
+                runner_info.runner_name
+                for runner_info in self.get_github_runner_info()
+                if runner_info.online
+            }
+        except GithubApiError:
+            logger.exception(
+                "Failed to retrieve set of online runners. Will not issue runner metrics"
+            )
+            return total_stats
 
         for extracted_metrics in runner_metrics.extract(
             metrics_storage_manager=metrics_storage,
@@ -1553,7 +1560,15 @@ class OpenstackRunnerManager:
             reconciliation_end_ts: The timestamp of when reconciliation ended.
             runner_states: The states of the runners.
         """
-        github_info = self.get_github_runner_info()
+        try:
+            github_info = self.get_github_runner_info()
+        except GithubApiError:
+            logger.exception(
+                "Failed to retrieve github info for reconciliation metric. "
+                "Will not issue reconciliation metric."
+            )
+            return
+
         online_runners = [runner for runner in github_info if runner.online]
         offline_runner_names = {runner.runner_name for runner in github_info if not runner.online}
         active_runner_names = {runner.runner_name for runner in online_runners if runner.busy}


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Ignore online runners when extracting metrics.

Also add handling of `GithubApiError`.

### Rationale

OpenStack uses a different definition of "unhealthy" runners than LXD mode. A runner is considered unhealthy if the instance is shutdown or the ssh health check fails, which can be a transient failure. Previously, the metrics storage for unhealthy runners was removed, even if they were still online and able to process jobs. See for example this log:

```
unit-openstack-arm-large-20: 21:08:01 WARNING unit.openstack-arm-large/20.juju-log Health check failed on openstack-arm-large-20-513bb1654f929bf48747875c with all of the following addresses: ['10.145.225.51']
unit-openstack-arm-large-20: 21:08:03 INFO unit.openstack-arm-large/20.juju-log Connected (version 2.0, client OpenSSH_8.9p1)
unit-openstack-arm-large-20: 21:08:03 INFO unit.openstack-arm-large/20.juju-log Authentication (publickey) successful!
unit-openstack-arm-large-20: 21:08:04 WARNING unit.openstack-arm-large/20.juju-log Health check failed on openstack-arm-large-20-f373bb69dea5ada32d4ae799 with all of the following addresses: ['10.145.225.101']
unit-openstack-arm-large-20: 21:08:05 WARNING unit.openstack-arm-large/20.juju-log pre-job-metrics.json not found for runner openstack-arm-large-20-513bb1654f929bf48747875c.
unit-openstack-arm-large-20: 21:08:05 WARNING unit.openstack-arm-large/20.juju-log Not able to issue metrics for runner openstack-arm-large-20-513bb1654f929bf48747875c
unit-openstack-arm-large-20: 21:08:11 WARNING unit.openstack-arm-large/20.juju-log pre-job-metrics.json not found for runner openstack-arm-large-20-f373bb69dea5ada32d4ae799.
unit-openstack-arm-large-20: 21:08:11 WARNING unit.openstack-arm-large/20.juju-log Not able to issue metrics for runner openstack-arm-large-20-f373bb69dea5ada32d4ae799


unit-openstack-arm-large-20: 21:20:42 INFO unit.openstack-arm-large/20.juju-log Attempting to remove OpenStack runner openstack-arm-large-20-513bb1654f929bf48747875c
unit-openstack-arm-large-20: 21:20:43 INFO unit.openstack-arm-large/20.juju-log Pulling metrics and deleting server for OpenStack runner openstack-arm-large-20-513bb1654f929bf48747875c
unit-openstack-arm-large-20: 21:20:43 ERROR unit.openstack-arm-large/20.juju-log Failed to get shared metrics storage for runner openstack-arm-large-20-513bb1654f929bf48747875c, will not be able to issue all metrics.
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/src/openstack_cloud/openstack_manager.py", line 1345, in _pull_metrics
    storage = metrics_storage.get(instance_name)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/src/metrics/storage.py", line 137, in get
    raise GetMetricsStorageError(f"Metrics storage for runner {runner_name} not found.")
errors.GetMetricsStorageError: Metrics storage for runner openstack-arm-large-20-513bb1654f929bf48747875c not found.
unit-openstack-arm-large-20: 21:20:43 INFO unit.openstack-arm-large/20.juju-log Connected (version 2.0, client OpenSSH_8.9p1)
unit-openstack-arm-large-20: 21:20:44 INFO unit.openstack-arm-large/20.juju-log Authentication (publickey) successful!
unit-openstack-arm-large-20: 21:20:47 INFO unit.openstack-arm-large/20.juju-log Attempting to remove OpenStack runner openstack-arm-large-20-f373bb69dea5ada32d4ae799
unit-openstack-arm-large-20: 21:20:48 INFO unit.openstack-arm-large/20.juju-log Pulling metrics and deleting server for OpenStack runner openstack-arm-large-20-f373bb69dea5ada32d4ae799
unit-openstack-arm-large-20: 21:20:48 ERROR unit.openstack-arm-large/20.juju-log Failed to get shared metrics storage for runner openstack-arm-large-20-f373bb69dea5ada32d4ae799, will not be able to issue all metrics.
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/src/openstack_cloud/openstack_manager.py", line 1345, in _pull_metrics
    storage = metrics_storage.get(instance_name)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/src/metrics/storage.py", line 137, in get
    raise GetMetricsStorageError(f"Metrics storage for runner {runner_name} not found.")
errors.GetMetricsStorageError: Metrics storage for runner openstack-arm-large-20-f373bb69dea5ada32d4ae799 not found.
```

This PR fixes the issue by also ignoring online runners.

### Juju Events Changes

n/a

### Module Changes

`openstack_cloud.openstack_manager.OpenstackRunnerManager._issue_runner_metrics`: Ignore online runners

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->