### PR TITLE
OpenStack COS: Fix runner_installed race condition

### DIFF
--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1324"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1326"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -231,7 +231,7 @@ Flush Openstack servers.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L863"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L865"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_github_runner_info`
 
@@ -248,7 +248,7 @@ Get information on GitHub for the runners.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1205"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1207"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1321"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1324"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -231,7 +231,7 @@ Flush Openstack servers.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L860"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L863"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_github_runner_info`
 
@@ -248,7 +248,7 @@ Get information on GitHub for the runners.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1202"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1205"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src/metrics/runner.py
+++ b/src/metrics/runner.py
@@ -154,7 +154,7 @@ def issue_events(
         logger.isEnabledFor(logging.WARNING)
         and runner_metrics.pre_job.timestamp < runner_metrics.installed_timestamp
     ):
-        logger.warning(
+        logger.info(
             "Pre-job timestamp %d is before installed timestamp %d for runner %s."
             " Setting idle_duration to zero",
             runner_metrics.pre_job.timestamp,

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -813,6 +813,9 @@ class OpenstackRunnerManager:
                 raise RunnerCreateError(
                     f"Timeout creating OpenStack runner {instance_config.name}"
                 ) from err
+            except openstack.exceptions.SDKException as err:
+                logger.exception("Failed to create OpenStack runner %s", instance_config.name)
+                raise RunnerCreateError(f"Failed to create OpenStack runner {instance_config.name}") from err
 
             logger.info("Waiting runner %s to come online", instance_config.name)
             OpenstackRunnerManager._wait_until_runner_process_running(conn, instance.name)

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -815,7 +815,9 @@ class OpenstackRunnerManager:
                 ) from err
             except openstack.exceptions.SDKException as err:
                 logger.exception("Failed to create OpenStack runner %s", instance_config.name)
-                raise RunnerCreateError(f"Failed to create OpenStack runner {instance_config.name}") from err
+                raise RunnerCreateError(
+                    f"Failed to create OpenStack runner {instance_config.name}"
+                ) from err
 
             logger.info("Waiting runner %s to come online", instance_config.name)
             OpenstackRunnerManager._wait_until_runner_process_running(conn, instance.name)


### PR DESCRIPTION
Applicable spec: n/a

### Overview

1.Set idle time in `RunnerStart` metric event to zero if difference between pre-job timestamp and runner_installed timestamp is negative.
2.Improve log output for errors when creating runners.

### Rationale

1. There can be a race condition if a job is picked up before the openstack runner manager considers a runner to be "installed" (retries are used with a delay, so a runner can be started between a delay and immediately picking up a job). This leads to reconciliation errors and a non-issued reconciliation metric:
```
unit-openstack-arm-large-20: 2024-05-27 05:54:24 ERROR unit.openstack-arm-large/20.juju-log Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/./src/charm.py", line 1165, in <module>
    main(GithubRunnerCharm)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/venv/ops/main.py", line 544, in main
    manager.run()
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/venv/ops/main.py", line 520, in run
    self._emit()
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/venv/ops/main.py", line 509, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/venv/ops/main.py", line 143, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/venv/ops/framework.py", line 352, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/venv/ops/framework.py", line 851, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/venv/ops/framework.py", line 941, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/./src/charm.py", line 110, in func_with_catch_errors
    func(self, event)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/./src/charm.py", line 726, in _on_reconcile_runners
    runner_manager.reconcile(state.runner_config.virtual_machines)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/src/openstack_cloud/openstack_manager.py", line 1313, in reconcile
    self._issue_reconciliation_metrics(
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/src/openstack_cloud/openstack_manager.py", line 1493, in _issue_reconciliation_metrics
    metric_stats = self._issue_runner_metrics(runner_states)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/src/openstack_cloud/openstack_manager.py", line 1524, in _issue_runner_metrics
    issued_events = runner_metrics.issue_events(
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/src/metrics/runner.py", line 149, in issue_events
    runner_start_event = metric_events.RunnerStart(
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/src/metrics/events.py", line 65, in __init__
    super().__init__(*args, **kwargs)
  File "/var/lib/juju/agents/unit-openstack-arm-large-20/charm/venv/pydantic/main.py", line 341, in __init__
    raise validation_error
pydantic.error_wrappers.ValidationError: 1 validation error for RunnerStart
idle
  ensure this value is greater than or equal to 0 (type=value_error.number.not_ge; limit_value=0)
```
2. It seems there are errors which are not caught on runner creation, due to doing this in a subprocess, there is no stack trace due to pickling error , see also https://bugs.launchpad.net/openstacksdk/+bug/2046838 and https://storyboard.openstack.org/#!/story/2008678 .


```
2024-05-26 09:41:04 ERROR unit.openstack-arm-large/21.juju-log server.go:325 Uncaught exception while in charm code:
2024-05-26 11:41:04.917	
Traceback (most recent call last):
2024-05-26 11:41:04.917	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/./src/charm.py", line 1165, in <module>
2024-05-26 11:41:04.917	
    main(GithubRunnerCharm)
2024-05-26 11:41:04.917	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/venv/ops/main.py", line 544, in main
2024-05-26 11:41:04.917	
    manager.run()
2024-05-26 11:41:04.917	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/venv/ops/main.py", line 520, in run
2024-05-26 11:41:04.917	
    self._emit()
2024-05-26 11:41:04.917	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/venv/ops/main.py", line 509, in _emit
2024-05-26 11:41:04.917	
    _emit_charm_event(self.charm, self.dispatcher.event_name)
2024-05-26 11:41:04.917	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/venv/ops/main.py", line 143, in _emit_charm_event
2024-05-26 11:41:04.917	
    event_to_emit.emit(*args, **kwargs)
2024-05-26 11:41:04.917	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/venv/ops/framework.py", line 352, in emit
2024-05-26 11:41:04.917	
    framework._emit(event)
2024-05-26 11:41:04.917	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/venv/ops/framework.py", line 851, in _emit
2024-05-26 11:41:04.917	
    self._reemit(event_path)
2024-05-26 11:41:04.917	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/venv/ops/framework.py", line 941, in _reemit
2024-05-26 11:41:04.917	
    custom_handler(event)
2024-05-26 11:41:04.917	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/./src/charm.py", line 110, in func_with_catch_errors
2024-05-26 11:41:04.917	
    func(self, event)
2024-05-26 11:41:04.918	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/./src/charm.py", line 726, in _on_reconcile_runners
2024-05-26 11:41:04.918	
    runner_manager.reconcile(state.runner_config.virtual_machines)
2024-05-26 11:41:04.918	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/src/openstack_cloud/openstack_manager.py", line 1296, in reconcile
2024-05-26 11:41:04.918	
    pool.map(
2024-05-26 11:41:04.918	
  File "/usr/lib/python3.10/multiprocessing/pool.py", line 367, in map
2024-05-26 11:41:04.918	
    return self._map_async(func, iterable, mapstar, chunksize).get()
2024-05-26 11:41:04.918	
  File "/usr/lib/python3.10/multiprocessing/pool.py", line 774, in get
2024-05-26 11:41:04.918	
    raise self._value
2024-05-26 11:41:04.918	
multiprocessing.pool.MaybeEncodingError: Error sending result: '<multiprocessing.pool.ExceptionWithTraceback object at 0xffffb2f65b10>'. Reason: 'AttributeError('owner_seen')'
```

### Juju Events Changes

n/a

### Module Changes
`metrics.runner.issue_events`: Set idle_duration to `max(runner_metrics.pre_job.timestamp - runner_metrics.installed_timestamp, 0)`
`openstack_cloud.openstack_manager.OpenstackRunnerManager._create_runner`: Catch openstack sdk base xecption `openstack.exceptions.SDKException` for `conn.create_server`

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->