### PR TITLE
OpenStack COS: Ignore openstack online runners

### DIFF
--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1509,7 +1509,7 @@ class OpenstackRunnerManager:
         """Issue runner metrics.
 
         Args:
-            runner_states: The states of the runners.
+            ssh_conn: SSH connection to the runner instance.
 
         Returns:
             The stats of issued metric events.
@@ -1519,13 +1519,20 @@ class OpenstackRunnerManager:
         try:
             openstack_instances = self._get_openstack_instances(ssh_conn)
         except openstack.exceptions.SDKException:
-            logger.exception("Failed to get openstack instances to ignore when extracting metrics."
-                             " Will not issue runner metrics")
+            logger.exception(
+                "Failed to get openstack instances to ignore when extracting metrics."
+                " Will not issue runner metrics"
+            )
             return total_stats
 
         # Don't extract metrics for instances which are still there, as it might be
-        # the case that the metrics have not yet been pulled (they get pulled right before server termination).
-        os_online_runners = {instance.name for instance in openstack_instances if instance.status == _INSTANCE_STATUS_ACTIVE}
+        # the case that the metrics have not yet been pulled
+        # (they get pulled right before server termination).
+        os_online_runners = {
+            instance.name
+            for instance in openstack_instances
+            if instance.status == _INSTANCE_STATUS_ACTIVE
+        }
 
         for extracted_metrics in runner_metrics.extract(
             metrics_storage_manager=metrics_storage,

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1318,7 +1318,7 @@ class OpenstackRunnerManager:
 
             end_ts = time.time()
             self._issue_reconciliation_metrics(
-                ssh_connection=conn, reconciliation_start_ts=start_ts, reconciliation_end_ts=end_ts
+                conn=conn, reconciliation_start_ts=start_ts, reconciliation_end_ts=end_ts
             )
 
             return delta
@@ -1482,7 +1482,7 @@ class OpenstackRunnerManager:
 
     def _issue_reconciliation_metrics(
         self,
-        ssh_connection: SshConnection,
+        conn: OpenstackConnection,
         reconciliation_start_ts: float,
         reconciliation_end_ts: float,
     ) -> None:
@@ -1491,13 +1491,13 @@ class OpenstackRunnerManager:
         This includes the metrics for the runners and the reconciliation metric itself.
 
         Args:
-            ssh_connection: The SSH connection to the runner instance.
+            conn: The connection object to access OpenStack cloud.
             reconciliation_start_ts: The timestamp of when reconciliation started.
             reconciliation_end_ts: The timestamp of when reconciliation ended.
         """
-        runner_states = self._get_openstack_runner_status(ssh_connection)
+        runner_states = self._get_openstack_runner_status(conn)
 
-        metric_stats = self._issue_runner_metrics(ssh_connection)
+        metric_stats = self._issue_runner_metrics(conn)
         self._issue_reconciliation_metric(
             metric_stats=metric_stats,
             reconciliation_start_ts=reconciliation_start_ts,
@@ -1505,11 +1505,11 @@ class OpenstackRunnerManager:
             runner_states=runner_states,
         )
 
-    def _issue_runner_metrics(self, ssh_conn: SshConnection) -> IssuedMetricEventsStats:
+    def _issue_runner_metrics(self, conn: OpenstackConnection) -> IssuedMetricEventsStats:
         """Issue runner metrics.
 
         Args:
-            ssh_conn: SSH connection to the runner instance.
+            conn: The connection object to access OpenStack cloud.
 
         Returns:
             The stats of issued metric events.
@@ -1517,7 +1517,7 @@ class OpenstackRunnerManager:
         total_stats: IssuedMetricEventsStats = {}
 
         try:
-            openstack_instances = self._get_openstack_instances(ssh_conn)
+            openstack_instances = self._get_openstack_instances(conn)
         except openstack.exceptions.SDKException:
             logger.exception(
                 "Failed to get openstack instances to ignore when extracting metrics."


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Ignore openstack online runners when extracting metrics.

### Rationale

as it may be that the metrics have not yet been pulled.

We have seen a case in production where a runner had no status at all in Github, but the Openstack instance was still up. This led to a metrics extraction which removed the metrics storage, and on the next reconciliation the code tried to pull the metrics from the server, but threw a `MetricsStorageError` as the metrics could not be found:

```
2024-05-29 06:59:03 INFO unit.openstack-arm-large/21.juju-log server.go:325 Found 0 online and 0 offline openstack runners, 0 of the runners are busy	
2024-05-29 07:04:21 WARNING unit.openstack-arm-large/21.juju-log server.go:325 Unable to SSH into openstack-arm-large-21-fb2158b3a5b82820be9c1e79 with address 10.145.225.121	
2024-05-29 07:08:35 DEBUG unit.openstack-arm-large/21.juju-log server.go:325 Found openstack instances: [openstack.compute.v2.server.Server(id=ff598200-6eaf-4c49-a2ae-f74a60ecd738, name=openstack-arm-large-21-fb2158b3a5b82820be9c1e79, status=ACTIVE, ...
2024-05-29 07:09:20 DEBUG unit.openstack-arm-large/21.juju-log server.go:325 Extracting metrics from metrics storage for runner openstack-arm-large-21-fb2158b3a5b82820be9c1e79
2024-05-29 07:09:20 WARNING unit.openstack-arm-large/21.juju-log server.go:325 pre-job-metrics.json not found for runner openstack-arm-large-21-fb2158b3a5b82820be9c1e79.	
2024-05-29 07:09:20 DEBUG unit.openstack-arm-large/21.juju-log server.go:325 Cleaning metrics storage for runner openstack-arm-large-21-fb2158b3a5b82820be9c1e79
2024-05-29 07:21:52 INFO unit.openstack-arm-large/21.juju-log server.go:325 Pulling metrics and deleting server for OpenStack runner openstack-arm-large-21-fb2158b3a5b82820be9c1e79
2024-05-29 07:21:52 ERROR unit.openstack-arm-large/21.juju-log server.go:325 Failed to get shared metrics storage for runner openstack-arm-large-21-fb2158b3a5b82820be9c1e79, will not be able to issue all metrics.
2024-05-29 09:21:53.069	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/src/openstack_cloud/openstack_manager.py", line 1352, in _pull_metrics
2024-05-29 09:21:53.069	
    storage = metrics_storage.get(instance_name)
2024-05-29 09:21:53.069	
  File "/var/lib/juju/agents/unit-openstack-arm-large-21/charm/src/metrics/storage.py", line 137, in get
2024-05-29 09:21:53.069	
    raise GetMetricsStorageError(f"Metrics storage for runner {runner_name} not found.")
2024-05-29 09:21:53.070	
errors.GetMetricsStorageError: Metrics storage for runner openstack-arm-large-21-fb2158b3a5b82820be9c1e79 not found.
```

### Juju Events Changes

n/a

### Module Changes

`openstack_cloud.openstack_manager.OpenstackRunnerManager._issue_runner_metrics`: Now lists the servers and ignores the servers=runners in ACTIVE mode for metrics extraction.

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->