### PR TITLE
Log different msg in pre-job for repo-policy 5xx

### DIFF
--- a/templates/pre-job.j2
+++ b/templates/pre-job.j2
@@ -93,8 +93,13 @@ if [[ $REPO_CHECK -ne 0 ]]; then
     if [[ -s repo_check_error.txt ]]; then
         logger -p user.error -s -f repo_check_error.txt
     fi
-  logger -p user.error -s "Stopping execution of jobs due to repository setup is not compliant with policies."
-  logger -p user.error -s "This runner will be stopped or lost, please fix the setup of the repository, then rerun this job."
+    if [[ $REPO_CHECK_HTTP_CODE -ge 500 ]] && [[ $REPO_CHECK_HTTP_CODE -lt 600 ]]; then
+        logger -p user.error -s "The repository setup check failed with HTTP code ${REPO_CHECK_HTTP_CODE}."
+        logger -p user.error -s "This runner will be stopped or lost, please contact the repo-policy-compliance server operators or try again later."
+    else
+      logger -p user.error -s "Stopping execution of jobs due to repository setup is not compliant with policies."
+      logger -p user.error -s "This runner will be stopped or lost, please fix the setup of the repository, then rerun this job."
+    fi
 
   # Killing the runner.Listener process to stop the runner application. This will prevent jobs from being executed.
   pkill -2 Runner.Listener


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Log a different message in the pre-job phase for an internal repo-policy-compliace server error, 

### Rationale

as this is unlikely to indicate a problem with the repo setup, but rather a problem with the repo-policy compliance check server.

### Juju Events Changes

n/a

### Module Changes

n/a

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->