### PR TITLE
Workaround import openstack bug

### DIFF
--- a/src/openstack_cloud/__init__.py
+++ b/src/openstack_cloud/__init__.py
@@ -4,6 +4,8 @@
 """Module for managing Openstack cloud."""
 
 import logging
+import os
+import shutil
 from pathlib import Path
 from typing import TypedDict, cast
 
@@ -15,6 +17,51 @@ logger = logging.getLogger(__name__)
 
 
 CLOUDS_YAML_PATH = Path(Path.home() / ".config/openstack/clouds.yaml")
+
+
+# Make sure we can import openstack, if not remove the old openstacksdk library and retry.
+# This is a workaround for https://bugs.launchpad.net/juju/+bug/2058335
+def _remove_old_openstacksdk_lib() -> None:
+    """Remove the old openstacksdk library if it exists."""
+    try:
+        unit_name = os.environ["JUJU_UNIT_NAME"].replace("/", "-")
+        venv_dir = Path(f"/var/lib/juju/agents/unit-{unit_name}/charm/venv/")
+        openstacksdk_dirs = list(venv_dir.glob("openstacksdk-*.dist-info"))
+        # use error log level as logging may not be fully initialized yet
+        logger.error("Found following openstack dirs: %s", openstacksdk_dirs)
+        if len(openstacksdk_dirs) > 1:
+            openstacksdk_dirs.sort()
+            for openstacksdk_dir in openstacksdk_dirs[:-1]:
+                logger.info("Removing old openstacksdk library: %s", openstacksdk_dir)
+                shutil.rmtree(openstacksdk_dir)
+        else:
+            logger.error(
+                "No old openstacksdk library to remove. "
+                "Please reach out to the charm dev team for further advice."
+            )
+    except FileNotFoundError:
+        logger.exception(
+            "Failed to remove old openstacksdk library. "
+            "Please reach out to the charm dev team for further advice."
+        )
+
+
+try:
+    import openstack
+except AttributeError:
+    logger.error(
+        "Failed to import openstack. Assuming juju bug https://bugs.launchpad.net/juju/+bug/2058335."
+        "Removing old openstacksdk library and retrying."
+    )
+    _remove_old_openstacksdk_lib()
+    try:
+        # The import is there to make sure the charm fails if the openstack import is not working.
+        import openstack  # noqa: F401
+    except AttributeError:
+        logger.exception(
+            "Failed to import openstack. Please reach out to the charm team for further advice."
+        )
+        raise
 
 
 class CloudConfig(TypedDict):

--- a/src/openstack_cloud/__init__.py
+++ b/src/openstack_cloud/__init__.py
@@ -32,7 +32,7 @@ def _remove_old_openstacksdk_lib() -> None:
         if len(openstacksdk_dirs) > 1:
             openstacksdk_dirs.sort()
             for openstacksdk_dir in openstacksdk_dirs[:-1]:
-                logger.info("Removing old openstacksdk library: %s", openstacksdk_dir)
+                logger.error("Removing old openstacksdk library: %s", openstacksdk_dir)
                 shutil.rmtree(openstacksdk_dir)
         else:
             logger.error(

--- a/src/openstack_cloud/__init__.py
+++ b/src/openstack_cloud/__init__.py
@@ -39,7 +39,7 @@ def _remove_old_openstacksdk_lib() -> None:
                 "No old openstacksdk library to remove. "
                 "Please reach out to the charm dev team for further advice."
             )
-    except FileNotFoundError:
+    except OSError:
         logger.exception(
             "Failed to remove old openstacksdk library. "
             "Please reach out to the charm dev team for further advice."

--- a/src/openstack_cloud/__init__.py
+++ b/src/openstack_cloud/__init__.py
@@ -50,7 +50,8 @@ try:
     import openstack
 except AttributeError:
     logger.error(
-        "Failed to import openstack. Assuming juju bug https://bugs.launchpad.net/juju/+bug/2058335."
+        "Failed to import openstack. "
+        "Assuming juju bug https://bugs.launchpad.net/juju/+bug/2058335. "
         "Removing old openstacksdk library and retrying."
     )
     _remove_old_openstacksdk_lib()


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Workaround juju bug https://bugs.launchpad.net/juju/+bug/2058335 


### Rationale

It prevents charm upgrades.

Logs:

```
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm Traceback (most recent call last):
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/./src/charm.py", line 69, in <module>
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     from openstack_cloud import openstack_manager
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/src/openstack_cloud/openstack_manager.py", line 13, in <module>
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     import openstack
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/venv/openstack/__init__.py", line 57, in <module>
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     import openstack.config
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/venv/openstack/config/__init__.py", line 17, in <module>
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     from openstack.config.loader import OpenStackConfig  # noqa
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/venv/openstack/config/loader.py", line 34, in <module>
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     from openstack.config import cloud_region
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/venv/openstack/config/cloud_region.py", line 51, in <module>
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     from openstack import version as openstack_version
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/venv/openstack/version.py", line 16, in <module>
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     __version__ = pbr.version.VersionInfo('openstacksdk').version_string()
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/venv/pbr/version.py", line 505, in version_string
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     return self.semantic_version().brief_string()
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/venv/pbr/version.py", line 498, in semantic_version
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     self._semantic = self._get_version_from_importlib_metadata()
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/venv/pbr/version.py", line 483, in _get_version_from_importlib_metadata
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     return SemanticVersion.from_pip_string(result_string)
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/venv/pbr/version.py", line 156, in from_pip_string
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     return klass._from_pip_string_unsafe(version_string)
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm   File "/var/lib/juju/agents/unit-github-runner-6/charm/venv/pbr/version.py", line 163, in _from_pip_string_unsafe
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm     version_string = version_string.lstrip('vV')
unit-github-runner-6: 09:18:22 WARNING unit.github-runner/6.upgrade-charm AttributeError: 'NoneType' object has no attribute 'lstrip'
unit-github-runner-6: 09:18:22 ERROR juju.worker.uniter.operation hook "upgrade-charm" (via hook dispatching script: dispatch) failed: exit status 1
```

See multiple openstacksdk dirs:

```
drwxr-xr-x 91 root root   4096 Jun  4 20:21 ./
drwxr-xr-x  8 root root   4096 Jun  4 20:21 ../
drwxr-xr-x  2 root root   4096 Jun  4 20:20 Jinja2-3.1.3.dist-info/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 MarkupSafe-2.1.5.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:21 OpenSSL/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 PyYAML-6.0.1.dist-info/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 __pycache__/
-rwxr-xr-x  1 root root 977968 Jun  4 20:20 _cffi_backend.cpython-310-x86_64-linux-gnu.so*
drwxr-xr-x  3 root root   4096 Jun  4 20:20 _distutils_hack/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 _yaml/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 certifi/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 certifi-2024.2.2.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:21 cffi/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 cffi-1.16.0.dist-info/
drwxr-xr-x  4 root root   4096 Jun  4 20:20 charset_normalizer/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 charset_normalizer-3.3.2.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 cosl/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 cosl-0.0.11.dist-info/
drwxr-xr-x  5 root root   4096 Jun  4 20:20 cryptography/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 cryptography-42.0.5.dist-info/
drwxr-xr-x  6 root root   4096 Jun  4 20:20 dateutil/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 decorator-5.1.1.dist-info/
-rw-r--r--  1 root root  16752 Jun  4 20:20 decorator.py
-rw-r--r--  1 root root    152 Jun  4 20:20 distutils-precedence.pth
drwxr-xr-x  6 root root   4096 Jun  4 20:20 dogpile/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 dogpile.cache-1.3.2.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 fastcore/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 fastcore-1.5.29.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:21 ghapi/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 ghapi-1.0.5.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 idna/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 idna-3.7.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:21 integration/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 iso8601/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 iso8601-2.1.0.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:21 jinja2/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 jmespath/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 jmespath-1.0.1.dist-info/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 jsonpatch-1.33.dist-info/
-rw-r--r--  1 root root  29778 Jun  4 20:20 jsonpatch.py
drwxr-xr-x  2 root root   4096 Jun  4 20:20 jsonpointer-2.4.dist-info/
-rw-r--r--  1 root root  10964 Jun  4 20:20 jsonpointer.py
drwxr-xr-x 11 root root   4096 Jun  4 20:21 keystoneauth1/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 keystoneauth1-5.6.0.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 markupsafe/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 migration/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 netifaces-0.11.0.dist-info/
-rwxr-xr-x  1 root root  67032 Jun  4 20:20 netifaces.cpython-310-x86_64-linux-gnu.so*
drwxr-xr-x 30 root root   4096 Jun  4 20:20 openstack/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 openstacksdk-3.0.0.dist-info/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 openstacksdk-3.1.0.dist-info/
drwxr-xr-x  5 root root   4096 Jun  4 20:20 ops/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 ops-2.12.0.dist-info/
drwxr-xr-x  5 root root   4096 Jun  4 20:21 os_service_types/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 os_service_types-1.7.0.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 packaging/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 packaging-24.0.dist-info/
drwxr-xr-x  6 root root   4096 Jun  4 20:21 pbr/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 pbr-6.0.0.dist-info/
drwxr-xr-x  5 root root   4096 Jun  4 20:20 pip/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 pip-23.2.1.dist-info/
drwxr-xr-x  6 root root   4096 Jun  4 20:21 pkg_resources/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 platformdirs/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 platformdirs-4.2.0.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 platformdirs-4.2.1.dist-info/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 pyOpenSSL-24.1.0.dist-info/
drwxr-xr-x  4 root root   4096 Jun  4 20:20 pycparser/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 pycparser-2.22.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 pydantic/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 pydantic-1.10.15.dist-info/
drwxr-xr-x  5 root root   4096 Jun  4 20:21 pylxd/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 pylxd-2.3.2.dist-info/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 python_dateutil-2.9.0.post0.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:21 requests/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 requests-2.31.0.dist-info/
drwxr-xr-x 10 root root   4096 Jun  4 20:20 requests_toolbelt/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 requests_toolbelt-1.0.0.dist-info/
drwxr-xr-x  4 root root   4096 Jun  4 20:20 requests_unixsocket/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 requests_unixsocket-0.3.0.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:20 requestsexceptions/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 requestsexceptions-1.4.0.dist-info/
drwxr-xr-x  7 root root   4096 Jun  4 20:20 setuptools/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 setuptools-59.6.0.dist-info/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 six-1.16.0.dist-info/
-rw-r--r--  1 root root  34549 Jun  4 20:20 six.py
drwxr-xr-x  6 root root   4096 Jun  4 20:20 stevedore/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 stevedore-5.2.0.dist-info/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 typing_extensions-4.11.0.dist-info/
-rw-r--r--  1 root root 122293 Jun  4 20:20 typing_extensions.py
drwxr-xr-x  6 root root   4096 Jun  4 20:21 urllib3/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 urllib3-1.26.18.dist-info/
drwxr-xr-x  4 root root   4096 Jun  4 20:21 websocket/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 websocket_client-1.7.0.dist-info/
drwxr-xr-x  2 root root   4096 Jun  4 20:20 websocket_client-1.8.0.dist-info/
drwxr-xr-x  5 root root   4096 Jun  4 20:20 wheel/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 wheel-0.43.0.dist-info/
drwxr-xr-x  5 root root   4096 Jun  4 20:21 ws4py/
drwxr-xr-x  2 root root   4096 Jun  4 20:21 ws4py-0.5.1.dist-info/
drwxr-xr-x  3 root root   4096 Jun  4 20:21 yaml/
```


### Juju Events Changes

n/a

### Module Changes

`openstack_cloud/__init__.py`: Try to import openstack, and if its not possible, remove the old library version.

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->