### PR TITLE
Openstack COS: Ignore all runners with OpenStack instances

### DIFF
--- a/docs/how-to/debug-with-ssh.md
+++ b/docs/how-to/debug-with-ssh.md
@@ -7,7 +7,7 @@ for automatic configuration.
 
 ## Prerequisites
 
-To enhance the security of self-hosted runners and its infrastracture, only authorized connections
+To enhance the security of self-hosted runners and its infrastructure, only authorized connections
 can be established. Hence, action-tmate users must have
 [ssh-key registered](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
 on the GitHub account.

--- a/src-docs/github.md
+++ b/src-docs/github.md
@@ -8,7 +8,7 @@ Functions to calculate metrics from data retrieved from GitHub.
 
 ---
 
-<a href="../src/metrics/github.py#L13"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/metrics/github.py#L16"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `job`
 

--- a/src/metrics/github.py
+++ b/src/metrics/github.py
@@ -2,12 +2,15 @@
 #  See LICENSE file for licensing details.
 
 """Functions to calculate metrics from data retrieved from GitHub."""
+import logging
 
 from charm_state import GithubRepo
 from errors import GithubMetricsError, JobNotFoundError
 from github_client import GithubClient
 from metrics.runner import PreJobMetrics
 from metrics.type import GithubJobMetrics
+
+logger = logging.getLogger(__name__)
 
 
 def job(
@@ -38,6 +41,13 @@ def job(
         )
     except JobNotFoundError as exc:
         raise GithubMetricsError from exc
+    logger.debug(
+        "Job info for runner %s with workflow run id %s: %s",
+        runner_name,
+        pre_job_metrics.workflow_run_id,
+        job_info,
+    )
+
     queue_duration = (job_info.started_at - job_info.created_at).total_seconds()
 
     return GithubJobMetrics(queue_duration=queue_duration, conclusion=job_info.conclusion)

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1525,12 +1525,14 @@ class OpenstackRunnerManager:
             )
             return total_stats
 
-        logger.debug("Found following openstack instances before extracting metrics: %s",
-                     openstack_instances)
+        logger.debug(
+            "Found following openstack instances before extracting metrics: %s",
+            openstack_instances,
+        )
         # Don't extract metrics for instances which are still there, as it might be
         # the case that the metrics have not yet been pulled
         # (they get pulled right before server termination).
-        instance_names = { instance.name for instance in openstack_instances}
+        instance_names = {instance.name for instance in openstack_instances}
 
         for extracted_metrics in runner_metrics.extract(
             metrics_storage_manager=metrics_storage,

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1525,18 +1525,16 @@ class OpenstackRunnerManager:
             )
             return total_stats
 
+        logger.debug("Found following openstack instances before extracting metrics: %s",
+                     openstack_instances)
         # Don't extract metrics for instances which are still there, as it might be
         # the case that the metrics have not yet been pulled
         # (they get pulled right before server termination).
-        os_online_runners = {
-            instance.name
-            for instance in openstack_instances
-            if instance.status == _INSTANCE_STATUS_ACTIVE
-        }
+        instance_names = { instance.name for instance in openstack_instances}
 
         for extracted_metrics in runner_metrics.extract(
             metrics_storage_manager=metrics_storage,
-            ignore_runners=os_online_runners,
+            ignore_runners=instance_names,
         ):
             try:
                 job_metrics = github_metrics.job(

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -407,7 +407,7 @@ class MockGhapiActions:
     """Mock for actions in Ghapi client."""
 
     def __init__(self):
-        """A placeholder method for test stub/fakes initializtion."""
+        """A placeholder method for test stub/fakes initialization."""
         hash = hashlib.sha256()
         hash.update(TEST_BINARY)
         self.test_hash = hash.hexdigest()

--- a/tests/unit/test_openstack_manager.py
+++ b/tests/unit/test_openstack_manager.py
@@ -1,5 +1,6 @@
 #  Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
+import random
 import secrets
 from pathlib import Path
 from typing import Optional
@@ -744,7 +745,7 @@ def test_reconcile_ignores_metrics_for_openstack_online_runners(
     """
     arrange: Combination of runner status/github status and openstack status.
     act: Call reconcile.
-    assert: The runners returned with status ACTIVE are ignored for metrics extraction.
+    assert: All runners which have an instance on Openstack are ignored for metrics extraction.
     """
     runner_metrics_path = tmp_path / "runner_fs"
     runner_metrics_path.mkdir()
@@ -760,12 +761,17 @@ def test_reconcile_ignores_metrics_for_openstack_online_runners(
             "unhealthy_online",
             "unhealthy_offline",
             "openstack_online_no_github_status",
+            "github_online_no_openstack_status",
         ]
     }
     openstack_manager_for_reconcile._get_openstack_runner_status = MagicMock(
         return_value=RunnerByHealth(
             healthy=(runner_names["healthy_online"], runner_names["healthy_offline"]),
-            unhealthy=(runner_names["unhealthy_online"], runner_names["unhealthy_offline"]),
+            unhealthy=(
+                runner_names["unhealthy_online"],
+                runner_names["unhealthy_offline"],
+                runner_names["github_online_no_openstack_status"],
+            ),
         )
     )
     openstack_manager_for_reconcile.get_github_runner_info = MagicMock(
@@ -785,26 +791,27 @@ def test_reconcile_ignores_metrics_for_openstack_online_runners(
                 online=False,
                 busy=False,
             ),
+            RunnerGithubInfo(
+                runner_name=runner_names["github_online_no_openstack_status"],
+                runner_id=4,
+                online=True,
+                busy=False,
+            ),
         )
     )
 
     openstack_online_runner_names = [
-        runner_names["healthy_online"],
-        runner_names["healthy_offline"],
-        runner_names["unhealthy_online"],
-        runner_names["openstack_online_no_github_status"],
+        runner
+        for (name, runner) in runner_names.items()
+        if name != "github_online_no_openstack_status"
     ]
-    openstack_online_runners = [
-        openstack_manager.openstack.compute.v2.server.Server(name=runner_name, status="ACTIVE")
+    openstack_instances = [
+        openstack_manager.openstack.compute.v2.server.Server(
+            name=runner_name, status=random.choice(("ACTIVE", "BUILD", "STOPPED"))
+        )
         for runner_name in openstack_online_runner_names
     ]
-    openstack_offline_runners = [
-        openstack_manager.openstack.compute.v2.server.Server(name=runner_name, status="SHUTOFF")
-        for runner_name in [runner_names["unhealthy_offline"]]
-    ]
-    patched_create_connection_context.list_servers.return_value = (
-        openstack_online_runners + openstack_offline_runners
-    )
+    patched_create_connection_context.list_servers.return_value = openstack_instances
 
     openstack_manager.runner_metrics.extract.return_value = (MagicMock() for _ in range(1))
     openstack_manager.runner_metrics.issue_events.side_effect = [


### PR DESCRIPTION
Applicable spec: n/a

### Overview

1. Ignore all runners with Openstack instances when extracting metrics.
2. Catch validation error for RunnerStart/RunnerStop metrics.

### Rationale
1. We have observed the case where the creation of the runner timed out, resulting in the instance not being in ACTIVE state and the metrics storage already being deleted, even though the instance still in alive. See https://pastebin.canonical.com/p/R9W94GYkSw/ and the logs for `openstack-arm-edge-20-039cfd8ad605b2e31fb5346e`
2. We have observed a `RunnerStart` validation failure due to a negative queue duration. It should be caught and enough logs should be provided to allow debugging.
```
unit-openstack-arm-medium-52: 2024-06-04 16:06:05 ERROR unit.openstack-arm-medium/52.juju-log Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/./src/charm.py", line 1165, in <module>
    main(GithubRunnerCharm)
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/venv/ops/main.py", line 548, in main
    manager.run()
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/venv/ops/main.py", line 527, in run
    self._emit()
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/venv/ops/main.py", line 516, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name)
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/venv/ops/main.py", line 147, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/venv/ops/framework.py", line 348, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/venv/ops/framework.py", line 860, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/venv/ops/framework.py", line 950, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/./src/charm.py", line 110, in func_with_catch_errors
    func(self, event)
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/./src/charm.py", line 726, in _on_reconcile_runners
    runner_manager.reconcile(state.runner_config.virtual_machines)
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/src/openstack_cloud/openstack_manager.py", line 1320, in reconcile
    self._issue_reconciliation_metrics(
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/src/openstack_cloud/openstack_manager.py", line 1500, in _issue_reconciliation_metrics
    metric_stats = self._issue_runner_metrics(conn)
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/src/openstack_cloud/openstack_manager.py", line 1551, in _issue_runner_metrics
    issued_events = runner_metrics.issue_events(
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/src/metrics/runner.py", line 165, in issue_events
    runner_start_event = metric_events.RunnerStart(
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/src/metrics/events.py", line 65, in __init__
    super().__init__(*args, **kwargs)
  File "/var/lib/juju/agents/unit-openstack-arm-medium-52/charm/venv/pydantic/main.py", line 341, in __init__
    raise validation_error
pydantic.error_wrappers.ValidationError: 1 validation error for RunnerStart
queue_duration
  ensure this value is greater than or equal to 0 (type=value_error.number.not_ge; limit_value=0)
machine-98: 2024-06-04 16:06:05 INFO juju.util.exec run result: exit status 1
```

### Juju Events Changes

n/a

### Module Changes

`openstack_cloud.openstack_manager.OpenstackRunnerManager._issue_runner_metrics`:  Ignore all instances (not just the ones that are ACTIVE)
`metrics.github.job`:  Add debug logs
`metrics.runner.issue_events`: Catch validation errors and provide verbose logging for debugging.

### Library Changes

n/a
### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->