### PR TITLE
feat: passive runner deletion

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,7 +1,8 @@
 name: integration-tests
 
 on:
-  pull_request:
+  # TODO: Re-enable
+  # pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,8 +1,7 @@
 name: integration-tests
 
 on:
-  # TODO: Re-enable
-  # pull_request:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ placeholders/
 *.charm
 build/
 .coverage
+
+# testing artifacts
 lxd-profile.*
 tinyproxy.conf
+
+# development artifacts
 clouds.yaml
+.vscode/

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -833,7 +833,7 @@ class OpenstackRunnerManager:
                     host=ip,
                     user="ubuntu",
                     connect_kwargs={"key_filename": str(key_path)},
-                    connect_timeout=30,
+                    connect_timeout=timeout,
                 )
                 result = connection.run("echo hello world", warn=True, timeout=timeout)
                 if not result.ok:

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -767,7 +767,6 @@ class OpenstackRunnerManager:
         if not key_path.exists():
             raise _SSHError(f"Missing keyfile for server: {server.name}, key path: {key_path}")
         network_address_list = server.addresses.values()
-        print(network_address_list)
         if not network_address_list:
             raise _SSHError(f"No addresses found for OpenStack server {server.name}")
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,11 +3,13 @@
 
 import copy
 import secrets
+import typing
 import unittest.mock
 from pathlib import Path
 
 import pytest
 
+import utilities
 from openstack_cloud import openstack_manager
 from tests.unit.mock import MockGhapiClient, MockLxdClient, MockRepoPolicyComplianceClient
 
@@ -148,3 +150,34 @@ def multi_clouds_yaml_fixture(clouds_yaml: dict) -> dict:
         }
     }
     return multi_clouds_yaml
+
+
+@pytest.fixture(name="skip_retry")
+def skip_retry_fixture(monkeypatch: pytest.MonkeyPatch):
+    """Fixture for skipping retry for functions with retry decorator."""
+
+    def patched_retry(*args, **kwargs):
+        """A fallthrough decorator.
+
+        Args:
+            args: Positional arguments placeholder.
+            kwargs: Keyword arguments placeholder.
+
+        Returns:
+            The fallthrough decorator.
+        """
+
+        def patched_retry_decorator(func: typing.Callable):
+            """The fallthrough decorator.
+
+            Args:
+                func: The function to decorate.
+
+            Returns:
+                the function without any additional features.
+            """
+            return func
+
+        return patched_retry_decorator
+
+    monkeypatch.setattr(utilities, "retry", patched_retry)

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -12,6 +12,8 @@ from unittest.mock import MagicMock
 
 import factory
 import factory.fuzzy
+import invoke.runners
+import openstack.compute.v2.server
 from pydantic.networks import IPvAnyAddress
 
 from charm_state import (
@@ -152,3 +154,27 @@ def get_mock_github_runner_charm() -> MagicMock:
     mock_charm.unit.name = "github-runner/0"
     mock_charm.app.name = "github-runner"
     return mock_charm
+
+
+class MockOpenstackServer(factory.Factory):
+    """Mock Openstack server instance."""  # noqa: DCO060
+
+    class Meta:
+        """Configuration for factory."""  # noqa: DCO060
+
+        model = openstack.compute.v2.server.Server
+
+    status = "ACTIVE"
+
+
+class MockSSHRunResult(factory.Factory):
+    """Mock SSH run result."""  # noqa: DCO060
+
+    class Meta:
+        """Configuration for factory."""  # noqa: DCO060
+
+        model = invoke.runners.Result
+
+    exited = 0
+    stdout = ""
+    stderr = ""

--- a/tests/unit/test_openstack_manager.py
+++ b/tests/unit/test_openstack_manager.py
@@ -149,7 +149,7 @@ def openstack_manager_for_reconcile_fixture(
         cloud_config={},
     )
     os_runner_manager._ssh_health_check = MagicMock(return_value=True)
-    os_runner_manager._get_ssh_connections = MagicMock(
+    os_runner_manager._get_ssh_connection = MagicMock(
         return_value=(ssh_connection_mock for _ in range(10))
     )
     monkeypatch.setattr(

--- a/tests/unit/test_openstack_manager.py
+++ b/tests/unit/test_openstack_manager.py
@@ -1067,7 +1067,7 @@ def test__get_ssh_connection_server_no_addresses(monkeypatch: pytest.MonkeyPatch
             conn=mock_connection, server_name="test"
         )
 
-    assert "Missing keyfile for server" in str(exc.getrepr())
+    assert "No addresses found for OpenStack server" in str(exc.getrepr())
 
 
 @pytest.mark.usefixtures("skip_retry")
@@ -1112,7 +1112,7 @@ def test__get_ssh_connection_server_no_valid_connections(
             conn=mock_connection, server_name="test"
         )
 
-    assert "Missing keyfile for server" in str(exc.getrepr())
+    assert "No connectable SSH addresses found" in str(exc.getrepr())
 
 
 @pytest.mark.usefixtures("skip_retry")

--- a/tests/unit/test_openstack_manager.py
+++ b/tests/unit/test_openstack_manager.py
@@ -150,9 +150,7 @@ def openstack_manager_for_reconcile_fixture(
         cloud_config={},
     )
     os_runner_manager._ssh_health_check = MagicMock(return_value=True)
-    os_runner_manager._get_ssh_connection = MagicMock(
-        return_value=(ssh_connection_mock for _ in range(10))
-    )
+    os_runner_manager._get_ssh_connection = MagicMock(return_value=ssh_connection_mock)
     monkeypatch.setattr(
         openstack_manager.OpenstackRunnerManager, "_wait_until_runner_process_running", MagicMock()
     )


### PR DESCRIPTION
Applicable spec: N/A

Rejected:
- Alert logging: The alert logging is for debugging purposes and should be setup via grafana-dashboard with datasource as Loki.

### Overview

1. Refactor the module to be step-down ordering to follow [IS-Charms contributing guide](https://github.com/canonical/is-charms-contributing-guide/blob/main/CONTRIBUTING.md).
2. Refactor `_get_ssh_connection` function to return a single working SSH connection instance. (There is no need to loop over every possible network connections and try them for each business logic).
3. Create a general `_health_check` function that encapsulates the business logic of health checking for both startup and  running health checks.
4. ~Log and alert when there is an unexpected health check result to allow more insights into the state of Openstack GitHub runners.~

### Rationale

To gain more insights into interactions with Openstack.

### Juju Events Changes

None.

### Module Changes

- `openstack_manager.py`
  - refactored to step-down function ordering
  - added `_health_check` function
  - refactored `_get_ssh_connection` function

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
Testing has been one on PS6
<img width="698" alt="image" src="https://github.com/canonical/github-runner-operator/assets/37652070/c23974f9-37d1-46be-9a55-67bf431f8470">
