### PR TITLE
fix: key error on charm state upgrade

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -15,7 +15,7 @@ jobs:
       pre-run-script: scripts/pre-integration-test.sh
       provider: lxd
       test-tox-env: integration-juju2.9
-      modules: '["test_charm_base_image", "test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh"]'
+      modules: '["test_charm_base_image", "test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh", "test_charm_upgrade"]'
   integration-tests:
     name: Integration test with juju 3.1
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
@@ -25,7 +25,7 @@ jobs:
       pre-run-script: scripts/pre-integration-test.sh
       provider: lxd
       test-tox-env: integration-juju3.1
-      modules: '["test_charm_base_image", "test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh"]'
+      modules: '["test_charm_base_image", "test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_one_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh", "test_charm_upgrade"]'
   # openstack tests use microstack, whose setup is kind of special
   # - due to the huge resource requirements, we use self-hosted runners for these tests
   # - microstack requires juju 3.2 and microk8s 1.26

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -225,7 +225,7 @@ The charm state.
 
 ---
 
-<a href="../src/charm_state.py#L882"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L878"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src-docs/charm_state.py.md
+++ b/src-docs/charm_state.py.md
@@ -225,7 +225,7 @@ The charm state.
 
 ---
 
-<a href="../src/charm_state.py#L868"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm_state.py#L882"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -846,23 +846,37 @@ class CharmState:
         prev_state = json.loads(json_data)
         logger.info("Previous charm state: %s", prev_state)
 
-        if prev_state["runner_config"]["runner_storage"] != runner_storage:
-            logger.error(
-                "Storage option changed from %s to %s, blocking the charm",
-                prev_state["runner_config"]["runner_storage"],
-                runner_storage,
+        try:
+            if prev_state["runner_config"]["runner_storage"] != runner_storage:
+                logger.error(
+                    "Storage option changed from %s to %s, blocking the charm",
+                    prev_state["runner_config"]["runner_storage"],
+                    runner_storage,
+                )
+                raise ImmutableConfigChangedError(
+                    msg=(
+                        "runner-storage config cannot be changed after deployment, "
+                        "redeploy if needed"
+                    )
+                )
+        except KeyError as exc:
+            logger.warning(
+                "Key %s not found, this will be updated to current config.", exc.args[0]
             )
-            raise ImmutableConfigChangedError(
-                msg="runner-storage config cannot be changed after deployment, redeploy if needed"
-            )
-        if prev_state["runner_config"]["base_image"] != base_image.value:
-            logger.error(
-                "Base image option changed from %s to %s, blocking the charm",
-                prev_state["runner_config"]["base_image"],
-                runner_storage,
-            )
-            raise ImmutableConfigChangedError(
-                msg="base-image config cannot be changed after deployment, redeploy if needed"
+
+        try:
+            if prev_state["runner_config"]["base_image"] != base_image.value:
+                logger.error(
+                    "Base image option changed from %s to %s, blocking the charm",
+                    prev_state["runner_config"]["base_image"],
+                    runner_storage,
+                )
+                raise ImmutableConfigChangedError(
+                    msg="base-image config cannot be changed after deployment, redeploy if needed"
+                )
+        except KeyError as exc:
+            logger.warning(
+                "Key %s not found, this will be updated to current config.", exc.args[0]
             )
 
     @classmethod

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -860,9 +860,7 @@ class CharmState:
                     )
                 )
         except KeyError as exc:
-            logger.info(
-                "Key %s not found, this will be updated to current config.", exc.args[0]
-            )
+            logger.info("Key %s not found, this will be updated to current config.", exc.args[0])
 
         try:
             if prev_state["runner_config"]["base_image"] != base_image.value:
@@ -875,9 +873,7 @@ class CharmState:
                     msg="base-image config cannot be changed after deployment, redeploy if needed"
                 )
         except KeyError as exc:
-            logger.info(
-                "Key %s not found, this will be updated to current config.", exc.args[0]
-            )
+            logger.info("Key %s not found, this will be updated to current config.", exc.args[0])
 
     @classmethod
     def from_charm(cls, charm: CharmBase) -> "CharmState":

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -860,7 +860,7 @@ class CharmState:
                     )
                 )
         except KeyError as exc:
-            logger.warning(
+            logger.info(
                 "Key %s not found, this will be updated to current config.", exc.args[0]
             )
 
@@ -875,7 +875,7 @@ class CharmState:
                     msg="base-image config cannot be changed after deployment, redeploy if needed"
                 )
         except KeyError as exc:
-            logger.warning(
+            logger.info(
                 "Key %s not found, this will be updated to current config.", exc.args[0]
             )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,6 @@
 import logging
 import random
 import secrets
-import zipfile
 from pathlib import Path
 from time import sleep
 from typing import Any, AsyncIterator, Iterator, Optional
@@ -33,6 +32,7 @@ from github_client import GithubClient
 from tests.integration.helpers import (
     deploy_github_runner_charm,
     ensure_charm_has_runner,
+    inject_lxd_profile,
     reconcile,
     wait_for,
 )
@@ -61,39 +61,13 @@ def charm_file(
     """Path to the built charm."""
     charm = pytestconfig.getoption("--charm-file")
     assert charm, "Please specify the --charm-file command line option"
+    charm_path_str = f"./{charm}"
 
     if openstack_clouds_yaml:
-        return f"./{charm}"
+        return charm_path_str
 
-    lxd_profile_str = """config:
-    security.nesting: true
-    security.privileged: true
-    raw.lxc: |
-        lxc.apparmor.profile=unconfined
-        lxc.mount.auto=proc:rw sys:rw cgroup:rw
-        lxc.cgroup.devices.allow=a
-        lxc.cap.drop=
-devices:
-    kmsg:
-        path: /dev/kmsg
-        source: /dev/kmsg
-        type: unix-char
-"""
-    if loop_device:
-        lxd_profile_str += f"""    loop-control:
-        path: /dev/loop-control
-        type: unix-char
-    loop14:
-        path: {loop_device}
-        type: unix-block
-"""
-
-    with zipfile.ZipFile(charm, mode="a") as charm_file:
-        charm_file.writestr(
-            "lxd-profile.yaml",
-            lxd_profile_str,
-        )
-    return f"./{charm}"
+    inject_lxd_profile(charm_file=Path(charm_path_str), loop_device=loop_device)
+    return charm_path_str
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -648,3 +648,21 @@ devices:
             "lxd-profile.yaml",
             lxd_profile_str,
         )
+
+
+async def is_upgrade_charm_event_emitted(unit: Unit) -> bool:
+    """Check if the upgrade_charm event is emitted.
+
+    This is to ensure false positives from only waiting for ACTIVE status.
+
+    Args:
+        unit: The unit to check for upgrade charm event.
+
+    Returns:
+        bool: True if the event is emitted, False otherwise.
+    """
+    unit_name_without_slash = unit.name.replace("/", "-")
+    juju_unit_log_file = f"/var/log/juju/unit-{unit_name_without_slash}.log"
+    ret_code, stdout, stderr = await run_in_unit(unit=unit, command=f"cat {juju_unit_log_file}")
+    assert ret_code == 0, f"Failed to read the log file: {stderr}"
+    return stdout is not None and "Emitting Juju event upgrade_charm." in stdout

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -374,6 +374,7 @@ async def deploy_github_runner_charm(
     reconcile_interval: int,
     constraints: dict | None = None,
     config: dict | None = None,
+    deploy_kwargs: dict | None = None,
     wait_idle: bool = True,
 ) -> Application:
     """Deploy github-runner charm.
@@ -392,6 +393,7 @@ async def deploy_github_runner_charm(
         constraints: The custom machine constraints to use. See DEFAULT_RUNNER_CONSTRAINTS
             otherwise.
         config: Additional custom config to use.
+        deploy_kwargs: Additional model deploy arguments.
         wait_idle: wait for model to become idle.
 
     Returns:
@@ -432,6 +434,7 @@ async def deploy_github_runner_charm(
         config=default_config,
         constraints=constraints or DEFAULT_RUNNER_CONSTRAINTS,
         storage=storage,
+        **(deploy_kwargs or {}),
     )
 
     if wait_idle:

--- a/tests/integration/test_charm_no_runner.py
+++ b/tests/integration/test_charm_no_runner.py
@@ -200,7 +200,9 @@ async def test_reconcile_runners(model: Model, app_no_runner: Application) -> No
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_charm_upgrade(model: Model, app_no_runner: Application, charm_file: str) -> None:
+async def test_charm_no_runner_upgrade(
+    model: Model, app_no_runner: Application, charm_file: str
+) -> None:
     """
     arrange: A working application with no runners.
     act: Upgrade the charm.

--- a/tests/integration/test_charm_upgrade.py
+++ b/tests/integration/test_charm_upgrade.py
@@ -45,10 +45,10 @@ async def test_charm_upgrade(
     retcode, stdout, stderr = await ops_test.juju(
         "download",
         "github-runner",
-        # do not specify channel -
+        # do not specify revision
         # --revision cannot be specified together with --arch, --base, --channel
-        "--revision",
-        str(latest_stable_revision),
+        "--channel",
+        "latest/stable",
         "--filepath",
         str(latest_stable_path),
         "--no-progress",

--- a/tests/integration/test_charm_upgrade.py
+++ b/tests/integration/test_charm_upgrade.py
@@ -7,6 +7,7 @@ import pytest
 from juju.client import client
 from juju.model import Model
 
+from charm_state import TEST_MODE_CONFIG_NAME, VIRTUAL_MACHINES_CONFIG_NAME
 from tests.integration.helpers import deploy_github_runner_charm
 
 
@@ -45,6 +46,8 @@ async def test_charm_upgrade(
             "mem": 16 * 1024,
             "virt-type": "virtual-machine",
         },
+        # override default test-mode as this is not a local charm with overriden lxd-profile.
+        config={TEST_MODE_CONFIG_NAME: "", VIRTUAL_MACHINES_CONFIG_NAME: 1},
         deploy_kwargs={
             "channel": "latest/stable",
             "revision": 161,

--- a/tests/integration/test_charm_upgrade.py
+++ b/tests/integration/test_charm_upgrade.py
@@ -4,6 +4,7 @@
 """Integration tests for charm upgrades."""
 
 import pytest
+from juju.client import client
 from juju.model import Model
 
 from tests.integration.helpers import deploy_github_runner_charm
@@ -25,6 +26,7 @@ async def test_charm_upgrade(
     act: charm upgrade is called.
     assert: the charm is upgraded successfully.
     """
+    latest_stable_revision = 161
     # deploy latest stable version of the charm
     application = await deploy_github_runner_charm(
         model=model,
@@ -55,9 +57,19 @@ async def test_charm_upgrade(
         timeout=180 * 60,
         check_freq=30,
     )
+    origin = client.CharmOrigin(
+        source="charm-hub",
+        track="22.04",
+        risk="latest/stable",
+        branch="deadbeef",
+        hash_="hash",
+        id_="id",
+        revision=latest_stable_revision,
+        base=client.Base("22.04", "ubuntu"),
+    )
 
     # upgrade the charm with current local charm
-    await application.local_refresh(path=charm_file)
+    await application.local_refresh(path=charm_file, charm_origin=origin)
     await model.wait_for_idle(
         apps=[application.name],
         raise_on_error=False,

--- a/tests/integration/test_charm_upgrade.py
+++ b/tests/integration/test_charm_upgrade.py
@@ -3,35 +3,57 @@
 
 """Integration tests for charm upgrades."""
 
+import pathlib
+
 import pytest
 from juju.client import client
 from juju.model import Model
+from pytest_operator.plugin import OpsTest
 
-from charm_state import TEST_MODE_CONFIG_NAME, VIRTUAL_MACHINES_CONFIG_NAME
-from tests.integration.helpers import deploy_github_runner_charm
+from charm_state import VIRTUAL_MACHINES_CONFIG_NAME
+from tests.integration.helpers import deploy_github_runner_charm, inject_lxd_profile
 
 
 @pytest.mark.asyncio
 async def test_charm_upgrade(
     model: Model,
+    ops_test: OpsTest,
     charm_file: str,
+    loop_device: str | None,
     app_name: str,
     path: str,
     token: str,
     http_proxy: str,
     https_proxy: str,
     no_proxy: str,
+    tmp_path: pathlib.Path,
 ):
     """
     arrange: given latest stable version of the charm.
     act: charm upgrade is called.
     assert: the charm is upgraded successfully.
     """
+    latest_stable_path = tmp_path / "github-runner.charm"
     latest_stable_revision = 161
+    # download the charm and inject lxd profile for testing
+    retcode, stdout, stderr = await ops_test.juju(
+        "download",
+        "github-runner",
+        "--channel",
+        "latest/stable",
+        "--revision",
+        str(latest_stable_revision),
+        "--filepath",
+        str(latest_stable_path),
+        "--no-progress",
+    )
+    assert retcode == 0, f"failed to download charm, {stdout} {stderr}"
+    inject_lxd_profile(pathlib.Path(latest_stable_path), loop_device=loop_device)
+
     # deploy latest stable version of the charm
     application = await deploy_github_runner_charm(
         model=model,
-        charm_file="github-runner",
+        charm_file=str(latest_stable_path),
         app_name=app_name,
         path=path,
         token=token,
@@ -40,18 +62,8 @@ async def test_charm_upgrade(
         https_proxy=https_proxy,
         no_proxy=no_proxy,
         reconcile_interval=5,
-        constraints={
-            "root-disk": 20 * 1024,
-            "cores": 4,
-            "mem": 16 * 1024,
-            "virt-type": "virtual-machine",
-        },
-        # override default test-mode as this is not a local charm with overriden lxd-profile.
-        config={TEST_MODE_CONFIG_NAME: "", VIRTUAL_MACHINES_CONFIG_NAME: 1},
-        deploy_kwargs={
-            "channel": "latest/stable",
-            "revision": 161,
-        },
+        # override default virtual_machines=0 config.
+        config={VIRTUAL_MACHINES_CONFIG_NAME: 1},
     )
     await model.wait_for_idle(
         apps=[application.name],

--- a/tests/integration/test_charm_upgrade.py
+++ b/tests/integration/test_charm_upgrade.py
@@ -1,0 +1,67 @@
+#  Copyright 2024 Canonical Ltd.
+#  See LICENSE file for licensing details.
+
+"""Integration tests for charm upgrades."""
+
+import pytest
+from juju.model import Model
+
+from tests.integration.helpers import deploy_github_runner_charm
+
+
+@pytest.mark.asyncio
+async def test_charm_upgrade(
+    model: Model,
+    charm_file: str,
+    app_name: str,
+    path: str,
+    token: str,
+    http_proxy: str,
+    https_proxy: str,
+    no_proxy: str,
+):
+    """
+    arrange: given latest stable version of the charm.
+    act: charm upgrade is called.
+    assert: the charm is upgraded successfully.
+    """
+    # deploy latest stable version of the charm
+    application = await deploy_github_runner_charm(
+        model=model,
+        charm_file="github-runner",
+        app_name=app_name,
+        path=path,
+        token=token,
+        runner_storage="juju-storage",
+        http_proxy=http_proxy,
+        https_proxy=https_proxy,
+        no_proxy=no_proxy,
+        reconcile_interval=5,
+        constraints={
+            "root-disk": 20 * 1024,
+            "cores": 4,
+            "mem": 16 * 1024,
+            "virt-type": "virtual-machine",
+        },
+        deploy_kwargs={
+            "channel": "latest/stable",
+            "revision": 161,
+        },
+    )
+    await model.wait_for_idle(
+        apps=[application.name],
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=180 * 60,
+        check_freq=30,
+    )
+
+    # upgrade the charm with current local charm
+    await application.local_refresh(path=charm_file)
+    await model.wait_for_idle(
+        apps=[application.name],
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=180 * 60,
+        check_freq=30,
+    )

--- a/tests/integration/test_charm_upgrade.py
+++ b/tests/integration/test_charm_upgrade.py
@@ -49,6 +49,8 @@ async def test_charm_upgrade(
         # --revision cannot be specified together with --arch, --base, --channel
         "--channel",
         "latest/stable",
+        "--series",
+        "jammy",
         "--filepath",
         str(latest_stable_path),
         "--no-progress",

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -944,7 +944,7 @@ def test_check_immutable_config_key_error(
     caplog: pytest.LogCaptureFixture,
 ):
     """
-    arrange: Mock CHARM_STATE_PATH and read_text method to return previous state with same config.
+    arrange: Mock CHARM_STATE_PATH and read_text method to return modified immutable config values.
     act: Call _check_immutable_config_change method.
     assert: None is returned.
     """
@@ -955,9 +955,8 @@ def test_check_immutable_config_key_error(
         "read_text",
         MagicMock(return_value=json.dumps(mock_charm_state_data)),
     )
-    state = CharmState(**mock_charm_state_data)
 
-    assert state._check_immutable_config_change(RunnerStorage.MEMORY, BaseImage.JAMMY) is None
+    assert CharmState._check_immutable_config_change(RunnerStorage.MEMORY, BaseImage.JAMMY) is None
     assert any(
         f"Key {immutable_config} not found, this will be updated to current config." in message
         for message in caplog.messages

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -929,6 +929,41 @@ def mock_charm_state_data():
     }
 
 
+@pytest.mark.parametrize(
+    "immutable_config",
+    [
+        pytest.param("runner_storage", id="Runner storage"),
+        pytest.param("base_image", id="Base image"),
+    ],
+)
+def test_check_immutable_config_key_error(
+    mock_charm_state_path: Path,
+    mock_charm_state_data: dict[str, typing.Any],
+    immutable_config: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """
+    arrange: Mock CHARM_STATE_PATH and read_text method to return previous state with same config.
+    act: Call _check_immutable_config_change method.
+    assert: None is returned.
+    """
+    mock_charm_state_data["runner_config"].pop(immutable_config)
+    monkeypatch.setattr(charm_state, "CHARM_STATE_PATH", mock_charm_state_path)
+    monkeypatch.setattr(
+        charm_state.CHARM_STATE_PATH,
+        "read_text",
+        MagicMock(return_value=json.dumps(mock_charm_state_data)),
+    )
+    state = CharmState(**mock_charm_state_data)
+
+    assert state._check_immutable_config_change(RunnerStorage.MEMORY, BaseImage.JAMMY) is None
+    assert any(
+        f"Key {immutable_config} not found, this will be updated to current config." in message
+        for message in caplog.messages
+    )
+
+
 def test_check_immutable_config_change_no_previous_state(
     mock_charm_state_path: Path, mock_charm_state_data: dict, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Ignore KeyError on `immutable config changed`, since this is due to upgraded charm code not being aware of old saved JSON.
The code later on saves the new config correctly.

### Rationale

During charm upgrades, when we introduce a new persisted charm config that is immutable, we store them in a
persistent json file. When this is loaded, the previous state (the charm before the upgrade) has no idea about the added key and hence raises a KeyError. This PR fixes it.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

- `charm_state.py` - handles KeyError in `_check_immutable_config_changed`.

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->