### PR TITLE
Openstack: Delete keypairs on timeout

### DIFF
--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1326"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1335"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -231,7 +231,7 @@ Flush Openstack servers.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L865"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L874"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_github_runner_info`
 
@@ -248,7 +248,7 @@ Get information on GitHub for the runners.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1207"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1216"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -805,8 +805,17 @@ class OpenstackRunnerManager:
                         instance_config.name,
                     )
                     conn.delete_server(name_or_id=instance_config.name, wait=True)
+                    try:
+                        conn.delete_keypair(instance_config.name)
+                    except openstack.exceptions.SDKException:
+                        logger.exception(
+                            "Unable to delete OpenStack keypair %s", instance_config.name
+                        )
+                    OpenstackRunnerManager._get_key_path(instance_config.name).unlink(
+                        missing_ok=True
+                    )
                 except openstack.exceptions.SDKException:
-                    logger.critical(
+                    logger.exception(
                         "Cleanup of creation failure runner %s has failed", instance_config.name
                     )
                     # Reconcile will attempt to cleanup again prior to spawning new runners.


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Delete keypairs for runners that are deleted due to creation timeout

### Rationale

otherwise there will be a keypair <-> instance drift which can cause problems if the keypair quota is exceeded.

### Juju Events Changes
n/a

### Module Changes

`openstack_cloud.openstack_manager.OpenstackRunnerManager._create_runner`: add keypair cleanup code

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->