### PR TITLE
Openstack COS: Issue metrics even if runner creation fails

### DIFF
--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -13,10 +13,11 @@ Module for handling interactions with OpenStack.
 - **SECURITY_GROUP_NAME**
 - **BUILD_OPENSTACK_IMAGE_SCRIPT_FILENAME**
 - **MAX_METRICS_FILE_SIZE**
+- **CREATE_SERVER_TIMEOUT**
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L345"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L347"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `build_image`
 
@@ -56,7 +57,7 @@ Build and upload an image to OpenStack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L404"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L406"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `create_instance_config`
 
@@ -92,7 +93,7 @@ Create an instance config from charm data.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L118"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L120"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `InstanceConfig`
 The configuration values for creating a single runner instance. 
@@ -131,7 +132,7 @@ __init__(
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L193"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L195"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `ProxyStringValues`
 Wrapper class to proxy values to string. 
@@ -150,7 +151,7 @@ Wrapper class to proxy values to string.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L301"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L303"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackUpdateImageError`
 Represents an error while updating image on Openstack. 
@@ -161,7 +162,7 @@ Represents an error while updating image on Openstack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L498"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L500"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GithubRunnerRemoveError`
 Represents an error removing registered runner from Github. 
@@ -172,7 +173,7 @@ Represents an error removing registered runner from Github.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L506"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L508"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackRunnerManager`
 Runner manager for OpenStack-based instances. 
@@ -185,7 +186,7 @@ Runner manager for OpenStack-based instances.
  - <b>`unit_num`</b>:  The juju unit number. 
  - <b>`instance_name`</b>:  Prefix of the name for the set of runners. 
 
-<a href="../src/openstack_cloud/openstack_manager.py#L515"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L517"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -214,7 +215,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1386"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1388"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -231,7 +232,7 @@ Flush Openstack servers.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L874"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L876"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_github_runner_info`
 
@@ -248,7 +249,7 @@ Get information on GitHub for the runners.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1216"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1218"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src-docs/openstack_manager.md
+++ b/src-docs/openstack_manager.md
@@ -214,7 +214,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1335"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1386"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -263,12 +263,6 @@ Reconcile the quantity of runners.
 **Args:**
  
  - <b>`quantity`</b>:  The number of intended runners. 
-
-
-
-**Raises:**
- 
- - <b>`OpenstackInstanceLaunchError`</b>:  Unable to launch OpenStack instance. 
 
 
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1219,14 +1219,63 @@ class OpenstackRunnerManager:
         Args:
             quantity: The number of intended runners.
 
-        Raises:
-            OpenstackInstanceLaunchError: Unable to launch OpenStack instance.
-
         Returns:
             The change in number of runners.
         """
         start_ts = time.time()
+        try:
+            delta = self._reconcile_runners(quantity)
+        finally:
+            end_ts = time.time()
+            self._issue_reconciliation_metrics(
+                reconciliation_start_ts=start_ts, reconciliation_end_ts=end_ts
+            )
 
+        return delta
+
+    def _reconcile_runners(self, quantity: int) -> int:
+        """Reconcile the number of runners.
+
+        Args:
+            quantity: The number of intended runners.
+
+        Returns:
+            The change in number of runners.
+        """
+        with _create_connection(self._cloud_config) as conn:
+            runner_by_health = self._get_openstack_runner_status(conn)
+            logger.info(
+                "Found %s healthy runner and %s unhealthy runner",
+                len(runner_by_health.healthy),
+                len(runner_by_health.unhealthy),
+            )
+            logger.debug("Healthy runner: %s", runner_by_health.healthy)
+            logger.debug("Unhealthy runner: %s", runner_by_health.unhealthy)
+            remove_token = self._github.get_runner_remove_token(path=self._config.path)
+
+            self._clean_up_runners(
+                conn=conn, runner_by_health=runner_by_health, remove_token=remove_token
+            )
+
+            delta = self._scale(
+                quantity=quantity,
+                conn=conn,
+                runner_by_health=runner_by_health,
+                remove_token=remove_token,
+            )
+        return delta
+
+    def _clean_up_runners(
+        self, conn: OpenstackConnection, runner_by_health: RunnerByHealth, remove_token: str
+    ) -> None:
+        """Clean up offline or unhealthy runners.
+
+        Args:
+            conn: The openstack connection instance.
+            runner_by_health: The runner status grouped by health.
+            remove_token: The GitHub runner remove token.
+
+        """
         github_info = self.get_github_runner_info()
         online_runners = [runner.runner_name for runner in github_info if runner.online]
         offline_runners = [runner.runner_name for runner in github_info if not runner.online]
@@ -1241,96 +1290,98 @@ class OpenstackRunnerManager:
         logger.debug("Offline runner: %s", offline_runners)
         logger.debug("Busy runner: %s", busy_runners)
 
-        with _create_connection(self._cloud_config) as conn:
-            runner_by_health = self._get_openstack_runner_status(conn)
-            logger.info(
-                "Found %s healthy runner and %s unhealthy runner",
-                len(runner_by_health.healthy),
-                len(runner_by_health.unhealthy),
-            )
-            logger.debug("Healthy runner: %s", runner_by_health.healthy)
-            logger.debug("Unhealthy runner: %s", runner_by_health.unhealthy)
+        healthy_runners_set = set(runner_by_health.healthy)
+        busy_runners_set = set(busy_runners)
+        busy_unhealthy_runners = set(runner_by_health.unhealthy).intersection(busy_runners_set)
+        if busy_unhealthy_runners:
+            logger.warning("Found unhealthy busy runners %s", busy_unhealthy_runners)
 
-            healthy_runners_set = set(runner_by_health.healthy)
-            busy_runners_set = set(busy_runners)
-            busy_unhealthy_runners = set(runner_by_health.unhealthy).intersection(busy_runners_set)
-            if busy_unhealthy_runners:
-                logger.warning("Found unhealthy busy runners %s", busy_unhealthy_runners)
+        # Clean up offline (SHUTOFF) runners or unhealthy (no connection/cloud-init script)
+        # runners.
+        # Possible for a healthy runner to be appear as offline for sometime as GitHub can be
+        # slow to update the status.
+        # For busy runners let GitHub decide whether the runner should be removed.
+        instance_to_remove = tuple(
+            runner
+            for runner in (*runner_by_health.unhealthy, *offline_runners)
+            if runner not in healthy_runners_set and runner not in busy_runners_set
+        )
+        logger.debug("Removing following runners with issues %s", instance_to_remove)
+        self._remove_runners(
+            conn=conn, instance_names=instance_to_remove, remove_token=remove_token
+        )
+        # Clean up orphan keys, e.g., If openstack instance is removed externally the key
+        # would not be deleted.
+        self._clean_up_keys_files(conn, runner_by_health.healthy)
+        self._clean_up_openstack_keypairs(conn, runner_by_health.healthy)
 
-            # Clean up offline (SHUTOFF) runners or unhealthy (no connection/cloud-init script)
-            # runners.
-            remove_token = self._github.get_runner_remove_token(path=self._config.path)
-            # Possible for a healthy runner to be appear as offline for sometime as GitHub can be
-            # slow to update the status.
-            # For busy runners let GitHub decide whether the runner should be removed.
-            instance_to_remove = tuple(
-                runner
-                for runner in (*runner_by_health.unhealthy, *offline_runners)
-                if runner not in healthy_runners_set and runner not in busy_runners_set
-            )
-            logger.debug("Removing following runners with issues %s", instance_to_remove)
-            self._remove_runners(
-                conn=conn, instance_names=instance_to_remove, remove_token=remove_token
-            )
-            # Clean up orphan keys, e.g., If openstack instance is removed externally the key
-            # would not be deleted.
-            self._clean_up_keys_files(conn, runner_by_health.healthy)
-            self._clean_up_openstack_keypairs(conn, runner_by_health.healthy)
+    def _scale(
+        self,
+        quantity: int,
+        conn: OpenstackConnection,
+        runner_by_health: RunnerByHealth,
+        remove_token: str,
+    ) -> int:
+        """Scale the number of runners.
 
-            # Get the number of OpenStack servers.
-            # This is not calculated due to there might be removal failures.
-            servers = self._get_openstack_instances(conn)
-            delta = quantity - len(servers)
+        Args:
+            quantity: The number of intended runners.
+            conn: The openstack connection instance.
+            runner_by_health: The runner status grouped by health.
+            remove_token: The GitHub runner remove token.
 
-            # Spawn new runners
-            if delta > 0:
-                # Skip this reconcile if image not present.
-                try:
-                    if conn.get_image(name_or_id=IMAGE_NAME) is None:
-                        logger.warning(
-                            "No OpenStack runner was spawned due to image needed not found"
-                        )
-                        return 0
-                except openstack.exceptions.SDKException as exc:
-                    # Will be resolved by charm integration with image build charm.
-                    logger.exception("Multiple image named %s found", IMAGE_NAME)
-                    raise OpenstackInstanceLaunchError(
-                        "Multiple image found, unable to determine the image to use"
-                    ) from exc
+        Raises:
+            OpenstackInstanceLaunchError: Unable to launch OpenStack instance.
 
-                logger.info("Creating %s OpenStack runners", delta)
-                args = [
-                    OpenstackRunnerManager._CreateRunnerArgs(
-                        cloud_config=self._cloud_config,
-                        app_name=self.app_name,
-                        unit_num=self.unit_num,
-                        config=self._config,
-                    )
-                    for _ in range(delta)
-                ]
-                with Pool(processes=min(delta, 10)) as pool:
-                    pool.map(
-                        func=OpenstackRunnerManager._create_runner,
-                        iterable=args,
-                    )
+        Returns:
+            The change in number of runners.
+        """
+        # Get the number of OpenStack servers.
+        # This is not calculated due to there might be removal failures.
+        servers = self._get_openstack_instances(conn)
+        delta = quantity - len(servers)
 
-            elif delta < 0:
-                logger.info("Removing %s OpenStack runners", delta)
-                self._remove_runners(
-                    conn=conn,
-                    instance_names=runner_by_health.healthy,
-                    remove_token=remove_token,
-                    num_to_remove=abs(delta),
+        # Spawn new runners
+        if delta > 0:
+            # Skip this reconcile if image not present.
+            try:
+                if conn.get_image(name_or_id=IMAGE_NAME) is None:
+                    logger.warning("No OpenStack runner was spawned due to image needed not found")
+            except openstack.exceptions.SDKException as exc:
+                # Will be resolved by charm integration with image build charm.
+                logger.exception("Multiple image named %s found", IMAGE_NAME)
+                raise OpenstackInstanceLaunchError(
+                    "Multiple image found, unable to determine the image to use"
+                ) from exc
+
+            logger.info("Creating %s OpenStack runners", delta)
+            args = [
+                OpenstackRunnerManager._CreateRunnerArgs(
+                    cloud_config=self._cloud_config,
+                    app_name=self.app_name,
+                    unit_num=self.unit_num,
+                    config=self._config,
                 )
-            else:
-                logger.info("No changes to number of runners needed")
+                for _ in range(delta)
+            ]
+            with Pool(processes=min(delta, 10)) as pool:
+                pool.map(
+                    func=OpenstackRunnerManager._create_runner,
+                    iterable=args,
+                )
 
-            end_ts = time.time()
-            self._issue_reconciliation_metrics(
-                conn=conn, reconciliation_start_ts=start_ts, reconciliation_end_ts=end_ts
+        elif delta < 0:
+            logger.info("Removing %s OpenStack runners", delta)
+            self._remove_runners(
+                conn=conn,
+                instance_names=runner_by_health.healthy,
+                remove_token=remove_token,
+                num_to_remove=abs(delta),
             )
+        else:
+            logger.info("No changes to number of runners needed")
 
-            return delta
+        return delta
 
     def flush(self) -> int:
         """Flush Openstack servers.
@@ -1491,7 +1542,6 @@ class OpenstackRunnerManager:
 
     def _issue_reconciliation_metrics(
         self,
-        conn: OpenstackConnection,
         reconciliation_start_ts: float,
         reconciliation_end_ts: float,
     ) -> None:
@@ -1500,19 +1550,19 @@ class OpenstackRunnerManager:
         This includes the metrics for the runners and the reconciliation metric itself.
 
         Args:
-            conn: The connection object to access OpenStack cloud.
             reconciliation_start_ts: The timestamp of when reconciliation started.
             reconciliation_end_ts: The timestamp of when reconciliation ended.
         """
-        runner_states = self._get_openstack_runner_status(conn)
+        with _create_connection(self._cloud_config) as conn:
+            runner_states = self._get_openstack_runner_status(conn)
 
-        metric_stats = self._issue_runner_metrics(conn)
-        self._issue_reconciliation_metric(
-            metric_stats=metric_stats,
-            reconciliation_start_ts=reconciliation_start_ts,
-            reconciliation_end_ts=reconciliation_end_ts,
-            runner_states=runner_states,
-        )
+            metric_stats = self._issue_runner_metrics(conn)
+            self._issue_reconciliation_metric(
+                metric_stats=metric_stats,
+                reconciliation_start_ts=reconciliation_start_ts,
+                reconciliation_end_ts=reconciliation_end_ts,
+                runner_states=runner_states,
+            )
 
     def _issue_runner_metrics(self, conn: OpenstackConnection) -> IssuedMetricEventsStats:
         """Issue runner metrics.

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -90,6 +90,8 @@ METRICS_EXCHANGE_PATH = Path("/home/ubuntu/metrics-exchange")
 PRE_JOB_SCRIPT = RUNNER_APPLICATION / "pre-job.sh"
 MAX_METRICS_FILE_SIZE = 1024
 
+CREATE_SERVER_TIMEOUT = 5 * 60
+
 
 class _PullFileError(Exception):
     """Represents an error while pulling a file from the runner instance."""
@@ -794,7 +796,7 @@ class OpenstackRunnerManager:
                     security_groups=[SECURITY_GROUP_NAME],
                     userdata=cloud_userdata_str,
                     auto_ip=False,
-                    timeout=120,
+                    timeout=CREATE_SERVER_TIMEOUT,
                     wait=True,
                 )
             except openstack.exceptions.ResourceTimeout as err:


### PR DESCRIPTION
Applicable spec: n/a

### Overview

1. Output runner/reconciliation metrics even  if runner creation fails
2. Increase server timeout to 5 minutes.
3. Also refactor the big `reconcile` method a bit.

### Rationale

1. Otherwise there is no observability
2. 2 minutes may be too short
3. method was too complex (linter also complained)

### Juju Events Changes

n/a

### Module Changes

`openstack_cloud.openstack_manager.OpenstackRunnerManager.reconcile` has been refactored

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->