### PR TITLE
COS: Set queue_duration to a non-negative number

### DIFF
--- a/src-docs/github_type.py.md
+++ b/src-docs/github_type.py.md
@@ -55,6 +55,7 @@ Stats for a job on GitHub.
 
 **Attributes:**
  
+ - <b>`job_id`</b>:  The ID of the job. 
  - <b>`created_at`</b>:  The time the job was created. 
  - <b>`started_at`</b>:  The time the job was started. 
  - <b>`conclusion`</b>:  The end result of a job. 

--- a/src/github_client.py
+++ b/src/github_client.py
@@ -280,8 +280,13 @@ class GithubClient:
                         # though we would assume that it should always be present,
                         # as the job should be finished
                         conclusion = job.get("conclusion", None)
+
+                        job_id = job["id"]
                         return JobStats(
-                            created_at=created_at, started_at=started_at, conclusion=conclusion
+                            job_id=job_id,
+                            created_at=created_at,
+                            started_at=started_at,
+                            conclusion=conclusion,
                         )
 
         except HTTPError as exc:

--- a/src/github_type.py
+++ b/src/github_type.py
@@ -152,11 +152,13 @@ class JobStats(BaseModel):
     """Stats for a job on GitHub.
 
     Attributes:
+        job_id: The ID of the job.
         created_at: The time the job was created.
         started_at: The time the job was started.
         conclusion: The end result of a job.
     """
 
+    job_id: int
     created_at: datetime
     started_at: datetime
     conclusion: Optional[JobConclusion]

--- a/tests/unit/metrics/test_github.py
+++ b/tests/unit/metrics/test_github.py
@@ -2,6 +2,7 @@
 #  See LICENSE file for licensing details.
 import secrets
 from datetime import datetime, timedelta, timezone
+from random import randint
 from unittest.mock import MagicMock
 
 import pytest
@@ -42,6 +43,7 @@ def test_job(pre_job_metrics: PreJobMetrics):
         started_at=started_at,
         runner_name=runner_name,
         conclusion=JobConclusion.SUCCESS,
+        job_id=randint(1, 1000),
     )
 
     job_metrics = github_metrics.job(

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -17,7 +17,7 @@ from github_type import JobConclusion, JobStats
 
 JobStatsRawData = namedtuple(
     "JobStatsRawData",
-    ["created_at", "started_at", "runner_name", "conclusion"],
+    ["created_at", "started_at", "runner_name", "conclusion", "id"],
 )
 
 
@@ -30,6 +30,7 @@ def job_stats_fixture() -> JobStatsRawData:
         started_at="2021-10-01T01:00:00Z",
         conclusion="success",
         runner_name=runner_name,
+        id=random.randint(1, 1000),
     )
 
 
@@ -45,6 +46,7 @@ def github_client_fixture(job_stats_raw: JobStatsRawData) -> GithubClient:
                 "started_at": job_stats_raw.started_at,
                 "runner_name": job_stats_raw.runner_name,
                 "conclusion": job_stats_raw.conclusion,
+                "id": job_stats_raw.id,
             }
         ]
     }
@@ -77,6 +79,7 @@ def _mock_multiple_pages_for_job_response(
                     "started_at": job_stats_raw.started_at,
                     "runner_name": runner_names[i * no_of_jobs_per_page + j],
                     "conclusion": job_stats_raw.conclusion,
+                    "id": job_stats_raw.id,
                 }
                 for j in range(no_of_jobs_per_page)
             ]
@@ -103,6 +106,7 @@ def test_get_job_info(github_client: GithubClient, job_stats_raw: JobStatsRawDat
         started_at=datetime(2021, 10, 1, 1, 0, 0, tzinfo=timezone.utc),
         runner_name=job_stats_raw.runner_name,
         conclusion=JobConclusion.SUCCESS,
+        job_id=job_stats_raw.id,
     )
 
 
@@ -120,6 +124,7 @@ def test_get_job_info_no_conclusion(github_client: GithubClient, job_stats_raw: 
                 "started_at": job_stats_raw.started_at,
                 "runner_name": job_stats_raw.runner_name,
                 "conclusion": None,
+                "id": job_stats_raw.id,
             }
         ]
     }
@@ -134,6 +139,7 @@ def test_get_job_info_no_conclusion(github_client: GithubClient, job_stats_raw: 
         started_at=datetime(2021, 10, 1, 1, 0, 0, tzinfo=timezone.utc),
         runner_name=job_stats_raw.runner_name,
         conclusion=None,
+        job_id=job_stats_raw.id,
     )
 
 
@@ -161,6 +167,7 @@ def test_github_api_pagination_multiple_pages(
         started_at=datetime(2021, 10, 1, 1, 0, 0, tzinfo=timezone.utc),
         runner_name=job_stats_raw.runner_name,
         conclusion=JobConclusion.SUCCESS,
+        job_id=job_stats_raw.id,
     )
 
 


### PR DESCRIPTION
Applicable spec: n/a

### Overview

1. Set queue_duration to at least zero.
2. Include job_id in the job statistics.

### Rationale

1. Sometimes the github api returns `started_at < created_at`.
2. Simplify troubleshooting by making it easier to associate a problem with a particular job by including the job id in the debug logs.

### Juju Events Changes

n/a

### Module Changes

`metrics.runner`: Add `max(job_metrics.queue_duration, 0)`

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->