### PR TITLE
Docs: Fix repo runner token scope docs

### DIFF
--- a/docs/reference/token-scopes.md
+++ b/docs/reference/token-scopes.md
@@ -22,6 +22,7 @@ Repository:
 The following are the permissions scopes required for the GitHub runners when registering as an
 repository runner.
 
+- Administration: read & write
 - Contents: read
 - Metadata: read
 - Pull requests: read


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Add `- Administration: read & write` to the repo runner PAT scopes.

### Rationale

This was missing and therefore wrong.

### Juju Events Changes

n/a

### Module Changes

n/a

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->