### PR TITLE
Fix: config-change flushing of openstack runners

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -636,7 +636,7 @@ class GithubRunnerCharm(CharmBase):
 
         state = self._setup_state()
 
-        if state.instance_type == InstanceType.OPENSTACK:
+        if state.charm_config.token != self._stored.token and state.instance_type == InstanceType.OPENSTACK:
             openstack_runner_manager = self._get_openstack_runner_manager(state)
             openstack_runner_manager.flush()
             openstack_runner_manager.reconcile(state.runner_config.virtual_machines)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Add missing condition for config-change event for flushing runners.

### Rationale

<!-- The reason the change is needed -->
Bug fix.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->