### PR TITLE
Update token docs to include Actions: read

### DIFF
--- a/docs/reference/token-scopes.md
+++ b/docs/reference/token-scopes.md
@@ -16,6 +16,7 @@ Organisation:
 
 Repository:
 
+- Actions: read (required when COS integration is enabled)
 - Administration: read
 - Contents: read
 - Pull requests: read
@@ -25,6 +26,7 @@ Repository:
 The following are the permissions scopes required for the GitHub runners when registering as an
 repository runner.
 
+- Actions: read (required when COS integration is enabled)
 - Administration: read & write
 - Contents: read
 - Metadata: read

--- a/docs/reference/token-scopes.md
+++ b/docs/reference/token-scopes.md
@@ -16,7 +16,7 @@ Organisation:
 
 Repository:
 
-- Actions: read (required when COS integration is enabled)
+- Actions: read (required if COS integration is enabled and private repositories exist)
 - Administration: read
 - Contents: read
 - Pull requests: read
@@ -26,7 +26,7 @@ Repository:
 The following are the permissions scopes required for the GitHub runners when registering as an
 repository runner.
 
-- Actions: read (required when COS integration is enabled)
+- Actions: read (required if COS integration is enabled and the repository is private)
 - Administration: read & write
 - Contents: read
 - Metadata: read


### PR DESCRIPTION
Applicable spec:n/a

### Overview

Update fine-grained token docs to include `Actions: read` permission.

### Rationale

This is required when the charm  is collecting metrics for a runner on a private repo.

### Juju Events Changes

n/a

### Module Changes

n/a

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->