### PR TITLE
Remove residual empty directories from last revision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore D107 Missing docstring in __init__
 ignore = ["W503", "E501", "D107"]
 # D100, D101, D102, D103, D104: Ignore docstring style issues in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104,D205,D212"]
+# temporary disable E402 for the fix in charm.py for lp:2058335
+per-file-ignores = ["src/charm.py:E402", "tests/*:D100,D101,D102,D103,D104,D205,D212"]
 docstring-convention = "google"
 # Check for properly formatted copyright header in each file
 copyright-check = "True"

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,6 +8,14 @@
 
 """Charm for creating and managing GitHub self-hosted runner instances."""
 
+from utilities import bytes_with_unit_to_kib, execute_command, remove_residual_venv_dirs, retry
+
+# This is a workaround for https://bugs.launchpad.net/juju/+bug/2058335
+# pylint: disable=wrong-import-position,wrong-import-order
+# TODO: 2024-07-17 remove this once the issue has been fixed
+remove_residual_venv_dirs()
+
+
 import functools
 import logging
 import os
@@ -72,7 +80,6 @@ from openstack_cloud.openstack_manager import OpenstackRunnerManager
 from runner import LXD_PROFILE_YAML
 from runner_manager import RunnerManager, RunnerManagerConfig
 from runner_manager_type import FlushMode, OpenstackRunnerManagerConfig
-from utilities import bytes_with_unit_to_kib, execute_command, retry
 
 RECONCILE_RUNNERS_EVENT = "reconcile-runners"
 

--- a/src/openstack_cloud/__init__.py
+++ b/src/openstack_cloud/__init__.py
@@ -4,7 +4,6 @@
 """Module for managing Openstack cloud."""
 
 import logging
-import os
 from pathlib import Path
 from typing import TypedDict, cast
 
@@ -16,36 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 CLOUDS_YAML_PATH = Path(Path.home() / ".config/openstack/clouds.yaml")
-
-
-# This is a workaround for https://bugs.launchpad.net/juju/+bug/2058335
-def _remove_residual_venv_dirs() -> None:  # pragma: no cover
-    """Remove the residual empty directories from last revision if it exists."""
-    unit_name = os.environ["JUJU_UNIT_NAME"].replace("/", "-")
-    venv_dir = Path(f"/var/lib/juju/agents/unit-{unit_name}/charm/venv/")
-    for path in venv_dir.iterdir():
-        if path.is_dir() and not os.listdir(path):
-            logger.warning("Removing residual empty dir: %s", path)
-            path.rmdir()
-
-
-try:
-    import openstack
-except AttributeError:
-    logger.error(
-        "Failed to import openstack. "
-        "Assuming juju bug https://bugs.launchpad.net/juju/+bug/2058335. "
-        "Removing old openstacksdk library and retrying."
-    )
-    _remove_residual_venv_dirs()
-    try:
-        # The import is there to make sure the charm fails if the openstack import is not working.
-        import openstack  # noqa: F401
-    except AttributeError:
-        logger.exception(
-            "Failed to import openstack. Please reach out to the charm team for further advice."
-        )
-        raise
 
 
 class CloudConfig(TypedDict):

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -253,7 +253,7 @@ def remove_residual_venv_dirs() -> None:  # pragma: no cover
     """Remove the residual empty directories from last revision if it exists."""
     unit_name = os.environ.get("JUJU_UNIT_NAME", "").replace("/", "-")
     if not unit_name:
-        return 
+        return
     venv_dir = pathlib.Path(f"/var/lib/juju/agents/unit-{unit_name}/charm/venv/")
     if not venv_dir.exists():
         return

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -251,7 +251,9 @@ def bytes_with_unit_to_kib(num_bytes: str) -> int:
 # This is a workaround for https://bugs.launchpad.net/juju/+bug/2058335
 def remove_residual_venv_dirs() -> None:  # pragma: no cover
     """Remove the residual empty directories from last revision if it exists."""
-    unit_name = os.environ["JUJU_UNIT_NAME"].replace("/", "-")
+    unit_name = os.environ.get("JUJU_UNIT_NAME", "").replace("/", "-")
+    if not unit_name:
+        return 
     venv_dir = pathlib.Path(f"/var/lib/juju/agents/unit-{unit_name}/charm/venv/")
     if not venv_dir.exists():
         return


### PR DESCRIPTION
Juju sometimes leaves empty directories from the previous revision uncleaned during charm upgrades. This issue is tracked at [https://bugs.launchpad.net/juju/+bug/2058335](https://bugs.launchpad.net/juju/+bug/2058335). Until the fix is integrated into Juju, we need to update the patch we applied to this charm to mitigate this problem for now.