### PR TITLE
chore: image bulider match style

### DIFF
--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -31,7 +31,12 @@ from pydantic import (
 )
 
 import openstack_cloud
-from errors import MissingMongoDBError, OpenStackInvalidConfigError
+from errors import (
+    IntegrationDataNotReadyError,
+    IntegrationNotFoundError,
+    MissingMongoDBError,
+    OpenStackInvalidConfigError,
+)
 from firewall import FirewallEntry
 from utilities import get_env_var
 
@@ -590,25 +595,26 @@ class OpenstackImage(BaseModel):
         tags: Image tags, e.g. jammy
     """
 
-    id: str | None
-    tags: list[str] | None
+    id: str
+    tags: list[str]
 
     @classmethod
-    def from_charm(cls, charm: CharmBase) -> "OpenstackImage | None":
+    def from_charm(cls, charm: CharmBase) -> "OpenstackImage":
         """Initialize the OpenstackImage info from relation data.
-
-        None represents relation not established.
-        None values for id/tags represent image not yet ready but the relation exists.
 
         Args:
             charm: The charm instance.
 
         Returns:
             OpenstackImage metadata from charm relation data.
+
+        Raises:
+            IntegrationNotFoundError: if the charm has not yet been integrated.
+            IntegrationDataNotReadyError: if the integration data is not yet available.
         """
         relations = charm.model.relations[IMAGE_INTEGRATION_NAME]
         if not relations or not (relation := relations[0]).units:
-            return None
+            raise IntegrationNotFoundError(f"Please provide {IMAGE_INTEGRATION_NAME} relation.")
         for unit in relation.units:
             relation_data = relation.data[unit]
             if not relation_data:
@@ -617,7 +623,7 @@ class OpenstackImage(BaseModel):
                 id=relation_data.get("id", None),
                 tags=[tag.strip() for tag in relation_data.get("tags", "").split(",") if tag],
             )
-        return OpenstackImage(id=None, tags=None)
+        raise IntegrationDataNotReadyError(f"Waiting for {IMAGE_INTEGRATION_NAME} relation data.")
 
 
 class OpenstackRunnerConfig(BaseModel):

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -600,13 +600,13 @@ class OpenstackImage(BaseModel):
 
     @classmethod
     def from_charm(cls, charm: CharmBase) -> "OpenstackImage":
-        """Initialize the OpenstackImage info from relation data.
+        """Initialize the OpenstackImage info from integration data.
 
         Args:
             charm: The charm instance.
 
         Returns:
-            OpenstackImage metadata from charm relation data.
+            OpenstackImage metadata from charm integration data.
 
         Raises:
             IntegrationNotFoundError: if the charm has not yet been integrated.
@@ -614,16 +614,24 @@ class OpenstackImage(BaseModel):
         """
         relations = charm.model.relations[IMAGE_INTEGRATION_NAME]
         if not relations or not (relation := relations[0]).units:
-            raise IntegrationNotFoundError(f"Please provide {IMAGE_INTEGRATION_NAME} relation.")
+            raise IntegrationNotFoundError(f"Please provide {IMAGE_INTEGRATION_NAME} integration.")
         for unit in relation.units:
             relation_data = relation.data[unit]
             if not relation_data:
                 continue
+            image_id = relation_data.get("id", None)
+            image_tags = [tag.strip() for tag in relation_data.get("tags", "").split(",") if tag]
+            if not image_id:
+                raise IntegrationDataNotReadyError(
+                    f"Waiting for {IMAGE_INTEGRATION_NAME} integration data."
+                )
             return OpenstackImage(
-                id=relation_data.get("id", None),
-                tags=[tag.strip() for tag in relation_data.get("tags", "").split(",") if tag],
+                id=image_id,
+                tags=image_tags,
             )
-        raise IntegrationDataNotReadyError(f"Waiting for {IMAGE_INTEGRATION_NAME} relation data.")
+        raise IntegrationDataNotReadyError(
+            f"Waiting for {IMAGE_INTEGRATION_NAME} integration data."
+        )
 
 
 class OpenstackRunnerConfig(BaseModel):

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -639,7 +639,7 @@ class OpenstackRunnerConfig(BaseModel):
     virtual_machines: int
     openstack_flavor: str
     openstack_network: str
-    openstack_image: OpenstackImage | None
+    openstack_image: OpenstackImage
 
     @classmethod
     def from_charm(cls, charm: CharmBase) -> "OpenstackRunnerConfig":

--- a/src/errors.py
+++ b/src/errors.py
@@ -47,7 +47,19 @@ class ConfigurationError(Exception):
     """Error for juju configuration."""
 
 
-class MissingMongoDBError(Exception):
+class IntegrationBaseError(Exception):
+    """Base class for charm integration related errors."""
+
+
+class IntegrationNotFoundError(IntegrationBaseError):
+    """Represents an error with a necessary integration is not found."""
+
+
+class IntegrationDataNotReadyError(IntegrationBaseError):
+    """Represents an error with a necessary integration data not yet ready/populated."""
+
+
+class MissingMongoDBError(IntegrationBaseError):
     """Error for missing integration data."""
 
 
@@ -166,15 +178,3 @@ class OpenStackInvalidConfigError(OpenStackError):
 
 class OpenStackUnauthorizedError(OpenStackError):
     """Represents an unauthorized connection to OpenStack."""
-
-
-class IntegrationBaseError(Exception):
-    """Base class for charm integration related errors."""
-
-
-class IntegrationNotFoundError(IntegrationBaseError):
-    """Represents an error with a necessary integration is not found."""
-
-
-class IntegrationDataNotReadyError(IntegrationBaseError):
-    """Represents an error with a necessary integration data not yet ready/populated."""

--- a/src/errors.py
+++ b/src/errors.py
@@ -166,3 +166,15 @@ class OpenStackInvalidConfigError(OpenStackError):
 
 class OpenStackUnauthorizedError(OpenStackError):
     """Represents an unauthorized connection to OpenStack."""
+
+
+class IntegrationBaseError(Exception):
+    """Base class for charm integration related errors."""
+
+
+class IntegrationNotFoundError(IntegrationBaseError):
+    """Represents an error with a necessary integration is not found."""
+
+
+class IntegrationDataNotReadyError(IntegrationBaseError):
+    """Represents an error with a necessary integration data not yet ready/populated."""

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -43,6 +43,8 @@ from charm_state import (
     GithubOrg,
     GithubRepo,
     ImmutableConfigChangedError,
+    IntegrationDataNotReadyError,
+    IntegrationNotFoundError,
     LocalLxdRunnerConfig,
     OpenstackImage,
     OpenstackRunnerConfig,
@@ -551,23 +553,24 @@ def test_openstack_image_from_charm_no_connections():
     """
     arrange: Mock CharmBase instance without relation.
     act: Call OpenstackImage.from_charm method.
-    assert: Verify that the method returns the expected None value.
+    assert: IntegrationNotFoundError is raised.
     """
     mock_charm = MockGithubRunnerCharmFactory()
     relation_mock = MagicMock()
     relation_mock.units = []
     mock_charm.model.relations[IMAGE_INTEGRATION_NAME] = []
 
-    image = OpenstackImage.from_charm(mock_charm)
+    with pytest.raises(IntegrationNotFoundError) as exc:
+        OpenstackImage.from_charm(mock_charm)
 
-    assert image is None
+    assert f"Please provide {IMAGE_INTEGRATION_NAME} integration." in str(exc.getrepr())
 
 
 def test_openstack_image_from_charm_data_not_ready():
     """
     arrange: Mock CharmBase instance with no relation data.
     act: Call OpenstackImage.from_charm method.
-    assert: Verify that the method returns the expected None value for id and tags.
+    assert: IntegrationDataNotReadyError is raised.
     """
     mock_charm = MockGithubRunnerCharmFactory()
     relation_mock = MagicMock()
@@ -576,11 +579,10 @@ def test_openstack_image_from_charm_data_not_ready():
     relation_mock.data = {unit_mock: {}}
     mock_charm.model.relations[IMAGE_INTEGRATION_NAME] = [relation_mock]
 
-    image = OpenstackImage.from_charm(mock_charm)
+    with pytest.raises(IntegrationDataNotReadyError) as exc:
+        OpenstackImage.from_charm(mock_charm)
 
-    assert isinstance(image, OpenstackImage)
-    assert image.id is None
-    assert image.tags is None
+    assert f"Waiting for {IMAGE_INTEGRATION_NAME} integration data." in str(exc.getrepr())
 
 
 def test_openstack_image_from_charm():


### PR DESCRIPTION
Applicable spec: N/A

### Overview

From previous discussion, a charm state should raise an error if not valid and be caught, rather than returning validation result. This PR follows the pattern discussed.

### Rationale

To have consistent code styles.

### Juju Events Changes

None.

### Module Changes

- Removed `_get_set_image_ready_status` which sets charm states if image relation is not ready/ not provided.
- The charm now falls into BlockedStatus/WaitingStatus if the image relation is not provided regardless of whether the openstack charm deployment requires the image to be ready (e.g. flush doesn't require image to be ready)

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->