### PR TITLE
Deal with multiple security groups

### DIFF
--- a/src-docs/logrotate.md
+++ b/src-docs/logrotate.md
@@ -9,11 +9,12 @@ Logrotate setup and configuration.
 ---------------
 - **LOG_ROTATE_TIMER_SYSTEMD_SERVICE**
 - **METRICS_LOGROTATE_CONFIG**
+- **RUNNER_LOGROTATE_CONFIG**
 - **REACTIVE_LOGROTATE_CONFIG**
 
 ---
 
-<a href="../src/logrotate.py#L76"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/logrotate.py#L85"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `setup`
 
@@ -32,7 +33,7 @@ Enable and configure logrotate.
 
 ---
 
-<a href="../src/logrotate.py#L21"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/logrotate.py#L22"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `LogrotateFrequency`
 The frequency of log rotation. 
@@ -52,7 +53,7 @@ The frequency of log rotation.
 
 ---
 
-<a href="../src/logrotate.py#L37"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/logrotate.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `LogrotateConfig`
 Configuration for logrotate. 

--- a/src-docs/metrics.md
+++ b/src-docs/metrics.md
@@ -10,6 +10,9 @@ Package for common metrics-related code.
 - **events**: # Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
+- **runner_logs**: #  Copyright 2024 Canonical Ltd.
+#  See LICENSE file for licensing details.
+
 - **storage**: #  Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
@@ -20,9 +23,6 @@ Package for common metrics-related code.
 #  See LICENSE file for licensing details.
 
 - **github**: #  Copyright 2024 Canonical Ltd.
-#  See LICENSE file for licensing details.
-
-- **runner_logs**: #  Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
 

--- a/src-docs/openstack_cloud.openstack_manager.md
+++ b/src-docs/openstack_cloud.openstack_manager.md
@@ -146,7 +146,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1498"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1506"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 

--- a/src-docs/openstack_cloud.openstack_manager.md
+++ b/src-docs/openstack_cloud.openstack_manager.md
@@ -146,7 +146,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1506"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1501"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -779,7 +779,15 @@ class OpenstackRunnerManager:
         rule_exists_ssh = False
         rule_exists_tmate_ssh = False
 
-        existing_security_group = conn.get_security_group(name_or_id=SECURITY_GROUP_NAME)
+        security_groups = conn.list_security_groups(filters={"name": SECURITY_GROUP_NAME})
+        existing_security_group = None
+        if len(security_groups) == 1:
+            existing_security_group = security_groups[0]
+        elif len(security_groups) > 1:
+            # If found multiple security groups, there is likely an issue, delete them all.
+            for group in security_groups:
+                group.delete()
+
         if existing_security_group is None:
             logger.info("Security group %s not found, creating it", SECURITY_GROUP_NAME)
             conn.create_security_group(

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -780,13 +780,8 @@ class OpenstackRunnerManager:
         rule_exists_tmate_ssh = False
 
         security_groups = conn.list_security_groups(filters={"name": SECURITY_GROUP_NAME})
-        existing_security_group = None
-        if len(security_groups) == 1:
-            existing_security_group = security_groups[0]
-        elif len(security_groups) > 1:
-            # If found multiple security groups, there is likely an issue, delete them all.
-            for group in security_groups:
-                group.delete()
+        # Pick the first security_group returned.
+        existing_security_group = next(iter(security_groups), None)
 
         if existing_security_group is None:
             logger.info("Security group %s not found, creating it", SECURITY_GROUP_NAME)

--- a/tests/unit/test_openstack_manager.py
+++ b/tests/unit/test_openstack_manager.py
@@ -761,13 +761,15 @@ def test__ensure_security_group_with_existing_rules():
     assert: The security rules are not created again.
     """
     connection_mock = MagicMock(spec=openstack.connection.Connection)
-    connection_mock.list_security_groups.return_value = [{
-        "security_group_rules": [
-            {"protocol": "icmp"},
-            {"protocol": "tcp", "port_range_min": 22, "port_range_max": 22},
-            {"protocol": "tcp", "port_range_min": 10022, "port_range_max": 10022},
-        ]
-    }]
+    connection_mock.list_security_groups.return_value = [
+        {
+            "security_group_rules": [
+                {"protocol": "icmp"},
+                {"protocol": "tcp", "port_range_min": 22, "port_range_max": 22},
+                {"protocol": "tcp", "port_range_min": 10022, "port_range_max": 10022},
+            ]
+        }
+    ]
 
     openstack_manager.OpenstackRunnerManager._ensure_security_group(connection_mock)
     connection_mock.create_security_group_rule.assert_not_called()

--- a/tests/unit/test_openstack_manager.py
+++ b/tests/unit/test_openstack_manager.py
@@ -761,13 +761,13 @@ def test__ensure_security_group_with_existing_rules():
     assert: The security rules are not created again.
     """
     connection_mock = MagicMock(spec=openstack.connection.Connection)
-    connection_mock.get_security_group.return_value = {
+    connection_mock.list_security_groups.return_value = [{
         "security_group_rules": [
             {"protocol": "icmp"},
             {"protocol": "tcp", "port_range_min": 22, "port_range_max": 22},
             {"protocol": "tcp", "port_range_min": 10022, "port_range_max": 10022},
         ]
-    }
+    }]
 
     openstack_manager.OpenstackRunnerManager._ensure_security_group(connection_mock)
     connection_mock.create_security_group_rule.assert_not_called()


### PR DESCRIPTION
### Overview

Change to get a list of security group with the same name via Openstack API.
Then use the first in the list if present.

### Rationale

Accessing security group via name will result in exception if multiple security group with the same name.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->