### PR TITLE
Add security group rules by ID

### DIFF
--- a/src-docs/openstack_cloud.openstack_manager.md
+++ b/src-docs/openstack_cloud.openstack_manager.md
@@ -146,7 +146,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1501"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1507"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -794,7 +794,7 @@ class OpenstackRunnerManager:
             for rule in existing_rules:
                 if rule["protocol"] == "icmp":
                     logger.debug(
-                        "Found ICMP rule in existing security group %s", SECURITY_GROUP_NAME
+                        "Found ICMP rule in existing security group %s of ID %s", SECURITY_GROUP_NAME, existing_security_group.id
                     )
                     rule_exists_icmp = True
                 if (
@@ -802,7 +802,7 @@ class OpenstackRunnerManager:
                     and rule["port_range_min"] == rule["port_range_max"] == 22
                 ):
                     logger.debug(
-                        "Found SSH rule in existing security group %s", SECURITY_GROUP_NAME
+                        "Found SSH rule in existing security group %s of ID %s", SECURITY_GROUP_NAME, existing_security_group.id
                     )
                     rule_exists_ssh = True
                 if (
@@ -810,20 +810,20 @@ class OpenstackRunnerManager:
                     and rule["port_range_min"] == rule["port_range_max"] == 10022
                 ):
                     logger.debug(
-                        "Found tmate SSH rule in existing security group %s", SECURITY_GROUP_NAME
+                        "Found tmate SSH rule in existing security group %s of ID %s", SECURITY_GROUP_NAME, existing_security_group.id
                     )
                     rule_exists_tmate_ssh = True
 
         if not rule_exists_icmp:
             conn.create_security_group_rule(
-                secgroup_name_or_id=SECURITY_GROUP_NAME,
+                secgroup_name_or_id=existing_security_group.id,
                 protocol="icmp",
                 direction="ingress",
                 ethertype="IPv4",
             )
         if not rule_exists_ssh:
             conn.create_security_group_rule(
-                secgroup_name_or_id=SECURITY_GROUP_NAME,
+                secgroup_name_or_id=existing_security_group.id,
                 port_range_min="22",
                 port_range_max="22",
                 protocol="tcp",
@@ -832,7 +832,7 @@ class OpenstackRunnerManager:
             )
         if not rule_exists_tmate_ssh:
             conn.create_security_group_rule(
-                secgroup_name_or_id=SECURITY_GROUP_NAME,
+                secgroup_name_or_id=existing_security_group.id,
                 port_range_min="10022",
                 port_range_max="10022",
                 protocol="tcp",

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -794,7 +794,9 @@ class OpenstackRunnerManager:
             for rule in existing_rules:
                 if rule["protocol"] == "icmp":
                     logger.debug(
-                        "Found ICMP rule in existing security group %s of ID %s", SECURITY_GROUP_NAME, existing_security_group.id
+                        "Found ICMP rule in existing security group %s of ID %s",
+                        SECURITY_GROUP_NAME,
+                        existing_security_group["id"],
                     )
                     rule_exists_icmp = True
                 if (
@@ -802,7 +804,9 @@ class OpenstackRunnerManager:
                     and rule["port_range_min"] == rule["port_range_max"] == 22
                 ):
                     logger.debug(
-                        "Found SSH rule in existing security group %s of ID %s", SECURITY_GROUP_NAME, existing_security_group.id
+                        "Found SSH rule in existing security group %s of ID %s",
+                        SECURITY_GROUP_NAME,
+                        existing_security_group["id"],
                     )
                     rule_exists_ssh = True
                 if (
@@ -810,35 +814,37 @@ class OpenstackRunnerManager:
                     and rule["port_range_min"] == rule["port_range_max"] == 10022
                 ):
                     logger.debug(
-                        "Found tmate SSH rule in existing security group %s of ID %s", SECURITY_GROUP_NAME, existing_security_group.id
+                        "Found tmate SSH rule in existing security group %s of ID %s",
+                        SECURITY_GROUP_NAME,
+                        existing_security_group["id"],
                     )
                     rule_exists_tmate_ssh = True
 
-        if not rule_exists_icmp:
-            conn.create_security_group_rule(
-                secgroup_name_or_id=existing_security_group.id,
-                protocol="icmp",
-                direction="ingress",
-                ethertype="IPv4",
-            )
-        if not rule_exists_ssh:
-            conn.create_security_group_rule(
-                secgroup_name_or_id=existing_security_group.id,
-                port_range_min="22",
-                port_range_max="22",
-                protocol="tcp",
-                direction="ingress",
-                ethertype="IPv4",
-            )
-        if not rule_exists_tmate_ssh:
-            conn.create_security_group_rule(
-                secgroup_name_or_id=existing_security_group.id,
-                port_range_min="10022",
-                port_range_max="10022",
-                protocol="tcp",
-                direction="egress",
-                ethertype="IPv4",
-            )
+            if not rule_exists_icmp:
+                conn.create_security_group_rule(
+                    secgroup_name_or_id=existing_security_group["id"],
+                    protocol="icmp",
+                    direction="ingress",
+                    ethertype="IPv4",
+                )
+            if not rule_exists_ssh:
+                conn.create_security_group_rule(
+                    secgroup_name_or_id=existing_security_group["id"],
+                    port_range_min="22",
+                    port_range_max="22",
+                    protocol="tcp",
+                    direction="ingress",
+                    ethertype="IPv4",
+                )
+            if not rule_exists_tmate_ssh:
+                conn.create_security_group_rule(
+                    secgroup_name_or_id=existing_security_group["id"],
+                    port_range_min="10022",
+                    port_range_max="10022",
+                    protocol="tcp",
+                    direction="egress",
+                    ethertype="IPv4",
+                )
 
     @staticmethod
     def _setup_runner_keypair(conn: OpenstackConnection, name: str) -> None:

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -785,7 +785,7 @@ class OpenstackRunnerManager:
 
         if existing_security_group is None:
             logger.info("Security group %s not found, creating it", SECURITY_GROUP_NAME)
-            conn.create_security_group(
+            existing_security_group = conn.create_security_group(
                 name=SECURITY_GROUP_NAME,
                 description="For servers managed by the github-runner charm.",
             )
@@ -820,14 +820,14 @@ class OpenstackRunnerManager:
                     )
                     rule_exists_tmate_ssh = True
 
-        if not rule_exists_icmp and existing_security_group is not None:
+        if not rule_exists_icmp:
             conn.create_security_group_rule(
                 secgroup_name_or_id=existing_security_group["id"],
                 protocol="icmp",
                 direction="ingress",
                 ethertype="IPv4",
             )
-        if not rule_exists_ssh and existing_security_group is not None:
+        if not rule_exists_ssh:
             conn.create_security_group_rule(
                 secgroup_name_or_id=existing_security_group["id"],
                 port_range_min="22",
@@ -836,7 +836,7 @@ class OpenstackRunnerManager:
                 direction="ingress",
                 ethertype="IPv4",
             )
-        if not rule_exists_tmate_ssh and existing_security_group is not None:
+        if not rule_exists_tmate_ssh:
             conn.create_security_group_rule(
                 secgroup_name_or_id=existing_security_group["id"],
                 port_range_min="10022",

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -820,31 +820,31 @@ class OpenstackRunnerManager:
                     )
                     rule_exists_tmate_ssh = True
 
-            if not rule_exists_icmp:
-                conn.create_security_group_rule(
-                    secgroup_name_or_id=existing_security_group["id"],
-                    protocol="icmp",
-                    direction="ingress",
-                    ethertype="IPv4",
-                )
-            if not rule_exists_ssh:
-                conn.create_security_group_rule(
-                    secgroup_name_or_id=existing_security_group["id"],
-                    port_range_min="22",
-                    port_range_max="22",
-                    protocol="tcp",
-                    direction="ingress",
-                    ethertype="IPv4",
-                )
-            if not rule_exists_tmate_ssh:
-                conn.create_security_group_rule(
-                    secgroup_name_or_id=existing_security_group["id"],
-                    port_range_min="10022",
-                    port_range_max="10022",
-                    protocol="tcp",
-                    direction="egress",
-                    ethertype="IPv4",
-                )
+        if not rule_exists_icmp and existing_security_group is not None:
+            conn.create_security_group_rule(
+                secgroup_name_or_id=existing_security_group["id"],
+                protocol="icmp",
+                direction="ingress",
+                ethertype="IPv4",
+            )
+        if not rule_exists_ssh and existing_security_group is not None:
+            conn.create_security_group_rule(
+                secgroup_name_or_id=existing_security_group["id"],
+                port_range_min="22",
+                port_range_max="22",
+                protocol="tcp",
+                direction="ingress",
+                ethertype="IPv4",
+            )
+        if not rule_exists_tmate_ssh and existing_security_group is not None:
+            conn.create_security_group_rule(
+                secgroup_name_or_id=existing_security_group["id"],
+                port_range_min="10022",
+                port_range_max="10022",
+                protocol="tcp",
+                direction="egress",
+                ethertype="IPv4",
+            )
 
     @staticmethod
     def _setup_runner_keypair(conn: OpenstackConnection, name: str) -> None:

--- a/tests/unit/test_openstack_manager.py
+++ b/tests/unit/test_openstack_manager.py
@@ -767,7 +767,8 @@ def test__ensure_security_group_with_existing_rules():
                 {"protocol": "icmp"},
                 {"protocol": "tcp", "port_range_min": 22, "port_range_max": 22},
                 {"protocol": "tcp", "port_range_min": 10022, "port_range_max": 10022},
-            ]
+            ],
+            "id": "TEST_ID",
         }
     ]
 


### PR DESCRIPTION


### Overview

1. Add ID of security group to logging.
2. Add security rules by ID of security group.

### Rationale

1. More info for debugging.
2. Causes an exception when:
  - Multiple security groups exists
  - The security groups does not have all the rules setup.
 
### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->