### PR TITLE
Use returned security group for create server

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -19,6 +19,8 @@ jobs:
       extra-arguments: "-m openstack"
       self-hosted-runner: true
       self-hosted-runner-label: stg-private-endpoint
+      tmate-debug: true
+      tmate-timeout: 300
 
   required_status_checks:
     name: Required E2E Test Status Checks

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -19,8 +19,6 @@ jobs:
       extra-arguments: "-m openstack"
       self-hosted-runner: true
       self-hosted-runner-label: stg-private-endpoint
-      tmate-debug: true
-      tmate-timeout: 300
 
   required_status_checks:
     name: Required E2E Test Status Checks

--- a/src-docs/openstack_cloud.openstack_manager.md
+++ b/src-docs/openstack_cloud.openstack_manager.md
@@ -18,7 +18,7 @@ Module for handling interactions with OpenStack.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L186"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L187"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `create_instance_config`
 
@@ -54,7 +54,7 @@ Create an instance config from charm data.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L110"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L111"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `InstanceConfig`
 The configuration values for creating a single runner instance. 
@@ -93,7 +93,7 @@ __init__(
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L279"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L280"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GithubRunnerRemoveError`
 Represents an error removing registered runner from Github. 
@@ -104,7 +104,7 @@ Represents an error removing registered runner from Github.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L289"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L290"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `OpenstackRunnerManager`
 Runner manager for OpenStack-based instances. 
@@ -117,7 +117,7 @@ Runner manager for OpenStack-based instances.
  - <b>`unit_num`</b>:  The juju unit number. 
  - <b>`instance_name`</b>:  Prefix of the name for the set of runners. 
 
-<a href="../src/openstack_cloud/openstack_manager.py#L298"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L299"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -146,7 +146,7 @@ Construct OpenstackRunnerManager object.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L1507"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L1512"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `flush`
 
@@ -163,7 +163,7 @@ Flush Openstack servers.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L400"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L401"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `get_github_runner_info`
 
@@ -180,7 +180,7 @@ Get information on GitHub for the runners.
 
 ---
 
-<a href="../src/openstack_cloud/openstack_manager.py#L329"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/openstack_cloud/openstack_manager.py#L330"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `reconcile`
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -534,7 +534,7 @@ class OpenstackRunnerManager:
     @staticmethod
     @retry(tries=3, delay=5, max_delay=60, backoff=2, local_logger=logger)
     def _get_ssh_connection(
-        conn: OpenstackConnection, server_name: str, timeout: int = 30
+        conn: OpenstackConnection, server_name: str, timeout: int = 60
     ) -> SshConnection:
         """Get a valid ssh connection within a network for a given openstack instance.
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -534,7 +534,7 @@ class OpenstackRunnerManager:
     @staticmethod
     @retry(tries=3, delay=5, max_delay=60, backoff=2, local_logger=logger)
     def _get_ssh_connection(
-        conn: OpenstackConnection, server_name: str, timeout: int = 60
+        conn: OpenstackConnection, server_name: str, timeout: int = 30
     ) -> SshConnection:
         """Get a valid ssh connection within a network for a given openstack instance.
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -689,7 +689,7 @@ class OpenstackRunnerManager:
                     key_name=instance_config.name,
                     flavor=args.config.flavor,
                     network=args.config.network,
-                    security_groups=[runner_security_group],
+                    security_groups=[runner_security_group["id"]],
                     userdata=cloud_userdata_str,
                     auto_ip=False,
                     timeout=CREATE_SERVER_TIMEOUT,

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -36,6 +36,7 @@ from invoke.runners import Result
 from openstack.compute.v2.server import Server
 from openstack.connection import Connection as OpenstackConnection
 from openstack.exceptions import SDKException
+from openstack.network.v2.security_group import SecurityGroup
 from paramiko.ssh_exception import NoValidConnectionsError
 
 import reactive.runner_manager as reactive_runner_manager
@@ -677,7 +678,7 @@ class OpenstackRunnerManager:
         )
 
         with _create_connection(cloud_config=args.cloud_config) as conn:
-            OpenstackRunnerManager._ensure_security_group(conn)
+            security_group = OpenstackRunnerManager._ensure_security_group(conn)
             OpenstackRunnerManager._setup_runner_keypair(conn, instance_config.name)
 
             logger.info("Creating runner %s", instance_config.name)
@@ -688,7 +689,7 @@ class OpenstackRunnerManager:
                     key_name=instance_config.name,
                     flavor=args.config.flavor,
                     network=args.config.network,
-                    security_groups=[SECURITY_GROUP_NAME],
+                    security_groups=[security_group.id],
                     userdata=cloud_userdata_str,
                     auto_ip=False,
                     timeout=CREATE_SERVER_TIMEOUT,
@@ -769,34 +770,37 @@ class OpenstackRunnerManager:
         return pre_job_contents
 
     @staticmethod
-    def _ensure_security_group(conn: OpenstackConnection) -> None:
+    def _ensure_security_group(conn: OpenstackConnection) -> SecurityGroup:
         """Ensure runner security group exists.
 
         Args:
             conn: The connection object to access OpenStack cloud.
+
+        Returns:
+            The security group with the rules for runners.
         """
         rule_exists_icmp = False
         rule_exists_ssh = False
         rule_exists_tmate_ssh = False
 
-        security_groups = conn.list_security_groups(filters={"name": SECURITY_GROUP_NAME})
+        security_group_list = conn.list_security_groups(filters={"name": SECURITY_GROUP_NAME})
         # Pick the first security_group returned.
-        existing_security_group = next(iter(security_groups), None)
+        security_group = next(iter(security_group_list), None)
 
-        if existing_security_group is None:
+        if security_group is None:
             logger.info("Security group %s not found, creating it", SECURITY_GROUP_NAME)
-            existing_security_group = conn.create_security_group(
+            security_group = conn.create_security_group(
                 name=SECURITY_GROUP_NAME,
                 description="For servers managed by the github-runner charm.",
             )
         else:
-            existing_rules = existing_security_group["security_group_rules"]
+            existing_rules = security_group["security_group_rules"]
             for rule in existing_rules:
                 if rule["protocol"] == "icmp":
                     logger.debug(
                         "Found ICMP rule in existing security group %s of ID %s",
                         SECURITY_GROUP_NAME,
-                        existing_security_group["id"],
+                        security_group["id"],
                     )
                     rule_exists_icmp = True
                 if (
@@ -806,7 +810,7 @@ class OpenstackRunnerManager:
                     logger.debug(
                         "Found SSH rule in existing security group %s of ID %s",
                         SECURITY_GROUP_NAME,
-                        existing_security_group["id"],
+                        security_group["id"],
                     )
                     rule_exists_ssh = True
                 if (
@@ -816,20 +820,20 @@ class OpenstackRunnerManager:
                     logger.debug(
                         "Found tmate SSH rule in existing security group %s of ID %s",
                         SECURITY_GROUP_NAME,
-                        existing_security_group["id"],
+                        security_group["id"],
                     )
                     rule_exists_tmate_ssh = True
 
         if not rule_exists_icmp:
             conn.create_security_group_rule(
-                secgroup_name_or_id=existing_security_group["id"],
+                secgroup_name_or_id=security_group["id"],
                 protocol="icmp",
                 direction="ingress",
                 ethertype="IPv4",
             )
         if not rule_exists_ssh:
             conn.create_security_group_rule(
-                secgroup_name_or_id=existing_security_group["id"],
+                secgroup_name_or_id=security_group["id"],
                 port_range_min="22",
                 port_range_max="22",
                 protocol="tcp",
@@ -838,13 +842,14 @@ class OpenstackRunnerManager:
             )
         if not rule_exists_tmate_ssh:
             conn.create_security_group_rule(
-                secgroup_name_or_id=existing_security_group["id"],
+                secgroup_name_or_id=security_group["id"],
                 port_range_min="10022",
                 port_range_max="10022",
                 protocol="tcp",
                 direction="egress",
                 ethertype="IPv4",
             )
+        return security_group
 
     @staticmethod
     def _setup_runner_keypair(conn: OpenstackConnection, name: str) -> None:

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -678,7 +678,7 @@ class OpenstackRunnerManager:
         )
 
         with _create_connection(cloud_config=args.cloud_config) as conn:
-            security_group = OpenstackRunnerManager._ensure_security_group(conn)
+            runner_security_group = OpenstackRunnerManager._ensure_security_group(conn)
             OpenstackRunnerManager._setup_runner_keypair(conn, instance_config.name)
 
             logger.info("Creating runner %s", instance_config.name)
@@ -689,7 +689,7 @@ class OpenstackRunnerManager:
                     key_name=instance_config.name,
                     flavor=args.config.flavor,
                     network=args.config.network,
-                    security_groups=[security_group.id],
+                    security_groups=[runner_security_group],
                     userdata=cloud_userdata_str,
                     auto_ip=False,
                     timeout=CREATE_SERVER_TIMEOUT,


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Use the security group configured with the correct rules for create server for openstack runners.

### Rationale
Fixes bug where multiple security rule might result in wrong security group (with incomplete rules) used.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->