### PR TITLE
Fix scheduled E2E-test

### DIFF
--- a/.github/workflows/scheduled_e2e_test.yaml
+++ b/.github/workflows/scheduled_e2e_test.yaml
@@ -250,7 +250,7 @@ jobs:
           REF_SHA=$(gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ secrets.E2E_TESTING_REPO }}/git/ref/heads/$GITHUB_HEAD_REF \
+            /repos/${{ secrets.E2E_TESTING_REPO }}/git/ref/heads/$GITHUB_REF_NAME \
             --jq .object.sha)
 
           # Create a temporary reference/branch


### PR DESCRIPTION
Applicable spec: n/a

### Overview

 Use GITHUB_REF_NAME environment variable instead of GITHUB_HEAD_REF 

### Rationale

because GITHUB_HEAD_REF is not defined for scheduled events(see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)

### Juju Events Changes

n/a

### Module Changes

n/a

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->