### PR TITLE
fix: setuptools breaking dep issue

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,7 +4,7 @@
 type: charm
 parts:
   charm:
-    charm-python-packages:
+    charm-binary-python-packages:
       - setuptools  # for jinja2
     build-packages:
       - git  # for installing git source of pylxd 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Setuptools new major release is not compatible with building from source with dogpile lib.
Using binary dependency fixes it.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->