### PR TITLE
Refine token docs for OpenStack

### DIFF
--- a/docs/reference/token-scopes.md
+++ b/docs/reference/token-scopes.md
@@ -18,8 +18,8 @@ Repository:
 
 - Actions: read (required if COS integration is enabled and private repositories exist)
 - Administration: read
-- Contents: read
-- Pull requests: read
+- Contents: read (not required if the charm is configured to use OpenStack runners)
+- Pull requests: read (not required if the charm is configured to use OpenStack runners)
 
 ### Repository Runners
 
@@ -28,9 +28,9 @@ repository runner.
 
 - Actions: read (required if COS integration is enabled and the repository is private)
 - Administration: read & write
-- Contents: read
+- Contents: read (not required if the charm is configured to use OpenStack runners)
 - Metadata: read
-- Pull requests: read
+- Pull requests: read (not required if the charm is configured to use OpenStack runners)
 
 ## Personal access token scopes
 


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Refine the token scope documentation for the "runners on Openstack cloud" use case.

### Rationale

Certain permissions are not required because the repo-policy deployment is external.

### Juju Events Changes

n/a

### Module Changes

n/a

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->