### PR TITLE
Add test args for openstack interface

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,3 +139,16 @@ def pytest_addoption(parser: Parser):
         help="The Openstack region to authenticate to.",
         default=None,
     )
+    # OpenStack integration tests
+    parser.addoption(
+        "--openstack-test-image",
+        action="store",
+        help="The image for testing openstack interfaces. Any ubuntu image should work.",
+        default=None,
+    )
+    parser.addoption(
+        "--openstack-test-flavor",
+        action="store",
+        help="The flavor for testing openstack interfaces. The resource should be enough to boot the test image.",
+        default=None,
+    )


### PR DESCRIPTION


### Overview

<!-- A high level overview of the change -->

Add new tests args for a upcoming PR.

### Rationale

<!-- The reason the change is needed -->

This prevents the integration test of other PR throwing errors due to extra tests args.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->