### PR TITLE
feat: openstack flush mode

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,10 +12,15 @@ parts:
       - libssl-dev  # for cryptography
       - rust-all  # for cryptography
       - pkg-config # for cryptography
+  scripts:
+    plugin: dump
+    source: scripts
+    organize:
+      build-lxd-image.sh: scripts/build-lxd-image.sh
+      reactive_runner.py: scripts/reactive_runner.py
+      repo_policy_compliance_service.py: scripts/repo_policy_compliance_service.py
     prime:
-      - scripts/build-lxd-image.sh
-      - scripts/reactive_runner.py
-      - scripts/repo_policy_compliance_service.py
+      - scripts/
 bases:
   - build-on:
     - name: "ubuntu"

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -462,7 +462,6 @@ class OpenstackRunnerManager:
         conn: OpenstackConnection,
         server_name: str,
         startup: bool = False,
-        building_timeout_mins: int = 10,
     ) -> bool:
         """Health check a server instance.
 
@@ -481,8 +480,6 @@ class OpenstackRunnerManager:
             conn: The Openstack connection instance.
             server_name: The name of the OpenStack server to health check.
             startup: Check only whether the startup is successful.
-            building_timeout_mins: How long to wait for BUILDING status until it is deemed
-                unhealthy.
 
         Returns:
             Whether the instance is healthy.
@@ -496,9 +493,9 @@ class OpenstackRunnerManager:
             return False
         created_at = datetime.strptime(server.created_at, "%Y-%m-%dT%H:%M:%SZ")
         current_time = datetime.now(created_at.tzinfo)
-        elapsed_min = (created_at - current_time).total_seconds() / 60
+        elapsed_min = (created_at - current_time).total_seconds()
         if server.status == _INSTANCE_STATUS_BUILDING:
-            return elapsed_min < building_timeout_mins
+            return elapsed_min < CREATE_SERVER_TIMEOUT
         return OpenstackRunnerManager._ssh_health_check(
             conn=conn, server_name=server_name, startup=startup
         )

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -1574,6 +1574,6 @@ class OpenstackRunnerManager:
                 warn=True,
             )
             if not result.ok:
-                logger.warning("Failed to kill idle runner process. Instance: %s", server.name)
+                logger.warning("Failed to kill runner process. Instance: %s", server.name)
                 continue
-            logger.info("Successfully killed idle runner process. Instance: %s", server.name)
+            logger.info("Successfully killed runner process. Instance: %s", server.name)

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -467,9 +467,10 @@ class OpenstackRunnerManager:
 
         A healthy server is defined as:
             1. Openstack instance status is ACTIVE or BUILDING.
-            2. Runner.Worker exists (running a job).
-            3. Runner.Listener exists (waiting for job).
-            3. GitHub runner status is Idle or Active.
+            2. Openstack instance status is in BUILDING less than CREATE_SERVER_TIMEOUT seconds.
+            3. Runner.Worker exists (running a job).
+            4. Runner.Listener exists (waiting for job).
+            5. GitHub runner status is Idle or Active.
 
         An undetermined server is marked as healthy when:
             1. SSH fails - could be a transient network error.

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -20,6 +20,7 @@ import shutil
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from multiprocessing import Pool
 from pathlib import Path
 from typing import Iterable, Iterator, Literal, Optional, cast
@@ -32,7 +33,6 @@ import openstack.exceptions
 import openstack.image.v2.image
 import paramiko
 from fabric import Connection as SshConnection
-from invoke.runners import Result
 from openstack.compute.v2.server import Server
 from openstack.connection import Connection as OpenstackConnection
 from openstack.exceptions import SDKException
@@ -60,7 +60,7 @@ from metrics import storage as metrics_storage
 from metrics.runner import RUNNER_INSTALLED_TS_FILE_NAME
 from repo_policy_compliance_client import RepoPolicyComplianceClient
 from runner_manager import IssuedMetricEventsStats
-from runner_manager_type import OpenstackRunnerManagerConfig
+from runner_manager_type import FlushMode, OpenstackRunnerManagerConfig
 from runner_type import GithubPath, RunnerByHealth, RunnerGithubInfo
 from utilities import retry, set_env_var
 
@@ -457,7 +457,12 @@ class OpenstackRunnerManager:
         ]
 
     @staticmethod
-    def _health_check(conn: OpenstackConnection, server_name: str, startup: bool = False) -> bool:
+    def _health_check(
+        conn: OpenstackConnection,
+        server_name: str,
+        startup: bool = False,
+        building_timeout_mins: int = 10,
+    ) -> bool:
         """Health check a server instance.
 
         A healthy server is defined as:
@@ -475,6 +480,8 @@ class OpenstackRunnerManager:
             conn: The Openstack connection instance.
             server_name: The name of the OpenStack server to health check.
             startup: Check only whether the startup is successful.
+            building_timeout_mins: How long to wait for BULIDING status until it is deemed
+                unhealthy.
 
         Returns:
             Whether the instance is healthy.
@@ -486,6 +493,11 @@ class OpenstackRunnerManager:
             return False
         if server.status not in (_INSTANCE_STATUS_ACTIVE, _INSTANCE_STATUS_BUILDING):
             return False
+        created_at = datetime.strptime(server.created_at, "%Y-%m-%dT%H:%M:%SZ")
+        current_time = datetime.now(created_at.tzinfo)
+        elapsed_min = (created_at - current_time).total_seconds() / 60
+        if server.status == _INSTANCE_STATUS_BUILDING:
+            return elapsed_min < building_timeout_mins
         return OpenstackRunnerManager._ssh_health_check(
             conn=conn, server_name=server_name, startup=startup
         )
@@ -527,8 +539,7 @@ class OpenstackRunnerManager:
         if RUNNER_WORKER_PROCESS in result.stdout or RUNNER_LISTENER_PROCESS in result.stdout:
             return True
 
-        logger.error("[ALERT] Health check failed for server: %s", server_name)
-        return True
+        return False
 
     @staticmethod
     @retry(tries=3, delay=5, max_delay=60, backoff=2, local_logger=logger)
@@ -1178,7 +1189,7 @@ class OpenstackRunnerManager:
             ) from exc
 
         try:
-            result: Result = ssh_conn.run(
+            result: invoke.runners.Result = ssh_conn.run(
                 f"{_CONFIG_SCRIPT_PATH} remove --token {remove_token}",
                 warn=True,
             )
@@ -1498,20 +1509,66 @@ class OpenstackRunnerManager:
         except IssueMetricEventError:
             logger.exception("Failed to issue Reconciliation metric")
 
-    def flush(self) -> int:
+    def flush(self, mode: FlushMode = FlushMode.FLUSH_IDLE) -> int:
         """Flush Openstack servers.
+
+        1. Kill the processes depending on flush mode.
+        2. Get unhealthy runners after process purging.
+        3. Delete unhealthy runners.
 
         Returns:
             The number of runners flushed.
         """
         logger.info("Flushing OpenStack all runners")
         with _create_connection(self._cloud_config) as conn:
+            self._kill_runner_processes(conn=conn, mmode=mode)
             runner_by_health = self._get_openstack_runner_status(conn)
             remove_token = self._github.get_runner_remove_token(path=self._config.path)
-            runners_to_delete = (*runner_by_health.healthy, *runner_by_health.unhealthy)
             self._remove_runners(
                 conn=conn,
-                instance_names=runners_to_delete,
+                instance_names=runner_by_health.unhealthy,
                 remove_token=remove_token,
             )
-            return len(runners_to_delete)
+        return len(runner_by_health.unhealthy)
+
+    def _kill_runner_processes(self, conn: OpenstackConnection, mode: FlushMode):
+        """Kill runner application that are not running any jobs.
+
+        Runners that have not picked up a job has
+        1. no Runner.Worker process
+        2. no pre-run.sh job process
+
+        Args:
+            conn: The connection object to access OpenStack cloud.
+            mode: The flush mode to determine which runner processes to kill.
+
+        Raises:
+            NotImplementedError: If unsupported flush mode has been passed.
+        """
+        killer_command: str
+        match mode:
+            case FlushMode.FLUSH_IDLE:
+                killer_command = (
+                    "! pgrep -x Runner.Worker && pgrep -x Runner.Listener && "
+                    "kill $(pgrep -x Runner.Listener)"
+                )
+            case FlushMode.FLUSH_BUSY:
+                # This kills pre-job as well.
+                killer_command = (
+                    "pgrep -x Runner.Listener && kill $(pgrep -x Runner.Listener);"
+                    "pgrep -x Runner.Worker && kill $(pgrep -x Runner.Worker);"
+                )
+            case _:
+                raise NotImplementedError(f"Unsupported flush mode {mode}")
+
+        servers = self._get_openstack_instances(conn=conn)
+        for server in servers:
+            ssh_conn: SshConnection = self._get_ssh_connection(conn=conn, server=server.name)
+            result: invoke.runners.Result = ssh_conn.run(
+                killer_command,
+                warn=True,
+            )
+            if not result.ok:
+                logger.warning("Failed to kill idle runner process. Instance: %s", server.name)
+                continue
+            logger.info("Successfully killed idle runner process. Instance: %s", server.name)

--- a/src/runner_manager.py
+++ b/src/runner_manager.py
@@ -672,11 +672,11 @@ class RunnerManager:
                     )
                 )
 
-        if mode in {
+        if mode in (
             FlushMode.FLUSH_BUSY_WAIT_REPO_CHECK,
             FlushMode.FLUSH_BUSY,
             FlushMode.FORCE_FLUSH_WAIT_REPO_CHECK,
-        }:
+        ):
             busy_runners = [runner for runner in self._get_runners() if runner.status.exist]
 
             logger.info("Removing existing %i busy local runners", len(runners))

--- a/src/runner_manager_type.py
+++ b/src/runner_manager_type.py
@@ -20,6 +20,9 @@ from repo_policy_compliance_client import RepoPolicyComplianceClient
 class FlushMode(Enum):
     """Strategy for flushing runners.
 
+    During pre-job (repo-check), the runners are marked as idle and if the pre-job fails, the
+    runner falls back to being idle again. Hence wait_repo_check is required.
+
     Attributes:
         FLUSH_IDLE: Flush only idle runners.
         FLUSH_IDLE_WAIT_REPO_CHECK: Flush only idle runners, then wait until repo-policy-check is

--- a/tests/integration/test_charm_base_image.py
+++ b/tests/integration/test_charm_base_image.py
@@ -48,7 +48,7 @@ async def test_runner_base_image(
     assert "noble" in str(stdout)
 
     # Workflow completes successfully
-    workflow = await dispatch_workflow(
+    workflow_run = await dispatch_workflow(
         app=app_no_wait,
         branch=test_github_branch,
         github_repository=github_repository,
@@ -56,4 +56,4 @@ async def test_runner_base_image(
         workflow_id_or_name=DISPATCH_E2E_TEST_RUN_WORKFLOW_FILENAME,
         dispatch_input={"runner-tag": app_no_wait.name, "runner-virt-type": "lxd"},
     )
-    await wait_for(lambda: workflow.get_runs()[0].status == "completed")
+    await wait_for(lambda: workflow_run.update() and workflow_run.status == "completed")

--- a/tests/integration/test_charm_runner.py
+++ b/tests/integration/test_charm_runner.py
@@ -93,7 +93,7 @@ async def test_flush_runner_and_resource_config(
     unit = app.units[0]
 
     # 1.
-    action = await app.units[0].run_action("check-runners")
+    action: Action = await app.units[0].run_action("check-runners")
     await action.wait()
 
     assert action.status == "completed"
@@ -148,14 +148,14 @@ async def test_flush_runner_and_resource_config(
         wait=False,
     )
     await wait_for(lambda: workflow.update() or workflow.status == "in_progress")
-    action: Action = await app.units[0].run_action("flush-runners")
+    action = await app.units[0].run_action("flush-runners")
     await action.wait()
 
     assert action.status == "completed"
     assert action.results["delta"]["virtual-machines"] == "0"
 
     await wait_for(lambda: workflow.update() or workflow.status == "completed")
-    action: Action = await app.units[0].run_action("flush-runners")
+    action = await app.units[0].run_action("flush-runners")
     await action.wait()
 
     assert action.status == "completed"

--- a/tests/integration/test_charm_runner.py
+++ b/tests/integration/test_charm_runner.py
@@ -20,6 +20,7 @@ from charm_state import (
 from tests.integration.helpers import lxd
 from tests.integration.helpers.common import (
     DISPATCH_TEST_WORKFLOW_FILENAME,
+    DISPATCH_WAIT_TEST_WORKFLOW_FILENAME,
     InstanceHelper,
     dispatch_workflow,
     wait_for,
@@ -141,7 +142,8 @@ async def test_flush_runner_and_resource_config(
         branch=test_github_branch,
         github_repository=github_repository,
         conclusion="success",
-        workflow_id_or_name=DISPATCH_TEST_WORKFLOW_FILENAME,
+        workflow_id_or_name=DISPATCH_WAIT_TEST_WORKFLOW_FILENAME,
+        dispatch_input={"runner": app.name, "minutes": "5"},
         wait=False,
     )
     await wait_for(lambda: workflow.update() and workflow.status == "in_progress")

--- a/tests/integration/test_charm_runner.py
+++ b/tests/integration/test_charm_runner.py
@@ -146,7 +146,7 @@ async def test_flush_runner_and_resource_config(
         dispatch_input={"runner": app.name, "minutes": "5"},
         wait=False,
     )
-    await wait_for(lambda: workflow.update() and workflow.status == "in_progress")
+    await wait_for(lambda: workflow.update() or workflow.status == "in_progress")
     action = await app.units[0].run_action("flush-runners")
     await action.wait()
 

--- a/tests/integration/test_charm_runner.py
+++ b/tests/integration/test_charm_runner.py
@@ -153,6 +153,9 @@ async def test_flush_runner_and_resource_config(
     assert action.status == "completed"
     assert action.results["delta"]["virtual-machines"] == "0"
 
+    action = await app.units[0].run_action("reconcile-runners")
+    await action.wait()
+
 
 @pytest.mark.openstack
 @pytest.mark.asyncio

--- a/tests/unit/test_openstack_manager.py
+++ b/tests/unit/test_openstack_manager.py
@@ -26,6 +26,7 @@ from metrics.runner import RUNNER_INSTALLED_TS_FILE_NAME
 from metrics.storage import MetricsStorage
 from openstack_cloud import openstack_manager
 from openstack_cloud.openstack_manager import MAX_METRICS_FILE_SIZE, METRICS_EXCHANGE_PATH
+from runner_manager_type import FlushMode
 from runner_type import RunnerByHealth, RunnerGithubInfo
 from tests.unit import factories
 
@@ -149,7 +150,7 @@ def patched_create_connection_context_fixture(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture(name="ssh_connection_mock")
-def ssh_connection_mock_fixture(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+def ssh_connection_mock_fixture() -> MagicMock:
     """Return a mocked ssh connection."""
     test_file_content = secrets.token_hex(16)
     ssh_conn_mock = MagicMock(spec=openstack_manager.SshConnection)
@@ -834,7 +835,7 @@ def test__ssh_health_check_no_key(mock_server: MagicMock):
     )
 
 
-def test__ssh_health_check_error(mock_server: MagicMock, patch_ssh_connection_error):
+def test__ssh_health_check_error(mock_server: MagicMock):
     """
     arrange: A server with error on SSH run.
     act: Run health check on the server.
@@ -1147,3 +1148,72 @@ def test__get_ssh_connection_server(monkeypatch: pytest.MonkeyPatch):
         )
         == mock_ssh_connection
     )
+
+
+def test_flush(monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: given monkeypatched sub functions of flush.
+    act: when flush is called.
+    assert: sub functions are called.
+    """
+    monkeypatch.setattr(openstack_manager, "_create_connection", MagicMock())
+    monkeypatch.setattr(openstack_manager, "set_env_var", MagicMock())
+    runner_manager = openstack_manager.OpenstackRunnerManager(
+        app_name=MagicMock(),
+        unit_num=MagicMock(),
+        openstack_runner_manager_config=MagicMock(),
+        cloud_config=MagicMock(),
+    )
+    runner_manager._kill_runner_processes = MagicMock()
+    runner_manager._get_openstack_runner_status = MagicMock()
+    runner_manager._github = MagicMock()
+    runner_manager._remove_runners = MagicMock()
+
+    runner_manager.flush(mode=MagicMock())
+
+    runner_manager._kill_runner_processes.assert_called()
+    runner_manager._get_openstack_runner_status.assert_called()
+    runner_manager._github.get_runner_remove_token.assert_called()
+    runner_manager._remove_runners.assert_called()
+
+
+@pytest.mark.parametrize(
+    "flush_mode, expected_command",
+    [
+        pytest.param(
+            FlushMode.FLUSH_BUSY,
+            "pgrep -x Runner.Listener && kill $(pgrep -x Runner.Listener);"
+            "pgrep -x Runner.Worker && kill $(pgrep -x Runner.Worker);",
+            id="Flush Busy",
+        ),
+        pytest.param(
+            FlushMode.FLUSH_IDLE,
+            "! pgrep -x Runner.Worker && pgrep -x Runner.Listener && "
+            "kill $(pgrep -x Runner.Listener)",
+            id="Flush Idle",
+        ),
+    ],
+)
+def test__kill_runner_processes(
+    monkeypatch: pytest.MonkeyPatch, flush_mode: FlushMode, expected_command: str
+):
+    """
+    arrange: given supported flush modes.
+    act: when _kill_runner_processes is called.
+    assert: expected kill commands are issued.
+    """
+    monkeypatch.setattr(openstack_manager, "_create_connection", MagicMock())
+    monkeypatch.setattr(openstack_manager, "set_env_var", MagicMock())
+    runner_manager = openstack_manager.OpenstackRunnerManager(
+        app_name=MagicMock(),
+        unit_num=MagicMock(),
+        openstack_runner_manager_config=MagicMock(),
+        cloud_config=MagicMock(),
+    )
+    runner_manager._get_openstack_instances = MagicMock(return_value=[MagicMock(), MagicMock()])
+    mock_connection = MagicMock()
+    runner_manager._get_ssh_connection = MagicMock(return_value=mock_connection)
+
+    runner_manager._kill_runner_processes(conn=MagicMock(), mode=flush_mode)
+
+    mock_connection.run.assert_called_with(expected_command, warn=True)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Add flushmode support for Openstack.
- Add timeout to openstack runners being stuck in BUILD status for +10 min.

Flush logic:
1. Kill runner processes
  - IDLE: Dispatch ssh exec command to kill `Runner.Listener` process if `Runner.Worker` is not found.
  - BUSY: Dispatch ssh exec command to kill `Runner.Listener` and `Runner.Worker`.
2. Health check - since runner processes do not exist, health check should fail for that ones that were killed.
3. Cleanup - regular cleanup process & metrics extraction.

<!-- A high level overview of the change -->

### Rationale

- Imagebuilder update kept flushing runners to death.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

- `openstack_manager.py` now supports two flush modes: `FlushIdle` and `FlushBusy`
- Other flush modes are unsupported due to not enough use-case. Will propose to remove `WAIT_FOR_REPO_CHECK` type flush modes.
<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->