### PR TITLE
test: add amd64/arm64 testing options

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,7 @@ def pytest_addoption(parser: Parser):
         "--openstack-clouds-yaml",
         action="store",
         help="The OpenStack clouds yaml file for the charm to use.",
+        default="",
     )
     parser.addoption(
         "--use-existing-app",
@@ -66,7 +67,7 @@ def pytest_addoption(parser: Parser):
         "It is expected that the existing app is already integrated with other apps "
         "like grafana-agent, etc. ",
     )
-    # Private endpoint options
+    # Private endpoint shared options
     parser.addoption(
         "--openstack-http-proxy",
         action="store",
@@ -85,61 +86,99 @@ def pytest_addoption(parser: Parser):
         help="The no proxy used to openstack integration.",
         default=None,
     )
+    # Private endpoint options AMD64
     parser.addoption(
-        "--openstack-network-name",
+        "--openstack-network-name-amd64",
         action="store",
         help="The Openstack network to create testing instances under.",
-        default=None,
     )
     parser.addoption(
-        "--openstack-flavor-name",
+        "--openstack-flavor-name-amd64",
         action="store",
         help="The Openstack flavor to create testing instances with.",
-        default=None,
     )
     parser.addoption(
-        "--openstack-auth-url",
+        "--openstack-auth-url-amd64",
         action="store",
         help="The URL to Openstack authentication service, i.e. keystone.",
-        default=None,
     )
     parser.addoption(
-        "--openstack-password",
+        "--openstack-password-amd64",
         action="store",
         help="The password to authenticate to Openstack service.",
-        default=None,
     )
     parser.addoption(
-        "--openstack-project-domain-name",
+        "--openstack-project-domain-name-amd64",
         action="store",
         help="The Openstack project domain name to use.",
-        default=None,
     )
     parser.addoption(
-        "--openstack-project-name",
+        "--openstack-project-name-amd64",
         action="store",
         help="The Openstack project name to use.",
-        default=None,
     )
     parser.addoption(
-        "--openstack-user-domain-name",
+        "--openstack-user-domain-name-amd64",
         action="store",
         help="The Openstack user domain name to use.",
-        default=None,
     )
     parser.addoption(
-        "--openstack-username",
+        "--openstack-username-amd64",
         action="store",
         help="The Openstack user to authenticate as.",
-        default=None,
     )
     parser.addoption(
-        "--openstack-region-name",
+        "--openstack-region-name-amd64",
         action="store",
         help="The Openstack region to authenticate to.",
-        default=None,
     )
-    # OpenStack integration tests
+    # Private endpoint options ARM64
+    parser.addoption(
+        "--openstack-network-name-arm64",
+        action="store",
+        help="The Openstack network to create testing instances under.",
+    )
+    parser.addoption(
+        "--openstack-flavor-name-arm64",
+        action="store",
+        help="The Openstack flavor to create testing instances with.",
+    )
+    parser.addoption(
+        "--openstack-auth-url-arm64",
+        action="store",
+        help="The URL to Openstack authentication service, i.e. keystone.",
+    )
+    parser.addoption(
+        "--openstack-password-arm64",
+        action="store",
+        help="The password to authenticate to Openstack service.",
+    )
+    parser.addoption(
+        "--openstack-project-domain-name-arm64",
+        action="store",
+        help="The Openstack project domain name to use.",
+    )
+    parser.addoption(
+        "--openstack-project-name-arm64",
+        action="store",
+        help="The Openstack project name to use.",
+    )
+    parser.addoption(
+        "--openstack-user-domain-name-arm64",
+        action="store",
+        help="The Openstack user domain name to use.",
+    )
+    parser.addoption(
+        "--openstack-username-arm64",
+        action="store",
+        help="The Openstack user to authenticate as.",
+    )
+    parser.addoption(
+        "--openstack-region-name-arm64",
+        action="store",
+        help="The Openstack region to authenticate to.",
+    )
+    # Interface testing args
     parser.addoption(
         "--openstack-test-image",
         action="store",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -194,13 +194,13 @@ def loop_device(pytestconfig: pytest.Config) -> Optional[str]:
 @pytest.fixture(scope="module", name="private_endpoint_config")
 def private_endpoint_config_fixture(pytestconfig: pytest.Config) -> PrivateEndpointConfigs | None:
     """The private endpoint configuration values."""
-    auth_url = pytestconfig.getoption("--openstack-auth-url")
-    password = pytestconfig.getoption("--openstack-password")
-    project_domain_name = pytestconfig.getoption("--openstack-project-domain-name")
-    project_name = pytestconfig.getoption("--openstack-project-name")
-    user_domain_name = pytestconfig.getoption("--openstack-user-domain-name")
-    user_name = pytestconfig.getoption("--openstack-username")
-    region_name = pytestconfig.getoption("--openstack-region-name")
+    auth_url = pytestconfig.getoption("--openstack-auth-url-amd64")
+    password = pytestconfig.getoption("--openstack-password-amd64")
+    project_domain_name = pytestconfig.getoption("--openstack-project-domain-name-amd64")
+    project_name = pytestconfig.getoption("--openstack-project-name-amd64")
+    user_domain_name = pytestconfig.getoption("--openstack-user-domain-name-amd64")
+    user_name = pytestconfig.getoption("--openstack-username-amd64")
+    region_name = pytestconfig.getoption("--openstack-region-name-amd64")
     if any(
         not val
         for val in (
@@ -265,15 +265,15 @@ def clouds_yaml_contents_fixture(
 @pytest.fixture(scope="module", name="network_name")
 def network_name_fixture(pytestconfig: pytest.Config) -> str:
     """Network to use to spawn test instances under."""
-    network_name = pytestconfig.getoption("--openstack-network-name")
-    assert network_name, "Please specify the --openstack-network-name command line option"
+    network_name = pytestconfig.getoption("--openstack-network-name-amd64")
+    assert network_name, "Please specify the --openstack-network-name-amd64 command line option"
     return network_name
 
 
 @pytest.fixture(scope="module", name="flavor_name")
 def flavor_name_fixture(pytestconfig: pytest.Config) -> str:
     """Flavor to create testing instances with."""
-    flavor_name = pytestconfig.getoption("--openstack-flavor-name")
+    flavor_name = pytestconfig.getoption("--openstack-flavor-name-amd64")
     assert flavor_name, "Please specify the --openstack-flavor-name command line option"
     return flavor_name
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Add test options to enable ARM64 tests

### Rationale

- Implement CI for ARM64

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->