### PR TITLE
fix: ssh health check failure status report

### DIFF
--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -502,6 +502,7 @@ class OpenstackRunnerManager:
         )
 
     @staticmethod
+    @retry(tries=5, delay=10, max_delay=60, backoff=2, local_logger=logger)
     def _ssh_health_check(conn: OpenstackConnection, server_name: str, startup: bool) -> bool:
         """Use SSH to check whether runner application is running.
 
@@ -524,7 +525,7 @@ class OpenstackRunnerManager:
             )
         except _SSHError as exc:
             logger.error("[ALERT]: Unable to SSH to server: %s, reason: %s", server_name, str(exc))
-            return True
+            return False
 
         result: invoke.runners.Result = ssh_conn.run("ps aux", warn=True)
         logger.debug("Output of `ps aux` on %s stderr: %s", server_name, result.stderr)
@@ -541,7 +542,7 @@ class OpenstackRunnerManager:
         return False
 
     @staticmethod
-    @retry(tries=3, delay=5, max_delay=60, backoff=2, local_logger=logger)
+    @retry(tries=5, delay=10, max_delay=60, backoff=2, local_logger=logger)
     def _get_ssh_connection(
         conn: OpenstackConnection, server_name: str, timeout: int = 30
     ) -> SshConnection:

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -502,7 +502,7 @@ class OpenstackRunnerManager:
                 conn=conn, server_name=server_name, startup=startup
             )
         except _SSHError:
-            logger.warning("Health chedk failed, unable to SSH into server: %s", server_name)
+            logger.warning("Health check failed, unable to SSH into server: %s", server_name)
             return False
 
     @staticmethod

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -502,7 +502,7 @@ class OpenstackRunnerManager:
         )
 
     @staticmethod
-    @retry(tries=5, delay=10, max_delay=60, backoff=2, local_logger=logger)
+    @retry(tries=2, delay=30, max_delay=60, backoff=2, local_logger=logger)
     def _ssh_health_check(conn: OpenstackConnection, server_name: str, startup: bool) -> bool:
         """Use SSH to check whether runner application is running.
 

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -502,7 +502,8 @@ class OpenstackRunnerManager:
         )
 
     @staticmethod
-    @retry(tries=2, delay=30, max_delay=60, backoff=2, local_logger=logger)
+    # retry for 4m
+    @retry(tries=5, delay=20, max_delay=60, backoff=2, local_logger=logger)
     def _ssh_health_check(conn: OpenstackConnection, server_name: str, startup: bool) -> bool:
         """Use SSH to check whether runner application is running.
 
@@ -548,7 +549,8 @@ class OpenstackRunnerManager:
         return False
 
     @staticmethod
-    @retry(tries=5, delay=10, max_delay=60, backoff=2, local_logger=logger)
+    # retry for 4m
+    @retry(tries=5, delay=20, max_delay=60, backoff=2, local_logger=logger)
     def _get_ssh_connection(
         conn: OpenstackConnection, server_name: str, timeout: int = 30
     ) -> SshConnection:

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -516,6 +516,9 @@ class OpenstackRunnerManager:
             server_name: The openstack server instance to check connections.
             startup: Check only whether the startup is successful.
 
+        Raises:
+            _SSHError: if there was an error SSH-ing into the machine or with the SSH command.
+
         Returns:
             Whether the runner application is running.
         """
@@ -532,7 +535,7 @@ class OpenstackRunnerManager:
         if not result.ok:
             logger.warning("List all process command failed on %s.", server_name)
             raise _SSHError(f"List process command failed on {server_name}.")
-        if not RUNNER_STARTUP_PROCESS not in result.stdout:
+        if RUNNER_STARTUP_PROCESS not in result.stdout:
             raise _SSHError(f"Runner not yet started on {server_name}.")
 
         logger.info("Runner process found to be healthy on %s", server_name)

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -506,8 +506,7 @@ class OpenstackRunnerManager:
             return False
 
     @staticmethod
-    # retry for 6m 20s
-    @retry(tries=5, delay=20, max_delay=120, backoff=2, local_logger=logger)
+    @retry(tries=3, delay=5, max_delay=60, backoff=2, local_logger=logger)
     def _ssh_health_check(conn: OpenstackConnection, server_name: str, startup: bool) -> bool:
         """Use SSH to check whether runner application is running.
 
@@ -554,8 +553,7 @@ class OpenstackRunnerManager:
         return False
 
     @staticmethod
-    # retry for 6m 20s
-    @retry(tries=5, delay=20, max_delay=120, backoff=2, local_logger=logger)
+    @retry(tries=3, delay=5, max_delay=60, backoff=2, local_logger=logger)
     def _get_ssh_connection(
         conn: OpenstackConnection, server_name: str, timeout: int = 30
     ) -> SshConnection:

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -502,8 +502,8 @@ class OpenstackRunnerManager:
         )
 
     @staticmethod
-    # retry for 4m
-    @retry(tries=5, delay=20, max_delay=60, backoff=2, local_logger=logger)
+    # retry for 6m 20s
+    @retry(tries=5, delay=20, max_delay=120, backoff=2, local_logger=logger)
     def _ssh_health_check(conn: OpenstackConnection, server_name: str, startup: bool) -> bool:
         """Use SSH to check whether runner application is running.
 
@@ -549,8 +549,8 @@ class OpenstackRunnerManager:
         return False
 
     @staticmethod
-    # retry for 4m
-    @retry(tries=5, delay=20, max_delay=60, backoff=2, local_logger=logger)
+    # retry for 6m 20s
+    @retry(tries=5, delay=20, max_delay=120, backoff=2, local_logger=logger)
     def _get_ssh_connection(
         conn: OpenstackConnection, server_name: str, timeout: int = 30
     ) -> SshConnection:

--- a/src/openstack_cloud/openstack_manager.py
+++ b/src/openstack_cloud/openstack_manager.py
@@ -530,10 +530,10 @@ class OpenstackRunnerManager:
         result: invoke.runners.Result = ssh_conn.run("ps aux", warn=True)
         logger.debug("Output of `ps aux` on %s stderr: %s", server_name, result.stderr)
         if not result.ok:
-            logger.warning("List all process command failed on %s ", server_name)
-            raise _SSHError("List process command failed on %s ", server_name)
+            logger.warning("List all process command failed on %s.", server_name)
+            raise _SSHError(f"List process command failed on {server_name}.")
         if not RUNNER_STARTUP_PROCESS not in result.stdout:
-            raise _SSHError("Runner not yet started.")
+            raise _SSHError(f"Runner not yet started on {server_name}.")
 
         logger.info("Runner process found to be healthy on %s", server_name)
         if startup:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

If health check fails on SSH health check, report status as unhealthy. We've let SSH health checks pass previously to determine why the network is unable to connect to instances.

### Rationale

SSH health check will return as healthy even if the machines cannot be connected via ssh.

From our usual Openstack console logs, we can see that the boot process takes around 30s (usually faster).

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->