### PR TITLE
change hostname of the runner to mitigate too long hostname

### DIFF
--- a/.github/workflows/e2e_test_run.yaml
+++ b/.github/workflows/e2e_test_run.yaml
@@ -36,6 +36,8 @@ jobs:
     name: End-to-End Test Run
     runs-on: [self-hosted, linux, "${{ inputs.runner-tag }}"]
     steps:
+      - name: Hostname is set to "github-runner"
+        run: sudo hostnamectl hostname | grep github-runner
       # Snapd can have some issues in privileged LXD containers without setting
       # security.nesting=True and this.
       - name: Fix snap issue in privileged LXD containers

--- a/templates/openstack-userdata.sh.j2
+++ b/templates/openstack-userdata.sh.j2
@@ -2,6 +2,8 @@
 
 set -e
 
+hostnamectl set-hostname github-runner
+
 # Write .env contents
 su - ubuntu -c 'cd ~/actions-runner && echo "{{ env_contents }}" > .env'
 


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- change hostname of the runner machine on startup via cloud-init

### Rationale

There has been issues with long github runner VM's hostname w/ microk8s and other tools. This mitigates that.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->