### PR TITLE
feat: image-builder openstack creds relation

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1164,6 +1164,23 @@ class GithubRunnerCharm(CharmBase):
         )
 
     @catch_charm_errors
+    def _on_image_relation_joined(self, _: ops.RelationJoinedEvent) -> None:
+        """Handle image relation joined event."""
+        state = self._setup_state()
+
+        if state.instance_type != InstanceType.OPENSTACK:
+            self.unit.status = BlockedStatus(
+                "Openstack mode not enabled. Please remove the image integration."
+            )
+            return
+
+        clouds_yaml = state.charm_config.openstack_clouds_yaml
+        cloud = list(clouds_yaml["clouds"].keys())[0]
+        auth_map = clouds_yaml["clouds"][cloud]["auth"]
+        for relation in self.model.relations[IMAGE_INTEGRATION_NAME]:
+            relation.data[self.model.unit].update(auth_map)
+
+    @catch_charm_errors
     def _on_image_relation_changed(self, _: ops.RelationChangedEvent) -> None:
         """Handle image relation changed event."""
         state = self._setup_state()

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -14,7 +14,7 @@ import platform
 import re
 from enum import Enum
 from pathlib import Path
-from typing import NamedTuple, Optional, cast
+from typing import NamedTuple, Optional, TypedDict, cast
 from urllib.parse import urlsplit
 
 import yaml
@@ -27,6 +27,7 @@ from pydantic import (
     IPvAnyAddress,
     MongoDsn,
     ValidationError,
+    create_model_from_typeddict,
     validator,
 )
 
@@ -346,6 +347,48 @@ class RepoPolicyComplianceConfig(BaseModel):
         return cls(url=url, token=token)  # type: ignore
 
 
+class _OpenStackAuth(TypedDict):
+    """The OpenStack cloud connection authentication info.
+
+    Attributes:
+        auth_url: The OpenStack authentication URL (keystone).
+        password: The OpenStack project user's password.
+        project_domain_name: The project domain in which the project belongs to.
+        project_name: The OpenStack project to connect to.
+        user_domain_name: The user domain in which the user belongs to.
+        username: The user to authenticate as.
+    """
+
+    auth_url: str
+    password: str
+    project_domain_name: str
+    project_name: str
+    user_domain_name: str
+    username: str
+
+
+class _OpenStackCloud(TypedDict):
+    """The OpenStack cloud connection info.
+
+    See https://docs.openstack.org/python-openstackclient/pike/configuration/index.html.
+
+    Attributes:
+        auth: The connection authentication info.
+    """
+
+    auth: _OpenStackAuth
+
+
+class OpenStackCloudsYAML(TypedDict):
+    """The OpenStack clouds YAML dict mapping.
+
+    Attributes:
+        clouds: The map of cloud name to cloud connection info.
+    """
+
+    clouds: dict[str, _OpenStackCloud]
+
+
 class CharmConfig(BaseModel):
     """General charm configuration.
 
@@ -366,7 +409,7 @@ class CharmConfig(BaseModel):
     denylist: list[FirewallEntry]
     dockerhub_mirror: AnyHttpsUrl | None
     labels: tuple[str, ...]
-    openstack_clouds_yaml: dict[str, dict] | None
+    openstack_clouds_yaml: OpenStackCloudsYAML | None
     path: GithubPath
     reconcile_interval: int
     repo_policy_compliance: RepoPolicyComplianceConfig | None
@@ -421,7 +464,7 @@ class CharmConfig(BaseModel):
         return dockerhub_mirror
 
     @classmethod
-    def _parse_openstack_clouds_config(cls, charm: CharmBase) -> dict | None:
+    def _parse_openstack_clouds_config(cls, charm: CharmBase) -> OpenStackCloudsYAML | None:
         """Parse and validate openstack clouds yaml config value.
 
         Args:
@@ -440,16 +483,17 @@ class CharmConfig(BaseModel):
             return None
 
         try:
-            openstack_clouds_yaml = yaml.safe_load(cast(str, openstack_clouds_yaml_str))
-        except yaml.YAMLError as exc:
+            openstack_clouds_yaml: OpenStackCloudsYAML = yaml.safe_load(
+                cast(str, openstack_clouds_yaml_str)
+            )
+            # use Pydantic to validate TypedDict.
+            create_model_from_typeddict(OpenStackCloudsYAML)(**openstack_clouds_yaml)
+        except (yaml.YAMLError, TypeError) as exc:
             logger.error(f"Invalid {OPENSTACK_CLOUDS_YAML_CONFIG_NAME} config: %s.", exc)
             raise CharmConfigInvalidError(
                 f"Invalid {OPENSTACK_CLOUDS_YAML_CONFIG_NAME} config. Invalid yaml."
             ) from exc
-        if (config_type := type(openstack_clouds_yaml)) is not dict:
-            raise CharmConfigInvalidError(
-                f"Invalid openstack config format, expected dict, got {config_type}"
-            )
+
         try:
             openstack_cloud.initialize(openstack_clouds_yaml)
         except OpenStackInvalidConfigError as exc:
@@ -458,7 +502,7 @@ class CharmConfig(BaseModel):
                 "Invalid openstack config. Not able to initialize openstack integration."
             ) from exc
 
-        return cast(dict, openstack_clouds_yaml)
+        return openstack_clouds_yaml
 
     @validator("reconcile_interval")
     @classmethod


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Shares openstack credentials over relation data.

### Rationale

- To allow image-builder to be able to upload the image to the openstack project in which the runners are created in.

### Juju Events Changes

- Added `_on_image_relation_joined`

### Module Changes

- `charm.py` - added _on_image_relation_joined event handler
- `charm_state.py` - added type hint for openstack clouds yaml

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->