### PR TITLE
fix: add image relation joined framework register

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -247,6 +247,10 @@ class GithubRunnerCharm(CharmBase):
             self._on_debug_ssh_relation_changed,
         )
         self.framework.observe(
+            self.on[IMAGE_INTEGRATION_NAME].relation_joined,
+            self._on_image_relation_joined,
+        )
+        self.framework.observe(
             self.on[IMAGE_INTEGRATION_NAME].relation_changed,
             self._on_image_relation_changed,
         )
@@ -1178,7 +1182,7 @@ class GithubRunnerCharm(CharmBase):
         cloud = list(clouds_yaml["clouds"].keys())[0]
         auth_map = clouds_yaml["clouds"][cloud]["auth"]
         for relation in self.model.relations[IMAGE_INTEGRATION_NAME]:
-            relation.data[self.model.unit].update(auth_map)
+            relation.data[self.unit].update(auth_map)
 
     @catch_charm_errors
     def _on_image_relation_changed(self, _: ops.RelationChangedEvent) -> None:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Adds image relation joined handler to framework observer.
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->