### PR TITLE
Fix missing reconciliation metric output

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ PyYAML ==6.0.*
 pyOpenSSL==24.2.1
 kombu==5.4.0
 pymongo==4.8.0
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@1f310b22b99a94bd5429184191558426b014ee82
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@fix/metrics-ISD-2362

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ PyYAML ==6.0.*
 pyOpenSSL==24.2.1
 kombu==5.4.0
 pymongo==4.8.0
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@fix/metrics-ISD-2362
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@d9013e0795c3265a3379e5d642d1ef3df04bb777


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Fix missing reconciliation metric output by pinning the fixed github-runner-manager.

### Rationale

See rationale in https://github.com/canonical/github-runner-manager/pull/5

### Juju Events Changes

n/a

### Module Changes

n/a

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->