### PR TITLE
Fix SSH health check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ PyYAML ==6.0.*
 pyOpenSSL==24.2.1
 kombu==5.4.0
 pymongo==4.8.0
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@1f310b22b99a94bd5429184191558426b014ee82
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@fix/heath_check

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ PyYAML ==6.0.*
 pyOpenSSL==24.2.1
 kombu==5.4.0
 pymongo==4.8.0
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@fix/heath_check
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@6f0f8679a46b727fddc866f25d8c139672f2a9e1


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Fix ssh health check by pinning the fixed github-runner-manager.

### Rationale

See rationale in https://github.com/canonical/github-runner-manager/pull/7

### Juju Events Changes

n/a

### Module Changes
n/a

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->