### PR TITLE
Add timeout command just before dispatch

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -574,6 +574,22 @@ class GithubRunnerCharm(CharmBase):
                 logger.error("Reconciliation event timer is not activated")
                 self._set_reconcile_timer()
 
+    @staticmethod
+    def _log_juju_processes() -> None:
+        """Log the running Juju processes.
+
+        Log all processes with 'juju' in the command line.
+        """
+        try:
+            processes, _ = execute_command(
+                ["ps", "afuwwx"],
+                check_exit=True,
+            )
+            juju_processes = "\n".join(line for line in processes.splitlines() if "juju" in line)
+            logger.info("Juju processes: %s", juju_processes)
+        except SubprocessError:
+            logger.exception("Failed to get Juju processes")
+
     @catch_charm_errors
     def _on_upgrade_charm(self, _: UpgradeCharmEvent) -> None:
         """Handle the update of charm."""
@@ -898,6 +914,7 @@ class GithubRunnerCharm(CharmBase):
     def _on_update_status(self, _: UpdateStatusEvent) -> None:
         """Handle the update of charm status."""
         self._ensure_reconcile_timer_is_active()
+        self._log_juju_processes()
 
     @catch_charm_errors
     def _on_stop(self, _: StopEvent) -> None:

--- a/templates/dispatch-event.service.j2
+++ b/templates/dispatch-event.service.j2
@@ -4,7 +4,7 @@ Description=Dispatch the {{event}} event on {{unit}}
 [Service]
 Type=oneshot
 # For juju 3 and juju 2 compatibility. The juju-run binary was renamed to juju-exec for juju 3.
-ExecStart=/usr/bin/timeout "{{timeout}}" /usr/bin/run-one /usr/bin/bash -c '/usr/bin/juju-exec "{{unit}}" "JUJU_DISPATCH_PATH={{event}} ./dispatch" || /usr/bin/juju-run "{{unit}}" "JUJU_DISPATCH_PATH={{event}} ./dispatch"'
+ExecStart=/usr/bin/timeout "{{timeout}}" /usr/bin/run-one /usr/bin/bash -c '/usr/bin/juju-exec "{{unit}}" "JUJU_DISPATCH_PATH={{event}} /usr/bin/timeout {{timeout}} ./dispatch" || /usr/bin/juju-run "{{unit}}" "JUJU_DISPATCH_PATH={{event}} /usr/bin/timeout {{timeout}} ./dispatch"'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Add timeout command just before dispatch. This is a follow-up for https://github.com/canonical/github-runner-operator/pull/367 .

Also log juju processes in `update-status` to assist troubleshooting.

### Rationale

The timeout introduced in https://github.com/canonical/github-runner-operator/pull/367 seems to not have fixed the issue. Local tests outlined that the `run-one` command is killed after the timeout interval, but a script placed in `/tmp/` (called `/tmp/juju-exec-aads/script.sh`) is still executing and may block the event queue.

See `ps aux | grep juju` before the timeout

![Screenshot from 2024-09-18 16-36-57](https://github.com/user-attachments/assets/d201d69a-ef30-4f59-b6ac-941ef58a62bb)

and after the timeout:


![Screenshot from 2024-09-18 16-37-07](https://github.com/user-attachments/assets/e2ab1030-ceee-4790-8339-bf71803fb3c9)


### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

`charm.py`: Log juju processes in update-status.

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->