### PR TITLE
fix: process kill command lib fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ PyYAML ==6.0.*
 pyOpenSSL==24.2.1
 kombu==5.4.1
 pymongo==4.8.0
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@59974da80e06907c3e1650d587ef0986f3b6db6d
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@fix/process_killer

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ PyYAML ==6.0.*
 pyOpenSSL==24.2.1
 kombu==5.4.1
 pymongo==4.8.0
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@fix/process_killer
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@2866c28b62e966a179931201e786c548573e6e7c


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Revert process kill commands in the lib

### Rationale

- The current process kill commands are faulty and kill the running worker process which results in running jobs being killed.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->