### PR TITLE
feat: Job label validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ cosl ==0.0.15
 # juju 3.1.2.0 depends on pyyaml<=6.0 and >=5.1.2
 PyYAML ==6.0.*
 pyOpenSSL==24.2.1
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@2866c28b62e966a179931201e786c548573e6e7c
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@feat/label-validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ cosl ==0.0.15
 # juju 3.1.2.0 depends on pyyaml<=6.0 and >=5.1.2
 PyYAML ==6.0.*
 pyOpenSSL==24.2.1
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@feat/label-validation
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@30fcc502eba82c4c4216f66f61380cfcbed517b1

--- a/src-docs/charm.md
+++ b/src-docs/charm.md
@@ -18,10 +18,11 @@ Charm for creating and managing GitHub self-hosted runner instances.
 - **RECONCILIATION_INTERVAL_TIMEOUT_FACTOR**
 - **RECONCILE_RUNNERS_EVENT**
 - **REACTIVE_MQ_DB_NAME**
+- **GITHUB_SELF_HOSTED_ARCH_LABELS**
 
 ---
 
-<a href="../src/charm.py#L120"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L122"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_charm_errors`
 
@@ -47,7 +48,7 @@ Catch common errors in charm.
 
 ---
 
-<a href="../src/charm.py#L161"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L163"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_action_errors`
 
@@ -73,7 +74,7 @@ Catch common errors in actions.
 
 ---
 
-<a href="../src/charm.py#L113"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `ReconcileRunnersEvent`
 Event representing a periodic check to ensure runners are ok. 
@@ -84,7 +85,7 @@ Event representing a periodic check to ensure runners are ok.
 
 ---
 
-<a href="../src/charm.py#L199"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L201"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GithubRunnerCharm`
 Charm for managing GitHub self-hosted runners. 
@@ -101,7 +102,7 @@ Charm for managing GitHub self-hosted runners.
  - <b>`ram_pool_path`</b>:  The path to memdisk storage. 
  - <b>`kernel_module_path`</b>:  The path to kernel modules. 
 
-<a href="../src/charm.py#L222"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L224"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -761,18 +761,18 @@ async def mongodb_fixture(model: Model, existing_app: str | None) -> Application
 @pytest_asyncio.fixture(scope="module", name="app_for_reactive")
 async def app_for_reactive_fixture(
     model: Model,
-    basic_app: Application,
+    app_openstack_runner: Application,
     mongodb: Application,
     existing_app: Optional[str],
 ) -> Application:
     """Application for testing reactive."""
     if not existing_app:
-        await model.relate(f"{basic_app.name}:mongodb", f"{mongodb.name}:database")
+        await model.relate(f"{app_openstack_runner.name}:mongodb", f"{mongodb.name}:database")
 
-    await basic_app.set_config({VIRTUAL_MACHINES_CONFIG_NAME: "1"})
-    await model.wait_for_idle(apps=[basic_app.name, mongodb.name], status=ACTIVE)
+    await app_openstack_runner.set_config({VIRTUAL_MACHINES_CONFIG_NAME: "1"})
+    await model.wait_for_idle(apps=[app_openstack_runner.name, mongodb.name], status=ACTIVE)
 
-    return basic_app
+    return app_openstack_runner
 
 
 @pytest_asyncio.fixture(scope="module", name="basic_app")

--- a/tests/integration/test_reactive.py
+++ b/tests/integration/test_reactive.py
@@ -1,9 +1,9 @@
 #  Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
+
+"""Testing reactive mode. This is only supported for the OpenStack cloud."""
 import json
-import random
 import re
-import secrets
 
 import pytest
 from github import Branch, Repository
@@ -21,8 +21,20 @@ from tests.integration.helpers.common import (
     wait_for_completion,
 )
 
+pytestmark = pytest.mark.openstack
 
-@pytest.mark.openstack
+
+@pytest.fixture(name="setup_queue", autouse=True)
+async def setup_queue_fixture(
+    ops_test: OpsTest,
+    app_for_reactive: Application,
+):
+    mongodb_uri = await _get_mongodb_uri(ops_test, app_for_reactive)
+
+    _clear_queue(mongodb_uri, app_for_reactive.name)
+    _assert_queue_is_empty(mongodb_uri, app_for_reactive.name)
+
+
 async def test_reactive_mode_consumes_jobs(
     ops_test: OpsTest,
     app_for_reactive: Application,
@@ -34,11 +46,7 @@ async def test_reactive_mode_consumes_jobs(
     act: Call reconcile.
     assert: The message is consumed and the job details are logged.
     """
-    unit = app_for_reactive.units[0]
-    mongodb_uri = await _get_mongodb_uri_from_integration_data(ops_test, unit)
-    if not mongodb_uri:
-        mongodb_uri = await _get_mongodb_uri_from_secrets(ops_test, unit.model)
-    assert mongodb_uri, "mongodb uri not found in integration data or secret"
+    mongodb_uri = await _get_mongodb_uri(ops_test, app_for_reactive)
 
     run = await dispatch_workflow(
         app=app_for_reactive,
@@ -53,10 +61,12 @@ async def test_reactive_mode_consumes_jobs(
     job = jobs[0]
     job_url = job.url
     job = JobDetails(
-        labels=[secrets.token_hex(16) for _ in range(random.randint(1, 4))], url=job_url
+        labels={app_for_reactive.name, "x64"},  # The architecture label should be ignored in the
+        # label validation in the reactive consumer.
+        url=job_url,
     )
     _add_to_queue(
-        json.dumps(job.dict() | {"ignored_noise": "foobar"}),
+        json.dumps(json.loads(job.json()) | {"ignored_noise": "foobar"}),
         mongodb_uri,
         app_for_reactive.name,
     )
@@ -68,6 +78,60 @@ async def test_reactive_mode_consumes_jobs(
 
     # Call reconcile to enable cleanup of the runner
     await reconcile(app_for_reactive, app_for_reactive.model)
+
+
+async def test_reactive_mode_does_not_consume_jobs_with_unsupported_labels(
+    ops_test: OpsTest,
+    app_for_reactive: Application,
+    github_repository: Repository,
+    test_github_branch: Branch,
+):
+    mongodb_uri = await _get_mongodb_uri(ops_test, app_for_reactive)
+
+    run = await dispatch_workflow(
+        app=app_for_reactive,
+        branch=test_github_branch,
+        github_repository=github_repository,
+        conclusion="success",  # this is ignored currently if wait=False kwarg is used
+        workflow_id_or_name=DISPATCH_TEST_WORKFLOW_FILENAME,
+        wait=False,
+    )
+    jobs = list(run.jobs())
+    assert len(jobs) == 1, "Expected 1 job to be created"
+    job = jobs[0]
+    job_url = job.url
+    job = JobDetails(labels={"not supported label"}, url=job_url)
+    _add_to_queue(
+        job.json(),
+        mongodb_uri,
+        app_for_reactive.name,
+    )
+
+    await reconcile(app_for_reactive, app_for_reactive.model)
+
+    run.update()
+    assert run.status == "queued"
+    run.cancel()
+
+    _assert_queue_has_size(mongodb_uri, app_for_reactive.name, 1)
+
+
+async def _get_mongodb_uri(ops_test: OpsTest, app_for_reactive: Application) -> str:
+    """Get the mongodb uri.
+
+    Args:
+        ops_test: The ops_test plugin.
+        app_for_reactive: The juju application containing the unit.
+
+    Returns:
+        The mongodb uri.
+
+    """
+    mongodb_uri = await _get_mongodb_uri_from_integration_data(ops_test, app_for_reactive.units[0])
+    if not mongodb_uri:
+        mongodb_uri = await _get_mongodb_uri_from_secrets(ops_test, app_for_reactive.model)
+    assert mongodb_uri, "mongodb uri not found in integration data or secret"
+    return mongodb_uri
 
 
 async def _get_mongodb_uri_from_integration_data(ops_test: OpsTest, unit: Unit) -> str | None:
@@ -136,6 +200,18 @@ def _add_to_queue(msg: str, mongodb_uri: str, queue_name: str) -> None:
             simple_queue.put(msg, retry=True)
 
 
+def _clear_queue(mongodb_uri: str, queue_name: str) -> None:
+    """Clear the queue.
+
+    Args:
+        mongodb_uri: The mongodb uri.
+        queue_name: The name of the queue to clear.
+    """
+    with Connection(mongodb_uri) as conn:
+        with conn.SimpleQueue(queue_name) as simple_queue:
+            simple_queue.clear()
+
+
 def _assert_queue_is_empty(mongodb_uri: str, queue_name: str):
     """Assert that the queue is empty.
 
@@ -143,6 +219,17 @@ def _assert_queue_is_empty(mongodb_uri: str, queue_name: str):
         mongodb_uri: The mongodb uri.
         queue_name: The name of the queue to check.
     """
+    _assert_queue_has_size(mongodb_uri, queue_name, 0)
+
+
+def _assert_queue_has_size(mongodb_uri: str, queue_name: str, size: int):
+    """Assert that the queue is empty.
+
+    Args:
+        mongodb_uri: The mongodb uri.
+        queue_name: The name of the queue to check.
+        size: The expected size of the queue.
+    """
     with Connection(mongodb_uri) as conn:
         with conn.SimpleQueue(queue_name) as simple_queue:
-            assert simple_queue.qsize() == 0
+            assert simple_queue.qsize() == size

--- a/tests/integration/test_reactive.py
+++ b/tests/integration/test_reactive.py
@@ -35,7 +35,7 @@ async def setup_queue_fixture(
     _assert_queue_is_empty(mongodb_uri, app_for_reactive.name)
 
 
-async def test_reactive_mode_consumes_jobs(
+async def test_reactive_mode_spawns_runner(
     ops_test: OpsTest,
     app_for_reactive: Application,
     github_repository: Repository,
@@ -44,7 +44,7 @@ async def test_reactive_mode_consumes_jobs(
     """
     arrange: A charm integrated with mongodb and a message is added to the queue.
     act: Call reconcile.
-    assert: The message is consumed and the job details are logged.
+    assert: The message is consumed and a runner is spawned.
     """
     mongodb_uri = await _get_mongodb_uri(ops_test, app_for_reactive)
 
@@ -86,6 +86,11 @@ async def test_reactive_mode_does_not_consume_jobs_with_unsupported_labels(
     github_repository: Repository,
     test_github_branch: Branch,
 ):
+    """
+    arrange: A charm integrated with mongodb and an unsupported label is added to the queue.
+    act: Call reconcile.
+    assert: No runner is spawned and the message is requeued.
+    """
     mongodb_uri = await _get_mongodb_uri(ops_test, app_for_reactive)
 
     run = await dispatch_workflow(


### PR DESCRIPTION
Applicable spec: [ISD-116](https://discourse.charmhub.io/t/specification-isd116-github-self-hosted-runners-reactive-scheduling/13755)

### Overview

Adaptations to make the charm work with https://github.com/canonical/github-runner-manager/pull/17.

### Rationale

See rationale in  https://github.com/canonical/github-runner-manager/pull/17.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

`charm.py`: Pass over supported_labels.

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->

[ISD-116]: https://warthogs.atlassian.net/browse/ISD-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ