### PR TITLE
Update tutorial

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -93,10 +93,10 @@ If the workflow failed at the `Set up runner` step with the following message:
 
 The repository setting does not comply with the best practice enforce by the charm. See [How to comply with repository policies](https://charmhub.io/github-runner/docs/repo-policy).
 
-#### Removing the charm
+### Clean up the environment
 
-The charm and the self-hosted runners can be removed with the following command:
+The Juju model, charm and the self-hosted runners can be removed with the following command:
 
 ```shell
-juju remove-application github-runner
+juju destroy-model --destroy-storage github-runner-tutorial
 ```

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -1,4 +1,4 @@
-# Quick start
+# Deploy the GitHub runner charm for the first time
 
 ## What you'll do
 

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -60,6 +60,8 @@ The `--storage` option mounts a juju storage to be used as the disk for LXD inst
 
 The charm performs various installation and configuration on startup. The charm might upgrade the kernel of the Juju machine and reboot the Juju machine. During reboot, the Juju machine will go into the `down` state; this is a part of the normal reboot process and the Juju machine should be restarted after a while.
 
+Monitor the deployment status using `juju status --watch 5s`. The deployment finishes when the status shows "Active".
+
 Once the charm reaches active status, visit the runner page for the GitHub repository (`https://github.com/{OWNER}/{REPO}/settings/actions/runners`) according to the instructions [here](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/using-self-hosted-runners-in-a-workflow#viewing-available-runners-for-a-repository). A single new runner should be available as it is the default number of self-hosted runners created.
 
 The charm will spawn new runners on a schedule. During this time, the charm will enter maintenance status.

--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -12,7 +12,7 @@
 
 - GitHub Account.
 - Juju 3 installed.
-- Juju controller on OpenStack or LXD (see [How to run on LXD cloud](https://charmhub.io/github-runner/docs/how-to-run-on-lxd)) and a Juju model.
+- Juju controller on OpenStack or LXD (see [How to run on LXD cloud](https://charmhub.io/github-runner/docs/how-to-run-on-lxd)).
 
 For more information about how to install and use Juju, see [Get started with Juju](https://juju.is/docs/olm/get-started-with-juju).
 
@@ -31,6 +31,14 @@ To create a GitHub repository, log in to [GitHub](https://github.com) with your 
 The GitHub runner charm relies on GitHub APIs for self-hosted runners. Some of the APIs will only be functional after a self-hosted runner registration token is requested for the repository for the first time.
 
 The registration token can be requested by calling the [GitHub API](https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-a-registration-token-for-a-repository). Alternatively, it can also be requested by visiting the "New self-hosted runner" page for the repository (`https://github.com/{OWNER}/{REPO}/settings/actions/runners/new`). This can be done by following the instruction to the 4th step provided [here](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners#adding-a-self-hosted-runner-to-a-repository).
+
+### Set up the tutorial model
+
+To easily clean up the resources and to separate your workload from the contents of this tutorial, set up a new Juju model with the following command.
+
+```
+juju add-model github-runner-tutorial
+```
 
 ### Deploy the GitHub runner charm
 


### PR DESCRIPTION
### Overview

Changes to the tutorial for standardisation with tutorials for the IS charms.

### Rationale

- ISD-2381: Updated the name of the tutorial to adopt the "Deploy X charm for the first time" convention.
- ISD-2383: Added a step to set up a Juju model (also edited the cleanup section to remove this model instead of the application).
- ISD-2383: Added explicit instructions to monitor `juju status` until the deployment is finished.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`.
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [X] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->