### PR TITLE
Fix: Regression on removal of residual dirs

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,11 +19,12 @@ jobs:
       pre-run-script: scripts/pre-integration-test.sh
       provider: lxd
       test-tox-env: integration-juju3.1
-      # These important local LXD test has no OpenStack integration versions.
+      # These important local LXD test have no OpenStack integration versions.
       # test_charm_scheduled_events ensures reconcile events are fired on a schedule.
       # test_debug_ssh ensures tmate SSH actions works.
+      # The test test_charm_upgrade needs to run to ensure the charm can be upgraded.
       # TODO: Add OpenStack integration versions of these tests.
-      modules: '["test_charm_scheduled_events", "test_debug_ssh"]'
+      modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'
   openstack-interface-tests-private-endpoint:
     name: openstack interface test using private-endpoint
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -23,7 +23,6 @@ jobs:
       # test_charm_scheduled_events ensures reconcile events are fired on a schedule.
       # test_debug_ssh ensures tmate SSH actions works.
       # The test test_charm_upgrade needs to run to ensure the charm can be upgraded.
-      # TODO: Add OpenStack integration versions of these tests.
       modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'
   openstack-interface-tests-private-endpoint:
     name: openstack interface test using private-endpoint

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2024-10-07
+
+- Fixed a regression in the removal of leftover directories.
+
 ### 2024-09-18
 
 - Changed code to be able to spawn a runner in reactive mode.

--- a/src-docs/charm.md
+++ b/src-docs/charm.md
@@ -22,7 +22,7 @@ Charm for creating and managing GitHub self-hosted runner instances.
 
 ---
 
-<a href="../src/charm.py#L124"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_charm_errors`
 
@@ -48,7 +48,7 @@ Catch common errors in charm.
 
 ---
 
-<a href="../src/charm.py#L165"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L164"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_action_errors`
 
@@ -74,7 +74,7 @@ Catch common errors in actions.
 
 ---
 
-<a href="../src/charm.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L116"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `ReconcileRunnersEvent`
 Event representing a periodic check to ensure runners are ok. 
@@ -85,7 +85,7 @@ Event representing a periodic check to ensure runners are ok.
 
 ---
 
-<a href="../src/charm.py#L203"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L202"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GithubRunnerCharm`
 Charm for managing GitHub self-hosted runners. 
@@ -102,7 +102,7 @@ Charm for managing GitHub self-hosted runners.
  - <b>`ram_pool_path`</b>:  The path to memdisk storage. 
  - <b>`kernel_module_path`</b>:  The path to kernel modules. 
 
-<a href="../src/charm.py#L226"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L225"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 

--- a/src-docs/charm.md
+++ b/src-docs/charm.md
@@ -22,7 +22,7 @@ Charm for creating and managing GitHub self-hosted runner instances.
 
 ---
 
-<a href="../src/charm.py#L122"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L124"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_charm_errors`
 
@@ -48,7 +48,7 @@ Catch common errors in charm.
 
 ---
 
-<a href="../src/charm.py#L163"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L165"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `catch_action_errors`
 
@@ -74,7 +74,7 @@ Catch common errors in actions.
 
 ---
 
-<a href="../src/charm.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `ReconcileRunnersEvent`
 Event representing a periodic check to ensure runners are ok. 
@@ -85,7 +85,7 @@ Event representing a periodic check to ensure runners are ok.
 
 ---
 
-<a href="../src/charm.py#L201"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L203"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GithubRunnerCharm`
 Charm for managing GitHub self-hosted runners. 
@@ -102,7 +102,7 @@ Charm for managing GitHub self-hosted runners.
  - <b>`ram_pool_path`</b>:  The path to memdisk storage. 
  - <b>`kernel_module_path`</b>:  The path to kernel modules. 
 
-<a href="../src/charm.py#L224"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L226"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,6 @@ from utilities import bytes_with_unit_to_kib, execute_command, remove_residual_v
 
 # This is a workaround for https://bugs.launchpad.net/juju/+bug/2058335
 # It is important that this is run before importation of any other modules.
-
 # pylint: disable=wrong-import-position,wrong-import-order
 # TODO: 2024-07-17 remove this once the issue has been fixed
 remove_residual_venv_dirs()

--- a/tests/integration/test_charm_upgrade.py
+++ b/tests/integration/test_charm_upgrade.py
@@ -40,7 +40,7 @@ async def test_charm_upgrade(
     assert: the charm is upgraded successfully.
     """
     latest_stable_path = tmp_path / "github-runner.charm"
-    latest_stable_revision = 161  # update this value every release to stable.
+    latest_stable_revision = 256  # update this value every release to stable.
     # download the charm and inject lxd profile for testing
     retcode, stdout, stderr = await ops_test.juju(
         "download",


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Move the removal of residual directories to the top of the charm code.

Also include the `test_charm_upgrade` integration test in the test suite for each PR.

### Rationale

A production upgrade encountered an issue:

```
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/./src/charm.py", line 19, in <module>
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     from github_runner_manager.manager.runner_scaler import RunnerScaler

2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/github_runner_manager/manager/runner_scaler.py", line 10, in <module>
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     import github_runner_manager.reactive.runner_manager as reactive_runner_manager
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/github_runner_manager/reactive/runner_manager.py", line 14, in <module>
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     from github_runner_manager.reactive.types_ import RunnerConfig
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/github_runner_manager/reactive/types_.py", line 9, in <module>
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     from github_runner_manager.openstack_cloud.openstack_runner_manager import (
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/github_runner_manager/openstack_cloud/openstack_runner_manager.py", line 45, in <module>
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     from github_runner_manager.openstack_cloud.openstack_cloud import OpenstackCloud, OpenstackInstance
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/github_runner_manager/openstack_cloud/openstack_cloud.py", line 14, in <module>
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     import openstack
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/openstack/__init__.py", line 57, in <module>
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     import openstack.config
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/openstack/config/__init__.py", line 17, in <module>
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     from openstack.config.loader import OpenStackConfig  # noqa
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/openstack/config/loader.py", line 27, in <module>
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     from keystoneauth1 import adapter
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/keystoneauth1/__init__.py", line 16, in <module>
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     __version__ = pbr.version.VersionInfo('keystoneauth1').version_string()
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/pbr/version.py", line 505, in version_string
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     return self.semantic_version().brief_string()
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/pbr/version.py", line 498, in semantic_version
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     self._semantic = self._get_version_from_importlib_metadata()
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/pbr/version.py", line 483, in _get_version_from_importlib_metadata
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     return SemanticVersion.from_pip_string(result_string)
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/pbr/version.py", line 156, in from_pip_string
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     return klass._from_pip_string_unsafe(version_string)
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60   File "/var/lib/juju/agents/unit-openstack-amd64-xlarge-ps5-0/charm/venv/pbr/version.py", line 163, in _from_pip_string_unsafe
2024-10-07 10:51:47.887	
2024-10-07 08:51:47 WARNING unit.openstack-amd64-xlarge-ps5/0.upgrade-charm logger.go:60     version_string = version_string.lstrip('vV')
```

The code to remove the remaining dirs must be run before the imports.



### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->