### PR TITLE
fix: shorten instance id

### DIFF
--- a/docs/how-to/openstack-runner.md
+++ b/docs/how-to/openstack-runner.md
@@ -57,3 +57,6 @@ The `openstack-network` configuration sets the network used to create the OpenSt
 Note that the network should be configured to allow traffic from the charm deployment (Juju machine) to the OpenStack virtual machine, and traffic from the OpenStack virtual machine to GitHub.
 
 The network documentation is [here](https://docs.openstack.org/neutron/latest/admin/intro-os-networking.html).
+
+> NOTE: The name of the application must not be longer than 50 characters. A valid runner name is 64 characters or less in length and does not include '"', '/', ':',
+'<', '>', '\', '|', '*' and '?'. 14 characters are reserved for Juju unit number and unique identifier.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ cosl ==0.0.15
 # juju 3.1.2.0 depends on pyyaml<=6.0 and >=5.1.2
 PyYAML ==6.0.*
 pyOpenSSL==24.2.1
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@fix/shorten_instance_id
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@16c82ddadb9abbafef0a80cc4f86faee1c96ee8a

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ cosl ==0.0.15
 # juju 3.1.2.0 depends on pyyaml<=6.0 and >=5.1.2
 PyYAML ==6.0.*
 pyOpenSSL==24.2.1
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@33bbaff42d7cc0f250006fdd08d24659cef364c9
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@fix/shorten_instance_id


### PR DESCRIPTION
Applicable spec: <link>

### Overview

See: https://github.com/canonical/github-runner-manager/pull/25

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->