### PR TITLE
fix: add nocreate to logrotate config

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2024-10-18
+
+- Bugfix for logrotate configuration ("nocreate" must be passed explicitly)
+
 ### 2024-10-17
 
 - Use in-memory authentication instead of clouds.yaml on disk for OpenStack. This prevents

--- a/src/logrotate.py
+++ b/src/logrotate.py
@@ -124,8 +124,8 @@ def _write_config(logrotate_config: LogrotateConfig) -> None:
 {logrotate_config.frequency}
 rotate {logrotate_config.rotate}
 missingok
-{"notifempty" if logrotate_config.notifempty else ""}
-{"create" if logrotate_config.create else ""}
+{"notifempty" if logrotate_config.notifempty else "ifempty"}
+{"create" if logrotate_config.create else "nocreate"}
 }}
 """,
         encoding="utf-8",

--- a/tests/unit/test_logrotate.py
+++ b/tests/unit/test_logrotate.py
@@ -111,8 +111,8 @@ def test__write_config(
 {frequency}
 rotate {rotate}
 missingok
-{"notifempty" if notifempty else ""}
-{"create" if create else ""}
+{"notifempty" if notifempty else "ifempty"}
+{"create" if create else "nocreate"}
 }}
 """
     assert (


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Add `nocreate` (if `create=False`) to the logrotate configuration.
### Rationale

Logrotate currently creates an empty file instead of removing (because `create` is set in `/etc/logrotate.conf` in the unit)

```
ubuntu@juju-d7b4aa-stg-github-runner-ps6-260:~$ ll /var/log/reactive_runner/
total 5480
drwxr-xr-x  2 runner-manager runner-manager    4096 Oct 18 08:27 ./
drwxrwxr-x 10 root           syslog            4096 Oct 18 00:00 ../
-rw-r--r--  1 runner-manager runner-manager       0 Oct 18 09:02 366484.log
-rw-r--r--  1 runner-manager runner-manager       0 Oct 18 09:02 368958.log
-rw-r--r--  1 runner-manager runner-manager       0 Oct 18 09:02 372527.log
-rw-r--r--  1 runner-manager runner-manager       0 Oct 18 09:02 508214.log
-rw-r--r--  1 runner-manager runner-manager 5598848 Oct 18 09:30 550857.log
ubuntu@juju-d7b4aa-stg-github-runner-ps6-260:~$ 
```


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->