### PR TITLE
fix: chown of existing reactive runner log dir 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2024-10-21
+
+- Fixed bug with charm upgrade due to wrong ownership of reactive runner log directory.
+
 ### 2024-10-18
 
 - Bugfix for logrotate configuration ("nocreate" must be passed explicitly)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ cosl ==0.0.15
 # juju 3.1.2.0 depends on pyyaml<=6.0 and >=5.1.2
 PyYAML ==6.0.*
 pyOpenSSL==24.2.1
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@fix/logdir
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@36bd8439a4a07397fa40453f1687d18d1e028a2b

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ cosl ==0.0.15
 # juju 3.1.2.0 depends on pyyaml<=6.0 and >=5.1.2
 PyYAML ==6.0.*
 pyOpenSSL==24.2.1
-github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@6b136f4e915c7dfec22e801981bcc0a6af581df1
+github_runner_manager @ git+https://github.com/canonical/github-runner-manager.git@fix/logdir


### PR DESCRIPTION
Applicable spec: n/a

### Overview & Rationale

Pin commit to include https://github.com/canonical/github-runner-manager/pull/26


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->