### PR TITLE
Rename gh action for github-runner-manager

### DIFF
--- a/.github/workflows/test_github_runner_manager.yaml
+++ b/.github/workflows/test_github_runner_manager.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  unit-tests:
+  unit-tests-github-runner-manager:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
     with:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Rename the job in the file `.github/workflows/test_github_runner_manager.yaml` so it has not the same name as the one for the charm tests.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->