### PR TITLE
fix: Support multiple flavors for "Available Runners" dashboard

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2024-11-27
+
+- Fix "Available Runners" dashboard panel to work for multiple flavors.
 
 ### 2024-11-15
 

--- a/src/grafana_dashboards/metrics.json
+++ b/src/grafana_dashboards/metrics.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 319,
+  "id": 1034,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -307,6 +307,15 @@
         }
       ],
       "title": "Available Runners",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "flavor",
+            "mode": "outer"
+          }
+        }
+      ],
       "type": "barchart"
     },
     {
@@ -2111,6 +2120,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "GitHub Self-Hosted Runner Metrics",
-  "version": 17,
+  "version": 18,
   "weekStart": ""
 }


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Join the data for Available and Max Available runners in "Available Runners" panel to look like

![Screenshot from 2024-11-27 15-20-00](https://github.com/user-attachments/assets/63395312-a761-4ed7-9dc2-54dbb16d7109)

### Rationale

otherwise, the panel is not working for multiple flavors (only displaying data for one flavor).


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->