### PR TITLE
Juju 3.6

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -12,10 +12,10 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      juju-channel: 3.2/stable
+      juju-channel: 3.6/stable
       pre-run-script: scripts/setup-lxd.sh
       provider: lxd
-      test-tox-env: integration-juju3.2
+      test-tox-env: integration-juju3.6
       modules: '["test_e2e"]'
       extra-arguments: "-m openstack"
       self-hosted-runner: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -29,10 +29,10 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      juju-channel: 3.2/stable
+      juju-channel: 3.6/stable
       pre-run-script: scripts/setup-lxd.sh
       provider: lxd
-      test-tox-env: integration-juju3.2
+      test-tox-env: integration-juju3.6
       modules: '["test_runner_manager_openstack"]'
       self-hosted-runner: true
       self-hosted-runner-label: stg-private-endpoint
@@ -42,10 +42,10 @@ jobs:
     needs: openstack-interface-tests-private-endpoint
     secrets: inherit
     with:
-      juju-channel: 3.2/stable
+      juju-channel: 3.6/stable
       pre-run-script: scripts/setup-lxd.sh
       provider: lxd
-      test-tox-env: integration-juju3.2
+      test-tox-env: integration-juju3.6
       modules: '["test_charm_metrics_failure", "test_charm_metrics_success", "test_charm_fork_repo", "test_charm_runner", "test_reactive"]'
       extra-arguments: "-m openstack"
       self-hosted-runner: true

--- a/.github/workflows/scheduled_integration_test.yaml
+++ b/.github/workflows/scheduled_integration_test.yaml
@@ -12,15 +12,15 @@ on:
 jobs:
   # test option values defined at test/conftest.py are passed on via repository secret
   # INTEGRATION_TEST_ARGS to operator-workflows automatically.
-  integration-tests-juju2:
-    name: Integration test with juju 2.9
+  integration-tests-juju36:
+    name: Integration test with juju 3.6
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      juju-channel: 2.9/stable
+      juju-channel: 3.6/stable
       pre-run-script: scripts/pre-integration-test.sh
       provider: lxd
-      test-tox-env: integration-juju2.9
+      test-tox-env: integration-juju3.6
       modules: '["test_charm_base_image", "test_charm_fork_repo", "test_charm_no_runner", "test_charm_scheduled_events", "test_charm_lxd_runner", "test_charm_runner", "test_charm_metrics_success", "test_charm_metrics_failure", "test_self_hosted_runner", "test_charm_with_proxy", "test_charm_with_juju_storage", "test_debug_ssh", "test_charm_upgrade"]'
   integration-tests:
     name: Integration test with juju 3.1

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -385,7 +385,7 @@ async def image_builder_fixture(
             "github-runner-image-builder",
             channel="latest/edge",
             revision=2,
-            constraints="cores=2 mem=16G root-disk=20G virt-type=virtual-machine",
+            constraints="cores=2 mem=2G root-disk=20G virt-type=virtual-machine",
             config={
                 "app-channel": "edge",
                 "build-interval": "12",

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -289,7 +289,7 @@ async def deploy_github_runner_charm(
         base="ubuntu@22.04",
         config=default_config,
         constraints=constraints or DEFAULT_RUNNER_CONSTRAINTS,
-        storage=storage,
+        storage=storage,  # type: ignore[arg-type]
         **(deploy_kwargs or {}),
     )
 

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -15,7 +15,6 @@ from functools import partial
 from typing import Awaitable, Callable, ParamSpec, TypeVar, cast
 
 import github
-import juju.version
 import requests
 from github.Branch import Branch
 from github.Repository import Repository

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -148,23 +148,10 @@ async def remove_runner_bin(unit: Unit) -> None:
     assert return_code != 0
 
 
-def on_juju_2() -> bool:
-    """Check if juju 2 is used.
-
-    Returns:
-        Whether juju 2 is used.
-    """
-    # The juju library does not support `__version__`.
-    # Prior to juju 3, the SUPPORTED_MAJOR_VERSION was not defined.
-    return not hasattr(juju.version, "SUPPORTED_MAJOR_VERSION")
-
-
 async def run_in_unit(
     unit: Unit, command: str, timeout=None, assert_on_failure=False, assert_msg=""
 ) -> tuple[int, str | None, str | None]:
     """Run command in juju unit.
-
-    Compatible with juju 3 and juju 2.
 
     Args:
         unit: Juju unit to execute the command in.
@@ -178,20 +165,12 @@ async def run_in_unit(
     """
     action: Action = await unit.run(command, timeout)
 
-    # For compatibility with juju 2.
-    if on_juju_2():
-        code, stdout, stderr = (
-            int(action.results["Code"]),
-            action.results.get("Stdout", None),
-            action.results.get("Stderr", None),
-        )
-    else:
-        await action.wait()
-        code, stdout, stderr = (
-            action.results["return-code"],
-            action.results.get("stdout", None),
-            action.results.get("stderr", None),
-        )
+    await action.wait()
+    code, stdout, stderr = (
+        action.results["return-code"],
+        action.results.get("stdout", None),
+        action.results.get("stderr", None),
+    )
 
     if assert_on_failure:
         assert code == 0, f"{assert_msg}: {stderr}"

--- a/tests/integration/test_charm_upgrade.py
+++ b/tests/integration/test_charm_upgrade.py
@@ -92,7 +92,14 @@ async def test_charm_upgrade(
     )
 
     # upgrade the charm with current local charm
-    await application.local_refresh(path=charm_file, charm_origin=origin)
+    await application.local_refresh(
+        path=charm_file,
+        charm_origin=origin,
+        force=False,
+        force_series=False,
+        force_units=False,
+        resources=None,
+    )
     unit = application.units[0]
     await wait_for(
         functools.partial(is_upgrade_charm_event_emitted, unit), timeout=360, check_interval=60

--- a/tests/integration/test_reactive.py
+++ b/tests/integration/test_reactive.py
@@ -286,7 +286,12 @@ async def _get_mongodb_uri_from_secrets(ops_test, model: Model) -> str | None:
     mongodb_uri = None
 
     juju_secrets = await model.list_secrets()
-    for secret in juju_secrets["results"]:
+
+    # Juju < 3.6 returns a dictionary instead of a list
+    if not isinstance(juju_secrets, list):
+        juju_secrets = juju_secrets["results"]
+
+    for secret in juju_secrets:
         if re.match(r"^database.\d+.user.secret$", secret.label):
             _, show_secret, _ = await ops_test.juju(
                 "show-secret", secret.uri, "--reveal", "--format", "json"

--- a/tests/integration/test_runner_manager_openstack.py
+++ b/tests/integration/test_runner_manager_openstack.py
@@ -6,6 +6,7 @@ It is assumed that the test runs in the CI under the ubuntu user.
 """
 
 
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -380,6 +381,10 @@ async def test_runner_flush_busy_lifecycle(
     assert busy_runner.github_state == GitHubRunnerState.BUSY
 
     # 4.
+    runner_manager_with_one_runner.flush_runners(flush_mode=FlushMode.FLUSH_BUSY)
+    # It takes a bit for the github agent to die, and it may not be cleaned
+    # in the first run. Just do it twice.
+    await asyncio.sleep(10)
     runner_manager_with_one_runner.flush_runners(flush_mode=FlushMode.FLUSH_BUSY)
     await wait_runner_amount(runner_manager_with_one_runner, 0)
 

--- a/tox.ini
+++ b/tox.ini
@@ -111,9 +111,6 @@ description = Run integration tests
 pass_env =
     PYTEST_ADDOPTS
 deps =
-    # Pin pytest version until the following issue is resolved.
-    # https://github.com/charmed-kubernetes/pytest-operator/issues/131
-    pytest==8.1.1
     juju3.1: juju==3.1.*
     juju3.6: juju==3.6.*
     nest-asyncio # Required due to https://github.com/pytest-dev/pytest-asyncio/issues/112

--- a/tox.ini
+++ b/tox.ini
@@ -106,7 +106,7 @@ deps =
 commands =
     bandit -c {toxinidir}/pyproject.toml -r {[vars]src_path}
 
-[testenv:integration-juju{3.2,3.1,2.9}]
+[testenv:integration-juju{3.1,3.6}]
 description = Run integration tests
 pass_env =
     PYTEST_ADDOPTS
@@ -114,9 +114,8 @@ deps =
     # Pin pytest version until the following issue is resolved.
     # https://github.com/charmed-kubernetes/pytest-operator/issues/131
     pytest==8.1.1
-    juju3.2: juju==3.2.*
     juju3.1: juju==3.1.*
-    juju2.9: juju==2.9.*
+    juju3.6: juju==3.6.*
     nest-asyncio # Required due to https://github.com/pytest-dev/pytest-asyncio/issues/112
     pytest-operator
     pytest-asyncio


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Use Juju 3.6 in integration tests and remove integration tests for Juju 2.9.

Also decrease resources for image builder in integration tests and add an extra step in `test_runner_flush_busy_lifecycle` that is failing in some cases.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->