### PR TITLE
All integrations tests should run in openstack

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,7 +12,7 @@ jobs:
   # INTEGRATION_TEST_ARGS to operator-workflows automatically.
   integration-tests:
     name: Integration test with juju 3.1
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@disable-snap-autorefresh
     secrets: inherit
     with:
       juju-channel: 3.1/stable

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   # test option values defined at test/conftest.py are passed on via repository secret
   # INTEGRATION_TEST_ARGS to operator-workflows automatically.
-  openstack-integration-tests:
+  integration-tests:
     name: Integration test with juju 3.1
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -25,7 +25,7 @@ jobs:
       self-hosted-runner-label: stg-private-endpoint
   openstack-interface-tests-private-endpoint:
     name: openstack interface test using private-endpoint
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@disable-snap-autorefresh
     secrets: inherit
     with:
       juju-channel: 3.6/stable
@@ -37,7 +37,7 @@ jobs:
       self-hosted-runner-label: stg-private-endpoint
   openstack-integration-tests-private-endpoint:
     name: Integration test using private-endpoint
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@disable-snap-autorefresh
     needs: openstack-interface-tests-private-endpoint
     secrets: inherit
     with:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,13 +10,13 @@ concurrency:
 jobs:
   # test option values defined at test/conftest.py are passed on via repository secret
   # INTEGRATION_TEST_ARGS to operator-workflows automatically.
-  integration-tests:
+  openstack-integration-tests:
     name: Integration test with juju 3.1
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
       juju-channel: 3.1/stable
-      pre-run-script: scripts/pre-integration-test.sh
+      pre-run-script: scripts/setup-lxd.sh
       provider: lxd
       test-tox-env: integration-juju3.1
       modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,11 +19,10 @@ jobs:
       pre-run-script: scripts/pre-integration-test.sh
       provider: lxd
       test-tox-env: integration-juju3.1
-      # These important local LXD test have no OpenStack integration versions.
-      # test_charm_scheduled_events ensures reconcile events are fired on a schedule.
-      # test_debug_ssh ensures tmate SSH actions works.
-      # The test test_charm_upgrade needs to run to ensure the charm can be upgraded.
       modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'
+      extra-arguments: "-m openstack"
+      self-hosted-runner: true
+      self-hosted-runner-label: stg-private-endpoint
   openstack-interface-tests-private-endpoint:
     name: openstack interface test using private-endpoint
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -38,7 +38,6 @@ jobs:
   openstack-integration-tests-private-endpoint:
     name: Integration test using private-endpoint
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@disable-snap-autorefresh
-    needs: openstack-interface-tests-private-endpoint
     secrets: inherit
     with:
       juju-channel: 3.6/stable

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,7 +12,7 @@ jobs:
   # INTEGRATION_TEST_ARGS to operator-workflows automatically.
   integration-tests:
     name: Integration test with juju 3.1
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@disable-snap-autorefresh
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
       juju-channel: 3.1/stable
@@ -25,7 +25,7 @@ jobs:
       self-hosted-runner-label: stg-private-endpoint
   openstack-interface-tests-private-endpoint:
     name: openstack interface test using private-endpoint
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@disable-snap-autorefresh
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
       juju-channel: 3.6/stable
@@ -37,7 +37,7 @@ jobs:
       self-hosted-runner-label: stg-private-endpoint
   openstack-integration-tests-private-endpoint:
     name: Integration test using private-endpoint
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@disable-snap-autorefresh
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
       juju-channel: 3.6/stable

--- a/.github/workflows/workflow_dispatch_ssh_debug.yaml
+++ b/.github/workflows/workflow_dispatch_ssh_debug.yaml
@@ -12,8 +12,6 @@ jobs:
   workflow-dispatch-tests:
     runs-on: [self-hosted, linux, "${{ inputs.runner }}"]
     steps:
-    - name: Wait
-      run: sleep 300
     - name: Setup tmate session
       uses: canonical/action-tmate@chore/env_var_change
       timeout-minutes: 5

--- a/.github/workflows/workflow_dispatch_ssh_debug.yaml
+++ b/.github/workflows/workflow_dispatch_ssh_debug.yaml
@@ -12,6 +12,8 @@ jobs:
   workflow-dispatch-tests:
     runs-on: [self-hosted, linux, "${{ inputs.runner }}"]
     steps:
+    - name: Wait
+      run: sleep 300
     - name: Setup tmate session
       uses: canonical/action-tmate@chore/env_var_change
       timeout-minutes: 5

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -384,7 +384,7 @@ async def image_builder_fixture(
         app = await model.deploy(
             "github-runner-image-builder",
             channel="latest/edge",
-            revision=43,
+            revision=2,
             constraints="cores=2 mem=2G root-disk=20G virt-type=virtual-machine",
             config={
                 "app-channel": "edge",
@@ -400,7 +400,7 @@ async def image_builder_fixture(
             },
         )
         await model.wait_for_idle(
-            apps=[app.name], timeout=IMAGE_BUILDER_DEPLOY_TIMEOUT_IN_SECONDS
+            apps=[app.name], wait_for_active=True, timeout=IMAGE_BUILDER_DEPLOY_TIMEOUT_IN_SECONDS
         )
     else:
         app = model.applications["github-runner-image-builder"]
@@ -440,7 +440,7 @@ async def app_openstack_runner_fixture(
             reconcile_interval=60,
             constraints={
                 "root-disk": 50 * 1024,
-                "mem": 16 * 1024,
+                "mem": 2 * 1024,
             },
             config={
                 OPENSTACK_CLOUDS_YAML_CONFIG_NAME: clouds_yaml_contents,
@@ -470,43 +470,28 @@ async def app_one_runner(model: Model, app_no_runner: Application) -> AsyncItera
     return app_no_runner
 
 
-@pytest_asyncio.fixture(scope="module")
-async def app_scheduled_events(
+@pytest_asyncio.fixture(scope="module", name="app_scheduled_events")
+async def app_scheduled_events_fixture(
     model: Model,
-    charm_file: str,
-    app_name: str,
-    path: str,
-    token: str,
-    http_proxy: str,
-    https_proxy: str,
-    no_proxy: str,
-) -> AsyncIterator[Application]:
-    """Application with no token.
-
-    Test should ensure it returns with the application having one runner.
-
-    This fixture has to deploy a new application. The scheduled events are set
-    to one hour in other application to avoid conflicting with the tests.
-    Changes to the duration of scheduled interval only takes effect after the
-    next trigger. Therefore, it would take a hour for the duration change to
-    take effect.
-    """
-    application = await deploy_github_runner_charm(
-        model=model,
-        charm_file=charm_file,
-        app_name=app_name,
-        path=path,
-        token=token,
-        runner_storage="memory",
-        http_proxy=http_proxy,
-        https_proxy=https_proxy,
-        no_proxy=no_proxy,
-        reconcile_interval=8,
-    )
-
+    app_openstack_runner,
+):
+    """Application to check scheduled events."""
+    application = app_openstack_runner
+    await application.set_config({"reconcile-interval": "8"})
     await application.set_config({VIRTUAL_MACHINES_CONFIG_NAME: "1"})
+    await model.wait_for_idle(apps=[application.name], status=ACTIVE, timeout=90 * 60)
     await reconcile(app=application, model=model)
+    return application
 
+
+@pytest_asyncio.fixture(scope="module", name="app_no_wait_openstack")
+async def app_no_wait_openstack_fixture(
+    model: Model,
+    app_openstack_runner,
+):
+    """Application to theck tmate ssh with openstack."""
+    application = app_openstack_runner
+    await application.set_config({"reconcile-interval": "60", VIRTUAL_MACHINES_CONFIG_NAME: "1"})
     return application
 
 
@@ -569,11 +554,11 @@ async def app_no_wait_fixture(
 
 @pytest_asyncio.fixture(scope="module", name="tmate_ssh_server_app")
 async def tmate_ssh_server_app_fixture(
-    model: Model, app_no_wait: Application
+    model: Model, app_no_wait_openstack: Application
 ) -> AsyncIterator[Application]:
     """tmate-ssh-server charm application related to GitHub-Runner app charm."""
     tmate_app: Application = await model.deploy("tmate-ssh-server", channel="edge")
-    await app_no_wait.relate("debug-ssh", f"{tmate_app.name}:debug-ssh")
+    await app_no_wait_openstack.relate("debug-ssh", f"{tmate_app.name}:debug-ssh")
     await model.wait_for_idle(apps=[tmate_app.name], status=ACTIVE, timeout=60 * 30)
 
     return tmate_app

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -384,7 +384,7 @@ async def image_builder_fixture(
         app = await model.deploy(
             "github-runner-image-builder",
             channel="latest/edge",
-            revision=2,
+            revision=43,
             constraints="cores=2 mem=2G root-disk=20G virt-type=virtual-machine",
             config={
                 "app-channel": "edge",
@@ -400,7 +400,7 @@ async def image_builder_fixture(
             },
         )
         await model.wait_for_idle(
-            apps=[app.name], wait_for_active=True, timeout=IMAGE_BUILDER_DEPLOY_TIMEOUT_IN_SECONDS
+            apps=[app.name], timeout=IMAGE_BUILDER_DEPLOY_TIMEOUT_IN_SECONDS
         )
     else:
         app = model.applications["github-runner-image-builder"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -489,7 +489,7 @@ async def app_no_wait_tmate_fixture(
     model: Model,
     app_openstack_runner,
 ):
-    """Application to theck tmate ssh with openstack."""
+    """Application to check tmate ssh with openstack without waiting for active."""
     application = app_openstack_runner
     await application.set_config({"reconcile-interval": "60", VIRTUAL_MACHINES_CONFIG_NAME: "1"})
     return application

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -484,8 +484,8 @@ async def app_scheduled_events_fixture(
     return application
 
 
-@pytest_asyncio.fixture(scope="module", name="app_no_wait_openstack")
-async def app_no_wait_openstack_fixture(
+@pytest_asyncio.fixture(scope="module", name="app_no_wait_tmate")
+async def app_no_wait_tmate_fixture(
     model: Model,
     app_openstack_runner,
 ):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -554,11 +554,11 @@ async def app_no_wait_fixture(
 
 @pytest_asyncio.fixture(scope="module", name="tmate_ssh_server_app")
 async def tmate_ssh_server_app_fixture(
-    model: Model, app_no_wait_openstack: Application
+    model: Model, app_no_wait_tmate: Application
 ) -> AsyncIterator[Application]:
     """tmate-ssh-server charm application related to GitHub-Runner app charm."""
     tmate_app: Application = await model.deploy("tmate-ssh-server", channel="edge")
-    await app_no_wait_openstack.relate("debug-ssh", f"{tmate_app.name}:debug-ssh")
+    await app_no_wait_tmate.relate("debug-ssh", f"{tmate_app.name}:debug-ssh")
     await model.wait_for_idle(apps=[tmate_app.name], status=ACTIVE, timeout=60 * 30)
 
     return tmate_app

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -74,11 +74,27 @@ class InstanceHelper(typing.Protocol):
         """
         ...
 
+    async def get_runner_names(self, unit: Unit) -> list[str]:
+        """Get the name of all the runners in the unit.
+
+        Args:
+            unit: The GitHub Runner Charm unit to get the runner names for.
+        """
+        ...
+
     async def get_runner_name(self, unit: Unit) -> str:
         """Get the name of the runner.
 
         Args:
             unit: The GitHub Runner Charm unit to get the runner name for.
+        """
+        ...
+
+    async def delete_single_runner(self, unit: Unit) -> None:
+        """Delete the only runner.
+
+        Args:
+            unit: The GitHub Runner Charm unit to delete the runner name for.
         """
         ...
 

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -55,7 +55,12 @@ class InstanceHelper(typing.Protocol):
     """Helper for running commands in instances."""
 
     async def run_in_instance(
-        self, unit: Unit, command: str, timeout: int | None = None
+        self,
+        unit: Unit,
+        command: str,
+        timeout: int | None = None,
+        assert_on_failure: bool = False,
+        assert_msg: str | None = None,
     ) -> tuple[int, str | None, str | None]:
         """Run command in instance.
 
@@ -63,6 +68,8 @@ class InstanceHelper(typing.Protocol):
             unit: Juju unit to execute the command in.
             command: Command to execute.
             timeout: Amount of time to wait for the execution.
+            assert_on_failure: Perform assertion on non-zero exit code.
+            assert_msg: Message for the failure assertion.
         """
         ...
 

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -73,6 +73,24 @@ class InstanceHelper(typing.Protocol):
         """
         ...
 
+    async def expose_to_instance(
+        self,
+        unit: Unit,
+        port: int,
+        host: str = "localhost",
+    ) -> None:
+        """Expose a port on the juju machine to the OpenStack instance.
+
+        Uses SSH remote port forwarding from the juju machine to the OpenStack instance containing
+        the runner.
+
+        Args:
+            unit: The juju unit of the github-runner charm.
+            port: The port on the juju machine to expose to the runner.
+            host: Host for the reverse tunnel.
+        """
+        ...
+
     async def ensure_charm_has_runner(self, app: Application):
         """Ensure charm has a runner.
 

--- a/tests/integration/helpers/lxd.py
+++ b/tests/integration/helpers/lxd.py
@@ -56,6 +56,29 @@ class LXDInstanceHelper(InstanceHelper):
         """
         return await get_runner_name(unit)
 
+    async def get_runner_names(self, unit: Unit) -> list[str]:
+        """Get the name of all the runners in the unit.
+
+        Args:
+            unit: The GitHub Runner Charm unit to get the runner names for.
+
+        Raises:
+            NotImplementedError: Not implemented yet.
+        """
+        raise NotImplementedError
+
+    async def delete_single_runner(self, unit: Unit) -> None:
+        """Delete the only runner.
+
+
+        Args:
+            unit: The GitHub Runner Charm unit to check.
+
+        Raises:
+            NotImplementedError: Not implemented yet.
+        """
+        raise NotImplementedError
+
 
 async def assert_resource_lxd_profile(unit: Unit, configs: dict[str, Any]) -> None:
     """Check for LXD profile of the matching resource config.

--- a/tests/integration/helpers/lxd.py
+++ b/tests/integration/helpers/lxd.py
@@ -20,7 +20,12 @@ class LXDInstanceHelper(InstanceHelper):
     """Helper class to interact with LXD instances."""
 
     async def run_in_instance(
-        self, unit: Unit, command: str, timeout: int | None = None
+        self,
+        unit: Unit,
+        command: str,
+        timeout: int | None = None,
+        assert_on_failure: bool = False,
+        assert_msg: str | None = None,
     ) -> tuple[int, str | None, str | None]:
         """Run command in LXD instance.
 
@@ -28,6 +33,8 @@ class LXDInstanceHelper(InstanceHelper):
             unit: Juju unit to execute the command in.
             command: Command to execute.
             timeout: Amount of time to wait for the execution.
+            assert_on_failure: Not used in lxd
+            assert_msg: Not used in lxd
 
         Returns:
             Tuple of return code, stdout and stderr.

--- a/tests/integration/helpers/lxd.py
+++ b/tests/integration/helpers/lxd.py
@@ -42,6 +42,27 @@ class LXDInstanceHelper(InstanceHelper):
         name = await self.get_runner_name(unit)
         return await run_in_lxd_instance(unit, name, command, timeout=timeout)
 
+    async def expose_to_instance(
+        self,
+        unit: Unit,
+        port: int,
+        host: str = "localhost",
+    ) -> None:
+        """Expose a port on the juju machine to the OpenStack instance.
+
+        Uses SSH remote port forwarding from the juju machine to the OpenStack instance containing
+        the runner.
+
+        Args:
+            unit: The juju unit of the github-runner charm.
+            port: The port on the juju machine to expose to the runner.
+            host: Host for the reverse tunnel.
+
+        Raises:
+            NotImplementedError: Not implemented yet.
+        """
+        raise NotImplementedError
+
     async def ensure_charm_has_runner(self, app: Application):
         """Reconcile the charm to contain one runner.
 

--- a/tests/integration/helpers/openstack.py
+++ b/tests/integration/helpers/openstack.py
@@ -32,6 +32,7 @@ class OpenStackInstanceHelper(InstanceHelper):
         self,
         unit: Unit,
         port: int,
+        host: str = "localhost",
     ) -> None:
         """Expose a port on the juju machine to the OpenStack instance.
 
@@ -41,6 +42,7 @@ class OpenStackInstanceHelper(InstanceHelper):
         Args:
             unit: The juju unit of the github-runner charm.
             port: The port on the juju machine to expose to the runner.
+            host: Host for the reverse tunnel.
         """
         runner = self._get_single_runner(unit=unit)
         assert runner, f"Runner not found for unit {unit.name}"
@@ -61,7 +63,7 @@ class OpenStackInstanceHelper(InstanceHelper):
         key_path = f"/home/{RUNNER_MANAGER_USER}/.ssh/{runner.name}.key"
         exit_code, _, _ = await run_in_unit(unit, f"ls {key_path}")
         assert exit_code == 0, f"Unable to find key file {key_path}"
-        ssh_cmd = f'ssh -fNT -R {port}:localhost:{port} -i {key_path} -o "StrictHostKeyChecking no" -o "ControlPersist yes" ubuntu@{ip} &'
+        ssh_cmd = f'ssh -fNT -R {port}:{host}:{port} -i {key_path} -o "StrictHostKeyChecking no" -o "ControlPersist yes" ubuntu@{ip} &'
         exit_code, _, stderr = await run_in_unit(unit, ssh_cmd)
         assert (
             exit_code == 0

--- a/tests/integration/test_charm_scheduled_events.py
+++ b/tests/integration/test_charm_scheduled_events.py
@@ -13,49 +13,48 @@ import pytest
 from juju.application import Application
 from juju.model import Model
 
-from runner_manager import LXDRunnerManager
-from tests.integration.helpers.common import check_runner_binary_exists
-from tests.integration.helpers.lxd import get_runner_names, run_in_unit, wait_till_num_of_runners
+from tests.integration.helpers.common import InstanceHelper, wait_for
 from tests.status_name import ACTIVE
+
+pytestmark = pytest.mark.openstack
 
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_update_interval(model: Model, app_scheduled_events: Application) -> None:
+async def test_update_interval(
+    model: Model,
+    app_scheduled_events: Application,
+    instance_helper: InstanceHelper,
+) -> None:
     """
     arrange: A working application with one runner.
     act:
-        1.  a. Remove runner binary.
-            b. Crash the one runner
+        1.  a. Crash/delete the one runner
         2.  Wait for 6 minutes, and then wait for ActiveStatus.
     assert:
-        1. a. No runner binary exists.
-           b. No runner exists.
-        2.  a. Runner binary exists.
-            b. One runner exists. The runner name should not be the same as the starting one.
+        1. a. No runner exists.
+        2. a. One runner exists. The runner name should not be the same as the starting one.
 
     This tests whether the reconcile-runner event is triggered, and updates the dependencies.
     The reconciliation logic is tested with the reconcile-runners action.
     """
     unit = app_scheduled_events.units[0]
-    assert await check_runner_binary_exists(unit)
 
-    ret_code, stdout, stderr = await run_in_unit(unit, f"rm -f {LXDRunnerManager.runner_bin_path}")
-    assert ret_code == 0, f"Failed to remove runner binary {stdout} {stderr}"
-    assert not await check_runner_binary_exists(unit)
+    oldnames = await instance_helper.get_runner_names(unit)
+    assert len(oldnames) == 1, "There should be one runner"
 
-    runner_names = await get_runner_names(unit)
-    assert len(runner_names) == 1
-    runner_name = runner_names[0]
-    ret_code, stdout, stderr = await run_in_unit(unit, f"lxc stop --force {runner_name}")
-    assert ret_code == 0, f"Failed to stop lxd instance, {stdout} {stderr}"
-    await wait_till_num_of_runners(unit, 0)
+    # delete the only runner
+    await instance_helper.delete_single_runner(unit)
+
+    async def _no_runners_available() -> bool:
+        """Check if there is only one runner."""
+        return len(await instance_helper.get_runner_names(unit)) == 0
+
+    await wait_for(_no_runners_available, timeout=30, check_interval=3)
 
     await sleep(10 * 60)
     await model.wait_for_idle(status=ACTIVE, timeout=20 * 60)
 
-    assert await check_runner_binary_exists(unit)
-
-    runner_names = await get_runner_names(unit)
-    assert len(runner_names) == 1
-    assert runner_name != runner_names[0]
+    newnames = await instance_helper.get_runner_names(unit)
+    assert len(newnames) == 1, "There should be one runner after reconciliation"
+    assert newnames[0] != oldnames[0]

--- a/tests/integration/test_charm_upgrade.py
+++ b/tests/integration/test_charm_upgrade.py
@@ -4,6 +4,7 @@
 """Integration tests for charm upgrades."""
 
 import functools
+import logging
 import pathlib
 
 import pytest
@@ -21,7 +22,6 @@ from charm_state import (
 )
 from tests.integration.helpers.common import (
     deploy_github_runner_charm,
-    inject_lxd_profile,
     is_upgrade_charm_event_emitted,
     wait_for,
 )
@@ -69,8 +69,8 @@ async def test_charm_upgrade(
         "--no-progress",
     )
     assert retcode == 0, f"failed to download charm, {stdout} {stderr}"
-    inject_lxd_profile(pathlib.Path(latest_stable_path), loop_device=loop_device)
 
+    logging.info("proxy value %s", http_proxy)
     # deploy latest stable version of the charm
     application = await deploy_github_runner_charm(
         model=model,

--- a/tests/integration/test_charm_upgrade.py
+++ b/tests/integration/test_charm_upgrade.py
@@ -4,7 +4,6 @@
 """Integration tests for charm upgrades."""
 
 import functools
-import logging
 import pathlib
 
 import pytest
@@ -38,9 +37,9 @@ async def test_charm_upgrade(
     app_name: str,
     path: str,
     token: str,
-    http_proxy: str,
-    https_proxy: str,
-    no_proxy: str,
+    openstack_http_proxy: str,
+    openstack_https_proxy: str,
+    openstack_no_proxy: str,
     tmp_path: pathlib.Path,
     clouds_yaml_contents: str,
     network_name: str,
@@ -70,7 +69,6 @@ async def test_charm_upgrade(
     )
     assert retcode == 0, f"failed to download charm, {stdout} {stderr}"
 
-    logging.info("proxy value %s", http_proxy)
     # deploy latest stable version of the charm
     application = await deploy_github_runner_charm(
         model=model,
@@ -79,9 +77,9 @@ async def test_charm_upgrade(
         path=path,
         token=token,
         runner_storage="juju-storage",
-        http_proxy=http_proxy,
-        https_proxy=https_proxy,
-        no_proxy=no_proxy,
+        http_proxy=openstack_http_proxy,
+        https_proxy=openstack_https_proxy,
+        no_proxy=openstack_no_proxy,
         reconcile_interval=5,
         # override default virtual_machines=0 config.
         config={

--- a/tests/integration/test_debug_ssh.py
+++ b/tests/integration/test_debug_ssh.py
@@ -4,6 +4,7 @@
 """Integration tests for github-runner charm with ssh-debug integration."""
 import logging
 
+import pytest
 from github.Branch import Branch
 from github.Repository import Repository
 from juju.application import Application
@@ -17,10 +18,12 @@ logger = logging.getLogger(__name__)
 
 SSH_DEBUG_WORKFLOW_FILE_NAME = "workflow_dispatch_ssh_debug.yaml"
 
+pytestmark = pytest.mark.openstack
+
 
 async def test_ssh_debug(
     model: Model,
-    app_no_wait: Application,
+    app_no_wait_openstack: Application,
     github_repository: Repository,
     test_github_branch: Branch,
     tmate_ssh_server_unit_ip: str,
@@ -31,7 +34,7 @@ async def test_ssh_debug(
     act: when canonical/action-tmate is triggered.
     assert: the ssh connection info from action-log and tmate-ssh-server matches.
     """
-    await app_no_wait.set_config(
+    await app_no_wait_openstack.set_config(
         {
             DENYLIST_CONFIG_NAME: (
                 "0.0.0.0/8,10.0.0.0/8,100.64.0.0/10,169.254.0.0/16,"
@@ -48,7 +51,7 @@ async def test_ssh_debug(
 
     # expect failure since the ssh workflow will timeout
     workflow_run = await dispatch_workflow(
-        app=app_no_wait,
+        app=app_no_wait_openstack,
         branch=test_github_branch,
         github_repository=github_repository,
         conclusion="failure",

--- a/tests/integration/test_debug_ssh.py
+++ b/tests/integration/test_debug_ssh.py
@@ -3,6 +3,8 @@
 
 """Integration tests for github-runner charm with ssh-debug integration."""
 import logging
+import socket
+import subprocess
 
 import pytest
 from github.Branch import Branch
@@ -11,7 +13,7 @@ from juju.application import Application
 from juju.model import Model
 
 from charm_state import DENYLIST_CONFIG_NAME
-from tests.integration.helpers.common import dispatch_workflow, get_job_logs
+from tests.integration.helpers.common import InstanceHelper, dispatch_workflow, get_job_logs
 from tests.status_name import ACTIVE
 
 logger = logging.getLogger(__name__)
@@ -27,6 +29,7 @@ async def test_ssh_debug(
     github_repository: Repository,
     test_github_branch: Branch,
     tmate_ssh_server_unit_ip: str,
+    instance_helper: InstanceHelper,
 ):
     """
     arrange: given an integrated GitHub-Runner charm and tmate-ssh-server charm with a denylist \
@@ -34,6 +37,13 @@ async def test_ssh_debug(
     act: when canonical/action-tmate is triggered.
     assert: the ssh connection info from action-log and tmate-ssh-server matches.
     """
+    # As the tmate_ssh_server runs in lxd under this host, we need all the connection
+    # that arrive to this host to port 10022 to go to the tmate_ssh_server unit.
+    subprocess.run(["sudo", "bash", "-c", "echo 1 > /proc/sys/net/ipv4/ip_forward"], check=True)
+    # This maybe problematic if we run the test twice in the same machine.
+    dnat_command_in_test_machine = f"sudo iptables -t nat -A PREROUTING -p tcp --dport 10022 -j DNAT --to-destination {tmate_ssh_server_unit_ip}:10022"
+    subprocess.run(dnat_command_in_test_machine.split(), check=True)
+
     await app_no_wait_openstack.set_config(
         {
             DENYLIST_CONFIG_NAME: (
@@ -45,6 +55,17 @@ async def test_ssh_debug(
         }
     )
     await model.wait_for_idle(status=ACTIVE, timeout=60 * 120)
+
+    unit = app_no_wait_openstack.units[0]
+    # We need the runner to connect to the current machine, instead of the tmate_ssh_server unit,
+    # as the tmate_ssh_server is not routable.
+    this_host_ip = _get_current_ip()
+    dnat_comman_in_runner = f"sudo iptables -t nat -A OUTPUT -p tcp --dport 10022 -j DNAT --to-destination {this_host_ip}:10022"
+    ret_code, stdout, stderr = await instance_helper.run_in_instance(
+        unit,
+        dnat_comman_in_runner,
+        assert_on_failure=True,
+    )
 
     # trigger tmate action
     logger.info("Dispatching workflow_dispatch_ssh_debug.yaml workflow.")
@@ -64,3 +85,14 @@ async def test_ssh_debug(
     logger.info("Logs: %s", logs)
     assert tmate_ssh_server_unit_ip in logs, "Tmate ssh server IP not found in action logs."
     assert "10022" in logs, "Tmate ssh server connection port not found in action logs."
+
+
+def _get_current_ip():
+    """Get the IP for the current machine."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(0)
+    try:
+        s.connect(("2.2.2.2", 1))
+        return s.getsockname()[0]
+    finally:
+        s.close()

--- a/tests/integration/test_debug_ssh.py
+++ b/tests/integration/test_debug_ssh.py
@@ -3,8 +3,6 @@
 
 """Integration tests for github-runner charm with ssh-debug integration."""
 import logging
-import socket
-import subprocess
 
 import pytest
 from github.Branch import Branch
@@ -37,13 +35,6 @@ async def test_ssh_debug(
     act: when canonical/action-tmate is triggered.
     assert: the ssh connection info from action-log and tmate-ssh-server matches.
     """
-    # As the tmate_ssh_server runs in lxd under this host, we need all the connection
-    # that arrive to this host to port 10022 to go to the tmate_ssh_server unit.
-    subprocess.run(["sudo", "bash", "-c", "echo 1 > /proc/sys/net/ipv4/ip_forward"], check=True)
-    # This maybe problematic if we run the test twice in the same machine.
-    dnat_command_in_test_machine = f"sudo iptables -t nat -A PREROUTING -p tcp --dport 10022 -j DNAT --to-destination {tmate_ssh_server_unit_ip}:10022"
-    subprocess.run(dnat_command_in_test_machine.split(), check=True)
-
     await app_no_wait_openstack.set_config(
         {
             DENYLIST_CONFIG_NAME: (
@@ -59,13 +50,13 @@ async def test_ssh_debug(
     unit = app_no_wait_openstack.units[0]
     # We need the runner to connect to the current machine, instead of the tmate_ssh_server unit,
     # as the tmate_ssh_server is not routable.
-    this_host_ip = _get_current_ip()
-    dnat_comman_in_runner = f"sudo iptables -t nat -A OUTPUT -p tcp --dport 10022 -j DNAT --to-destination {this_host_ip}:10022"
+    dnat_comman_in_runner = "sudo iptables -t nat -A OUTPUT -p tcp --dport 10022 -j DNAT --to-destination 127.0.0.1:10022"
     ret_code, stdout, stderr = await instance_helper.run_in_instance(
         unit,
         dnat_comman_in_runner,
         assert_on_failure=True,
     )
+    await instance_helper.expose_to_instance(unit=unit, port=10022, host=tmate_ssh_server_unit_ip)  # type: ignore[attr-defined]
 
     # trigger tmate action
     logger.info("Dispatching workflow_dispatch_ssh_debug.yaml workflow.")
@@ -85,14 +76,3 @@ async def test_ssh_debug(
     logger.info("Logs: %s", logs)
     assert tmate_ssh_server_unit_ip in logs, "Tmate ssh server IP not found in action logs."
     assert "10022" in logs, "Tmate ssh server connection port not found in action logs."
-
-
-def _get_current_ip():
-    """Get the IP for the current machine."""
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.settimeout(0)
-    try:
-        s.connect(("2.2.2.2", 1))
-        return s.getsockname()[0]
-    finally:
-        s.close()

--- a/tests/integration/test_debug_ssh.py
+++ b/tests/integration/test_debug_ssh.py
@@ -56,7 +56,7 @@ async def test_ssh_debug(
         dnat_comman_in_runner,
         assert_on_failure=True,
     )
-    await instance_helper.expose_to_instance(unit=unit, port=10022, host=tmate_ssh_server_unit_ip)  # type: ignore[attr-defined]
+    await instance_helper.expose_to_instance(unit=unit, port=10022, host=tmate_ssh_server_unit_ip)
 
     # trigger tmate action
     logger.info("Dispatching workflow_dispatch_ssh_debug.yaml workflow.")

--- a/tests/integration/test_debug_ssh.py
+++ b/tests/integration/test_debug_ssh.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.openstack
 
 async def test_ssh_debug(
     model: Model,
-    app_no_wait_openstack: Application,
+    app_no_wait_tmate: Application,
     github_repository: Repository,
     test_github_branch: Branch,
     tmate_ssh_server_unit_ip: str,
@@ -35,7 +35,7 @@ async def test_ssh_debug(
     act: when canonical/action-tmate is triggered.
     assert: the ssh connection info from action-log and tmate-ssh-server matches.
     """
-    await app_no_wait_openstack.set_config(
+    await app_no_wait_tmate.set_config(
         {
             DENYLIST_CONFIG_NAME: (
                 "0.0.0.0/8,10.0.0.0/8,100.64.0.0/10,169.254.0.0/16,"
@@ -47,7 +47,7 @@ async def test_ssh_debug(
     )
     await model.wait_for_idle(status=ACTIVE, timeout=60 * 120)
 
-    unit = app_no_wait_openstack.units[0]
+    unit = app_no_wait_tmate.units[0]
     # We need the runner to connect to the current machine, instead of the tmate_ssh_server unit,
     # as the tmate_ssh_server is not routable.
     dnat_comman_in_runner = "sudo iptables -t nat -A OUTPUT -p tcp --dport 10022 -j DNAT --to-destination 127.0.0.1:10022"
@@ -63,7 +63,7 @@ async def test_ssh_debug(
 
     # expect failure since the ssh workflow will timeout
     workflow_run = await dispatch_workflow(
-        app=app_no_wait_openstack,
+        app=app_no_wait_tmate,
         branch=test_github_branch,
         github_repository=github_repository,
         conclusion="failure",

--- a/tests/integration/test_debug_ssh.py
+++ b/tests/integration/test_debug_ssh.py
@@ -51,7 +51,7 @@ async def test_ssh_debug(
     # We need the runner to connect to the current machine, instead of the tmate_ssh_server unit,
     # as the tmate_ssh_server is not routable.
     dnat_comman_in_runner = "sudo iptables -t nat -A OUTPUT -p tcp --dport 10022 -j DNAT --to-destination 127.0.0.1:10022"
-    ret_code, stdout, stderr = await instance_helper.run_in_instance(
+    _, _, _ = await instance_helper.run_in_instance(
         unit,
         dnat_comman_in_runner,
         assert_on_failure=True,


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

We want all generic integration tests to run in openstack, as local lxd will be used in another track (not the latest one).

This PR uses openstack for the three integration tests that were using lxd, that is:
- test_charm_scheduled_events
- test_debug_ssh
- test_charm_upgrade

More cleaning will be done in subsequent PRs.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->