### PR TITLE
fix: Use busy flush on stop

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2024-12-04
+
+- Clean up corresponding OpenStack runner resources when a unit of the charm is removed.
+
 ### 2024-11-27
 
 - Fix "Available Runners" dashboard panel to work for multiple flavors.

--- a/github-runner-manager/src-docs/reactive.consumer.md
+++ b/github-runner-manager/src-docs/reactive.consumer.md
@@ -74,7 +74,7 @@ Log the job details and acknowledge the message. If the job details are invalid,
 
 ---
 
-<a href="../../reactive/consumer/signal_handler#L234"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../reactive/consumer/signal_handler#L238"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `signal_handler`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -962,7 +962,7 @@ class GithubRunnerCharm(CharmBase):
 
         if state.instance_type == InstanceType.OPENSTACK:
             runner_scaler = self._get_runner_scaler(state)
-            runner_scaler.flush()
+            runner_scaler.flush(FlushMode.FLUSH_BUSY)
             return
 
         runner_manager = self._get_runner_manager(state)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 import yaml
 from github_runner_manager.errors import ReconcileError
+from github_runner_manager.manager.runner_manager import FlushMode
 from github_runner_manager.manager.runner_scaler import RunnerScaler
 from github_runner_manager.types_.github import GitHubOrg, GitHubRepo, GitHubRunnerStatus
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, StatusBase, WaitingStatus
@@ -390,6 +391,24 @@ def test_on_reconcile_runners_reconcile_error(harness: Harness, monkeypatch: pyt
 
     assert harness.charm.unit.status.name == ActiveStatus.name
     assert harness.charm.unit.status.message == ACTIVE_STATUS_RECONCILIATION_FAILED_MSG
+
+
+def test_on_stop_busy_flush(harness: Harness, monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: Set up charm with Openstack mode and runner scaler mock.
+    act: Trigger stop event.
+    assert: Runner scaler mock flushes the runners using busy mode.
+    """
+    state_mock = MagicMock()
+    state_mock.instance_type = InstanceType.OPENSTACK
+    harness.charm._setup_state = MagicMock(return_value=state_mock)
+    runner_scaler_mock = MagicMock(spec=RunnerScaler)
+    harness.charm._get_runner_scaler = MagicMock(return_value=runner_scaler_mock)
+    mock_event = MagicMock()
+
+    harness.charm._on_stop(mock_event)
+
+    runner_scaler_mock.flush.assert_called_once_with(FlushMode.FLUSH_BUSY)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Use busy mode when flushing on a unit stop

### Rationale

to avoid dangling Openstack resources (as they are not currently being cleaned up by the other units).


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->