### PR TITLE
Add schedule to integration test for Allure

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -2,6 +2,9 @@ name: integration-tests
 
 on:
   pull_request:
+  schedule:
+    # Trigger at 6:00 AM and 6:00 PM UTC
+    - cron: "0 6,18 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -49,7 +52,7 @@ jobs:
       self-hosted-runner: true
       self-hosted-runner-label: stg-private-endpoint
   allure-report:
-    if: always() && !cancelled()
+    if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
     needs:
       - integration-tests
       - openstack-interface-tests-private-endpoint


### PR DESCRIPTION
### Overview

Change integration test workflow to generate allure reports only at the scheduled time (6 AM and 6 PM UTC)
<!-- A high level overview of the change -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->