### PR TITLE
Change codeowners to specific people

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/is-charms
+*       @bartz @yhaliaw @javierdelapuente

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @bartz @yhaliaw @javierdelapuente
+*       @cbartz @yhaliaw @javierdelapuente


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Change codeowners to specific people working on the team this cycle (according to roadmap sheet).

### Rationale

The github auto-assign feature is being tested, and we need to avoid assigning reviewers who are outside the roadmap mapping.


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->