### PR TITLE
Update setuptools to 75.8.0

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,7 +5,7 @@ type: charm
 parts:
   charm:
     charm-python-packages:
-      - setuptools  # for jinja2
+      - setuptools>=75.8.0  # for jinja2
     build-packages:
       - git  # for installing git source of pylxd 
       - libffi-dev  # for cffi


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Update `setuptools` to 75.8.0.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->