### PR TITLE
Use new security mechanism based on environment variables

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,6 +3,7 @@
 
 """Fixtures for github runner charm integration tests."""
 import logging
+import os
 import random
 import secrets
 import string
@@ -131,7 +132,7 @@ def path(pytestconfig: pytest.Config) -> str:
 @pytest.fixture(scope="module")
 def token(pytestconfig: pytest.Config) -> str:
     """Configured token setting."""
-    token = pytestconfig.getoption("--token")
+    token = pytestconfig.getoption("--token") or os.environ.get("INTEGRATION_TOKEN")
     assert token, "Please specify the --token command line option"
     tokens = {token.strip() for token in token.split(",")}
     random_token = random.choice(list(tokens))
@@ -141,7 +142,7 @@ def token(pytestconfig: pytest.Config) -> str:
 @pytest.fixture(scope="module")
 def token_alt(pytestconfig: pytest.Config, token: str) -> str:
     """Configured token_alt setting."""
-    token_alt = pytestconfig.getoption("--token-alt")
+    token_alt = pytestconfig.getoption("--token-alt") or os.environ.get("INTEGRATION_TOKEN_ALT")
     assert token_alt, (
         "Please specify the --token-alt command line option with GitHub Personal "
         "Access Token value."
@@ -203,6 +204,7 @@ def private_endpoint_config_fixture(pytestconfig: pytest.Config) -> PrivateEndpo
     """The private endpoint configuration values."""
     auth_url = pytestconfig.getoption("--openstack-auth-url-amd64")
     password = pytestconfig.getoption("--openstack-password-amd64")
+    password = password or os.environ.get("INTEGRATION_OPENSTACK_PASSWORD_AMD64")
     project_domain_name = pytestconfig.getoption("--openstack-project-domain-name-amd64")
     project_name = pytestconfig.getoption("--openstack-project-name-amd64")
     user_domain_name = pytestconfig.getoption("--openstack-user-domain-name-amd64")

--- a/tox.ini
+++ b/tox.ini
@@ -110,6 +110,9 @@ commands =
 description = Run integration tests
 pass_env =
     PYTEST_ADDOPTS
+    INTEGRATION_OPENSTACK_PASSWORD_AMD64
+    INTEGRATION_TOKEN
+    INTEGRATION_TOKEN_ALT
 deps =
     juju3.1: juju==3.1.*
     juju3.6: juju==3.6.*


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
In order to not leak secrets in pipelines, use environment variables instead of command line arguments for pytest.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`.
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The changes do not introduce any regression in code or tests related to LXD runner mode.

<!-- Explanation for any unchecked items above -->