### PR TITLE
Use latest image-builder with external build

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -359,7 +359,6 @@ async def image_builder_fixture(
             channel="latest/edge",
             revision=55,
             config={
-                "app-channel": "edge",
                 "build-interval": "12",
                 "revision-history-limit": "2",
                 "openstack-auth-url": private_endpoint_config["auth_url"],


### PR DESCRIPTION
Applicable spec: <link>

### Overview
Use latest image-builder with external build for integration tests.
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->