### PR TITLE
Put a timeout to integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -28,6 +28,7 @@ jobs:
       extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
       self-hosted-runner: true
       self-hosted-runner-label: stg-private-endpoint
+      test-timeout: 90
   openstack-interface-tests-private-endpoint:
     name: openstack interface test using private-endpoint
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -391,7 +391,9 @@ async def is_upgrade_charm_event_emitted(unit: Unit) -> bool:
     """
     unit_name_without_slash = unit.name.replace("/", "-")
     juju_unit_log_file = f"/var/log/juju/unit-{unit_name_without_slash}.log"
-    ret_code, stdout, stderr = await run_in_unit(unit=unit, command=f"cat {juju_unit_log_file}")
+    ret_code, stdout, stderr = await run_in_unit(
+        unit=unit, command=f"cat {juju_unit_log_file} | grep 'Emitting Juju event upgrade_charm.'"
+    )
     assert ret_code == 0, f"Failed to read the log file: {stderr}"
     return stdout is not None and "Emitting Juju event upgrade_charm." in stdout
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Any test taking more than 90 min is a broken test that should fail.

Also do not send a full file with logs with juju ssh, as it sometimes get stuck when the file is very big. Instead grep in the unit machine.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->