### PR TITLE
Bump pyopenssl and cryptography version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,10 @@ ops>=2.8
 pylxd @ git+https://github.com/canonical/pylxd
 requests
 typing-extensions
-cryptography <=44.0.0
+cryptography==44.0.1
 pydantic ==1.10.19
 cosl ==0.0.47
 # juju 3.1.2.0 depends on pyyaml<=6.0 and >=5.1.2
 PyYAML ==6.0.*
-pyOpenSSL==24.3.0
+pyOpenSSL==25.0.0
 ./github-runner-manager


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Bump pyopenssl and cryptography version.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->