### PR TITLE
use self-hosted for tics

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 jobs:
   TICS:
     name: TICS
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Overview

Switch tics workflow to use the self-hosted runners

### Rationale

It should be faster and will make sure that we are testing the self-hosted tics runners

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->