### PR TITLE
Simplify interface of the charm with the library

### DIFF
--- a/github-runner-manager/src/github_runner_manager/configuration/base.py
+++ b/github-runner-manager/src/github_runner_manager/configuration/base.py
@@ -42,7 +42,7 @@ class SupportServiceConfig(BaseModel):
 
     proxy_config: "ProxyConfig | None"
     dockerhub_mirror: str | None
-    ssh_debug_connections: "list[SSHDebugConnection] | None"
+    ssh_debug_connections: "list[SSHDebugConnection]"
     repo_policy_compliance: "RepoPolicyComplianceConfig | None"
 
 

--- a/github-runner-manager/src/github_runner_manager/constants.py
+++ b/github-runner-manager/src/github_runner_manager/constants.py
@@ -3,6 +3,8 @@
 
 """Constants for the library."""
 
+GITHUB_SELF_HOSTED_ARCH_LABELS = {"x64", "arm64"}
+
 # Pending to be removed when the application works in standalone mode.
 RUNNER_MANAGER_USER = "runner-manager"
 RUNNER_MANAGER_GROUP = "runner-manager"

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -96,8 +96,8 @@ class RunnerManager:
         """Construct the object.
 
         Args:
-            manager_name: TODO
-            github_configuration: TODO
+            manager_name: Name of the manager.
+            github_configuration: Configuration for GitHub.
             cloud_runner_manager: For managing the cloud instance of the runner.
         """
         self.manager_name = manager_name

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -79,19 +79,6 @@ class RunnerInstance:
         self.cloud_state = cloud_instance.state
 
 
-@dataclass
-class RunnerManagerConfig:
-    """Configuration for the runner manager.
-
-    Attributes:
-        name: A name to identify this manager.
-        github_configuration: GitHub configuration information.
-    """
-
-    name: str
-    github_configuration: GitHubConfiguration
-
-
 class RunnerManager:
     """Manage the runners.
 
@@ -102,22 +89,23 @@ class RunnerManager:
 
     def __init__(
         self,
+        manager_name: str,
+        github_configuration: GitHubConfiguration,
         cloud_runner_manager: CloudRunnerManager,
-        config: RunnerManagerConfig,
     ):
         """Construct the object.
 
         Args:
+            manager_name: TODO
+            github_configuration: TODO
             cloud_runner_manager: For managing the cloud instance of the runner.
-            config: Configuration of this class.
         """
-        self.manager_name = config.name
-        self._config = config
+        self.manager_name = manager_name
         self._cloud = cloud_runner_manager
         self.name_prefix = self._cloud.name_prefix
         self._github = GitHubRunnerManager(
             prefix=self.name_prefix,
-            github_configuration=self._config.github_configuration,
+            github_configuration=github_configuration,
         )
 
     def create_runners(self, num: int) -> tuple[InstanceId, ...]:

--- a/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
@@ -136,7 +136,6 @@ class RunnerScaler:
             github_path=application_configuration.github_config.path, labels=labels
         )
         openstack_runner_manager_config = OpenStackRunnerManagerConfig(
-            # The prefix is set to f"{application_name}-{unit number}"
             prefix=openstack_configuration.vm_prefix,
             credentials=openstack_configuration.credentials,
             server_config=server_config,

--- a/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
@@ -108,14 +108,14 @@ class RunnerScaler:
         application_configuration: ApplicationConfiguration,
         openstack_configuration: OpenStackConfiguration,
     ) -> "RunnerScaler":
-        """TODO.
+        """Create a RunnerScaler from application and OpenStack configuration.
 
         Args:
-            application_configuration: TODO
-            openstack_configuration: TODO
+            application_configuration: Main configuration for the application.
+            openstack_configuration: OpenStack configuration.
 
         Returns:
-            TODO.
+            A new RunnerScaler.
         """
         labels = application_configuration.extra_labels
         server_config = None

--- a/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
@@ -8,13 +8,20 @@ import time
 from dataclasses import dataclass
 
 import github_runner_manager.reactive.runner_manager as reactive_runner_manager
+from github_runner_manager.configuration import (
+    ApplicationConfiguration,
+)
+from github_runner_manager.constants import GITHUB_SELF_HOSTED_ARCH_LABELS
 from github_runner_manager.errors import (
     CloudError,
     IssueMetricEventError,
     MissingServerConfigError,
     ReconcileError,
 )
-from github_runner_manager.manager.cloud_runner_manager import HealthState
+from github_runner_manager.manager.cloud_runner_manager import (
+    GitHubRunnerConfig,
+    HealthState,
+)
 from github_runner_manager.manager.github_runner_manager import GitHubRunnerState
 from github_runner_manager.manager.runner_manager import (
     FlushMode,
@@ -23,6 +30,14 @@ from github_runner_manager.manager.runner_manager import (
     RunnerManager,
 )
 from github_runner_manager.metrics import events as metric_events
+from github_runner_manager.openstack_cloud.configuration import (
+    OpenStackConfiguration,
+)
+from github_runner_manager.openstack_cloud.openstack_runner_manager import (
+    OpenStackRunnerManager,
+    OpenStackRunnerManagerConfig,
+    OpenStackServerConfig,
+)
 from github_runner_manager.reactive.types_ import ReactiveProcessConfig
 
 logger = logging.getLogger(__name__)
@@ -87,8 +102,76 @@ class _ReconcileMetricData:
 class RunnerScaler:
     """Manage the reconcile of runners."""
 
+    @classmethod
+    def build(
+        cls,
+        application_configuration: ApplicationConfiguration,
+        openstack_configuration: OpenStackConfiguration,
+    ) -> "RunnerScaler":
+        """TODO.
+
+        Args:
+            application_configuration: TODO
+            openstack_configuration: TODO
+
+        Returns:
+            TODO.
+        """
+        labels = application_configuration.extra_labels
+        server_config = None
+        if combinations := application_configuration.non_reactive_configuration.combinations:
+            combination = combinations[0]
+            labels += combination.image.labels
+            labels += combination.flavor.labels
+            server_config = OpenStackServerConfig(
+                image=combination.image.name,
+                # Pending to add support for more flavor label combinations
+                flavor=combination.flavor.name,
+                network=openstack_configuration.network,
+            )
+
+        runner_config = GitHubRunnerConfig(
+            github_path=application_configuration.github_config.path, labels=labels
+        )
+        openstack_runner_manager_config = OpenStackRunnerManagerConfig(
+            # The prefix is set to f"{application_name}-{unit number}"
+            prefix=openstack_configuration.vm_prefix,
+            credentials=openstack_configuration.credentials,
+            server_config=server_config,
+            runner_config=runner_config,
+            service_config=application_configuration.service_config,
+        )
+        openstack_runner_manager = OpenStackRunnerManager(
+            config=openstack_runner_manager_config,
+        )
+        runner_manager = RunnerManager(
+            manager_name=application_configuration.name,
+            github_configuration=application_configuration.github_config,
+            cloud_runner_manager=openstack_runner_manager,
+        )
+
+        reactive_runner_config = None
+        if reactive_config := application_configuration.reactive_configuration:
+            # The charm is not able to determine which architecture the runner is running on,
+            # so we add all architectures to the supported labels.
+            supported_labels = set(labels) | GITHUB_SELF_HOSTED_ARCH_LABELS
+            reactive_runner_config = ReactiveProcessConfig(
+                queue=reactive_config.queue,
+                manager_name=application_configuration.name,
+                github_configuration=application_configuration.github_config,
+                cloud_runner_manager=openstack_runner_manager_config,
+                github_token=application_configuration.github_config.token,
+                supported_labels=supported_labels,
+            )
+        return cls(
+            runner_manager=runner_manager,
+            reactive_process_config=reactive_runner_config,
+        )
+
     def __init__(
-        self, runner_manager: RunnerManager, reactive_process_config: ReactiveProcessConfig | None
+        self,
+        runner_manager: RunnerManager,
+        reactive_process_config: ReactiveProcessConfig | None,
     ):
         """Construct the object.
 

--- a/github-runner-manager/src/github_runner_manager/reactive/runner.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/runner.py
@@ -45,8 +45,9 @@ def main() -> None:
     queue_config = runner_config.queue
     openstack_runner_manager = OpenStackRunnerManager(config=runner_config.cloud_runner_manager)
     runner_manager = RunnerManager(
+        manager_name=runner_config.manager_name,
+        github_configuration=runner_config.github_configuration,
         cloud_runner_manager=openstack_runner_manager,
-        config=runner_config.runner_manager,
     )
     github_client = GithubClient(token=runner_config.github_token)
     consume(

--- a/github-runner-manager/src/github_runner_manager/reactive/types_.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/types_.py
@@ -17,8 +17,8 @@ class ReactiveProcessConfig(BaseModel):
 
     Attributes:
         queue: The queue configuration.
-        manager_name: TODO
-        github_configuration: todo
+        manager_name: Name of the manager.
+        github_configuration: Configuration for GitHub.
         cloud_runner_manager: The OpenStack runner manager configuration.
         github_token: str
         supported_labels: The supported labels for the runner.

--- a/github-runner-manager/src/github_runner_manager/reactive/types_.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/types_.py
@@ -6,7 +6,7 @@
 from pydantic import BaseModel
 
 from github_runner_manager.configuration.base import QueueConfig
-from github_runner_manager.manager.runner_manager import RunnerManagerConfig
+from github_runner_manager.configuration.github import GitHubConfiguration
 from github_runner_manager.openstack_cloud.openstack_runner_manager import (
     OpenStackRunnerManagerConfig,
 )
@@ -17,14 +17,16 @@ class ReactiveProcessConfig(BaseModel):
 
     Attributes:
         queue: The queue configuration.
-        runner_manager: The runner manager configuration.
+        manager_name: TODO
+        github_configuration: todo
         cloud_runner_manager: The OpenStack runner manager configuration.
         github_token: str
         supported_labels: The supported labels for the runner.
     """
 
     queue: QueueConfig
-    runner_manager: RunnerManagerConfig
+    manager_name: str
+    github_configuration: GitHubConfiguration
     cloud_runner_manager: OpenStackRunnerManagerConfig
     github_token: str
     supported_labels: set[str]

--- a/github-runner-manager/tests/unit/test_runner_scaler.py
+++ b/github-runner-manager/tests/unit/test_runner_scaler.py
@@ -127,7 +127,7 @@ def runner_manager_fixture(
 
 @pytest.fixture(scope="function", name="application_configuration")
 def application_configuration_fixture() -> ApplicationConfiguration:
-    """TODO."""
+    """Returns a fixture with a fully populated ApplicationConfiguration."""
     return ApplicationConfiguration(
         name="app_name",
         extra_labels=["label1", "label2"],
@@ -186,7 +186,7 @@ def application_configuration_fixture() -> ApplicationConfiguration:
 
 @pytest.fixture(scope="function", name="openstack_configuration")
 def openstack_configuration_fixture() -> OpenStackConfiguration:
-    """TODO."""
+    """Returns a fixture with a fully populated OpenStackConfiguration."""
     return OpenStackConfiguration(
         vm_prefix="unit_name",
         network="network",

--- a/github-runner-manager/tests/unit/test_runner_scaler.py
+++ b/github-runner-manager/tests/unit/test_runner_scaler.py
@@ -2,22 +2,56 @@
 # See LICENSE file for licensing details.
 
 
+import getpass
+import grp
+import os
 from typing import Iterable
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic.networks import IPv4Address
 
-from github_runner_manager.configuration.github import GitHubConfiguration, GitHubPath, GitHubRepo
+from github_runner_manager.configuration import (
+    ApplicationConfiguration,
+    Flavor,
+    Image,
+    NonReactiveCombination,
+    NonReactiveConfiguration,
+    ProxyConfig,
+    QueueConfig,
+    ReactiveConfiguration,
+    RepoPolicyComplianceConfig,
+    SSHDebugConnection,
+    SupportServiceConfig,
+)
+from github_runner_manager.configuration.github import (
+    GitHubConfiguration,
+    GitHubOrg,
+    GitHubPath,
+    GitHubRepo,
+)
 from github_runner_manager.errors import CloudError, ReconcileError
-from github_runner_manager.manager.cloud_runner_manager import CloudRunnerState, InstanceId
+from github_runner_manager.manager.cloud_runner_manager import (
+    CloudRunnerState,
+    GitHubRunnerConfig,
+    InstanceId,
+)
 from github_runner_manager.manager.github_runner_manager import GitHubRunnerState
 from github_runner_manager.manager.runner_manager import (
     FlushMode,
     RunnerManager,
-    RunnerManagerConfig,
 )
 from github_runner_manager.manager.runner_scaler import RunnerScaler
 from github_runner_manager.metrics.events import Reconciliation
+from github_runner_manager.openstack_cloud.configuration import (
+    OpenStackConfiguration,
+    OpenStackCredentials,
+)
+from github_runner_manager.openstack_cloud.openstack_runner_manager import (
+    OpenStackRunnerManagerConfig,
+    OpenStackServerConfig,
+)
+from github_runner_manager.reactive.types_ import ReactiveProcessConfig
 from tests.unit.mock_runner_managers import (
     MockCloudRunnerManager,
     MockGitHubRunnerManager,
@@ -84,16 +118,94 @@ def runner_manager_fixture(
         "github_runner_manager.manager.runner_manager.runner_metrics.issue_events", MagicMock()
     )
 
-    config = RunnerManagerConfig(
-        "mock_runners", GitHubConfiguration(token="mock_token", path=github_path)
+    runner_manager = RunnerManager(
+        "mock_runners", GitHubConfiguration(token="mock_token", path=github_path), mock_cloud
     )
-    runner_manager = RunnerManager(mock_cloud, config)
     runner_manager._github = mock_github
     return runner_manager
 
 
+@pytest.fixture(scope="function", name="application_configuration")
+def application_configuration_fixture() -> ApplicationConfiguration:
+    """TODO."""
+    return ApplicationConfiguration(
+        name="app_name",
+        extra_labels=["label1", "label2"],
+        github_config=GitHubConfiguration(
+            token="githubtoken", path=GitHubOrg(org="canonical", group="group")
+        ),
+        service_config=SupportServiceConfig(
+            proxy_config=ProxyConfig(
+                http="http://httpproxy.example.com:3128",
+                https="http://httpsproxy.example.com:3128",
+                no_proxy="127.0.0.1",
+                use_aproxy=False,
+            ),
+            dockerhub_mirror="https://docker.example.com",
+            ssh_debug_connections=[
+                SSHDebugConnection(
+                    host=IPv4Address("10.10.10.10"),
+                    port=3000,
+                    rsa_fingerprint="SHA256:rsa",
+                    ed25519_fingerprint="SHA256:ed25519",
+                )
+            ],
+            repo_policy_compliance=RepoPolicyComplianceConfig(
+                token="token",
+                url="https://compliance.example.com",
+            ),
+        ),
+        non_reactive_configuration=NonReactiveConfiguration(
+            combinations=[
+                NonReactiveCombination(
+                    image=Image(
+                        name="image_id",
+                        labels=["arm64", "noble"],
+                    ),
+                    flavor=Flavor(
+                        name="flavor",
+                        labels=["flavorlabel"],
+                    ),
+                    base_virtual_machines=1,
+                )
+            ]
+        ),
+        reactive_configuration=ReactiveConfiguration(
+            queue=QueueConfig(
+                mongodb_uri="mongodb://user:password@localhost:27017",
+                queue_name="app_name",
+            ),
+            max_total_virtual_machines=2,
+            images=[
+                Image(name="image_id", labels=["arm64", "noble"]),
+            ],
+            flavors=[Flavor(name="flavor", labels=["flavorlabel"])],
+        ),
+    )
+
+
+@pytest.fixture(scope="function", name="openstack_configuration")
+def openstack_configuration_fixture() -> OpenStackConfiguration:
+    """TODO."""
+    return OpenStackConfiguration(
+        vm_prefix="unit_name",
+        network="network",
+        credentials=OpenStackCredentials(
+            auth_url="auth_url",
+            project_name="project_name",
+            username="username",
+            password="password",
+            user_domain_name="user_domain_name",
+            project_domain_name="project_domain_name",
+            region_name="region",
+        ),
+    )
+
+
 @pytest.fixture(scope="function", name="runner_scaler")
-def runner_scaler_fixture(runner_manager: RunnerManager) -> RunnerScaler:
+def runner_scaler_fixture(
+    runner_manager: RunnerManager,
+) -> RunnerScaler:
     return RunnerScaler(runner_manager, None)
 
 
@@ -146,6 +258,123 @@ def assert_runner_info(
     assert len(info.runners) == online
     assert isinstance(info.busy_runners, tuple)
     assert len(info.busy_runners) == busy
+
+
+def test_build_runner_scaler(
+    monkeypatch: pytest.MonkeyPatch,
+    application_configuration: ApplicationConfiguration,
+    openstack_configuration: OpenStackConfiguration,
+):
+    """
+    arrange: Given ApplicationConfiguration and OpenStackConfiguration.
+    act: Call RunnerScaler.build
+    assert: The RunnerScaler was created with the expected configuration.
+    """
+    monkeypatch.setattr("github_runner_manager.constants.RUNNER_MANAGER_USER", getpass.getuser())
+    monkeypatch.setattr(
+        "github_runner_manager.constants.RUNNER_MANAGER_GROUP", grp.getgrgid(os.getgid())
+    )
+
+    runner_scaler = RunnerScaler.build(application_configuration, openstack_configuration)
+    assert runner_scaler
+    # A few comprobations on key data
+    # TODO pending to refactor, too invasive.
+    assert runner_scaler._manager.manager_name == "app_name"
+    assert runner_scaler._manager._github._path == GitHubOrg(org="canonical", group="group")
+    # TODO this one will be well tested in the integration tests...
+    assert runner_scaler._manager._github.github._token == "githubtoken"
+    assert runner_scaler._manager._cloud._config == OpenStackRunnerManagerConfig(
+        prefix="unit_name",
+        credentials=OpenStackCredentials(
+            auth_url="auth_url",
+            project_name="project_name",
+            username="username",
+            password="password",
+            user_domain_name="user_domain_name",
+            project_domain_name="project_domain_name",
+            region_name="region",
+        ),
+        server_config=OpenStackServerConfig(image="image_id", flavor="flavor", network="network"),
+        runner_config=GitHubRunnerConfig(
+            github_path=GitHubOrg(org="canonical", group="group"),
+            labels=["label1", "label2", "arm64", "noble", "flavorlabel"],
+        ),
+        service_config=SupportServiceConfig(
+            proxy_config=ProxyConfig(
+                http="http://httpproxy.example.com:3128",
+                https="http://httpsproxy.example.com:3128",
+                no_proxy="127.0.0.1",
+                use_aproxy=False,
+            ),
+            dockerhub_mirror="https://docker.example.com",
+            ssh_debug_connections=[
+                SSHDebugConnection(
+                    host=IPv4Address("10.10.10.10"),
+                    port=3000,
+                    rsa_fingerprint="SHA256:rsa",
+                    ed25519_fingerprint="SHA256:ed25519",
+                )
+            ],
+            repo_policy_compliance=RepoPolicyComplianceConfig(
+                token="token",
+                url="https://compliance.example.com",
+            ),
+        ),
+    )
+    reactive_process_config = runner_scaler._reactive_config
+    assert reactive_process_config
+    assert reactive_process_config == ReactiveProcessConfig(
+        queue=QueueConfig(
+            mongodb_uri="mongodb://user:password@localhost:27017",
+            queue_name="app_name",
+        ),
+        manager_name="app_name",
+        github_configuration=GitHubConfiguration(
+            token="githubtoken", path=GitHubOrg(org="canonical", group="group")
+        ),
+        cloud_runner_manager=OpenStackRunnerManagerConfig(
+            prefix="unit_name",
+            credentials=OpenStackCredentials(
+                auth_url="auth_url",
+                project_name="project_name",
+                username="username",
+                password="password",
+                user_domain_name="user_domain_name",
+                project_domain_name="project_domain_name",
+                region_name="region",
+            ),
+            server_config=OpenStackServerConfig(
+                image="image_id", flavor="flavor", network="network"
+            ),
+            runner_config=GitHubRunnerConfig(
+                github_path=GitHubOrg(org="canonical", group="group"),
+                labels=["label1", "label2", "arm64", "noble", "flavorlabel"],
+            ),
+            service_config=SupportServiceConfig(
+                proxy_config=ProxyConfig(
+                    http="http://httpproxy.example.com:3128",
+                    https="http://httpsproxy.example.com:3128",
+                    no_proxy="127.0.0.1",
+                    use_aproxy=False,
+                ),
+                dockerhub_mirror="https://docker.example.com",
+                ssh_debug_connections=[
+                    SSHDebugConnection(
+                        host=IPv4Address("10.10.10.10"),
+                        port=3000,
+                        rsa_fingerprint="SHA256:rsa",
+                        ed25519_fingerprint="SHA256:ed25519",
+                    )
+                ],
+                repo_policy_compliance=RepoPolicyComplianceConfig(
+                    token="token",
+                    url="https://compliance.example.com",
+                ),
+            ),
+        ),
+        github_token="githubtoken",
+        supported_labels={"label1", "arm64", "flavorlabel", "label2", "x64", "noble"},
+    )
 
 
 def test_get_no_runner(runner_scaler: RunnerScaler):

--- a/github-runner-manager/tests/unit/test_runner_scaler.py
+++ b/github-runner-manager/tests/unit/test_runner_scaler.py
@@ -277,10 +277,9 @@ def test_build_runner_scaler(
     runner_scaler = RunnerScaler.build(application_configuration, openstack_configuration)
     assert runner_scaler
     # A few comprobations on key data
-    # TODO pending to refactor, too invasive.
+    # Pending to refactor, too invasive.
     assert runner_scaler._manager.manager_name == "app_name"
     assert runner_scaler._manager._github._path == GitHubOrg(org="canonical", group="group")
-    # TODO this one will be well tested in the integration tests...
     assert runner_scaler._manager._github.github._token == "githubtoken"
     assert runner_scaler._manager._cloud._config == OpenStackRunnerManagerConfig(
         prefix="unit_name",

--- a/src/charm.py
+++ b/src/charm.py
@@ -271,8 +271,6 @@ class GithubRunnerCharm(CharmBase):
         runner_scaler = create_runner_scaler(state, self.app.name, self.unit.name)
         self._reconcile_openstack_runners(
             runner_scaler,
-            base_num=state.runner_config.base_virtual_machines,
-            max_num=state.runner_config.max_total_virtual_machines,
         )
 
     def _set_reconcile_timer(self) -> None:
@@ -344,8 +342,6 @@ class GithubRunnerCharm(CharmBase):
             runner_scaler.flush(flush_mode=FlushMode.FLUSH_IDLE)
             self._reconcile_openstack_runners(
                 runner_scaler,
-                base_num=state.runner_config.base_virtual_machines,
-                max_num=state.runner_config.max_total_virtual_machines,
             )
 
     @catch_charm_errors
@@ -373,8 +369,6 @@ class GithubRunnerCharm(CharmBase):
         runner_scaler = create_runner_scaler(state, self.app.name, self.unit.name)
         self._reconcile_openstack_runners(
             runner_scaler,
-            base_num=state.runner_config.base_virtual_machines,
-            max_num=state.runner_config.max_total_virtual_machines,
         )
 
     @catch_action_errors
@@ -416,10 +410,7 @@ class GithubRunnerCharm(CharmBase):
 
         self.unit.status = MaintenanceStatus("Reconciling runners")
         try:
-            delta = runner_scaler.reconcile(
-                base_quantity=state.runner_config.base_virtual_machines,
-                max_quantity=state.runner_config.max_total_virtual_machines,
-            )
+            delta = runner_scaler.reconcile()
         except ReconcileError:
             logger.exception(FAILED_TO_RECONCILE_RUNNERS_MSG)
             self.unit.status = ActiveStatus(ACTIVE_STATUS_RECONCILIATION_FAILED_MSG)
@@ -444,10 +435,7 @@ class GithubRunnerCharm(CharmBase):
         logger.info("Flushed %s runners", flushed)
         self.unit.status = MaintenanceStatus("Reconciling runners")
         try:
-            delta = runner_scaler.reconcile(
-                base_quantity=state.runner_config.base_virtual_machines,
-                max_quantity=state.runner_config.max_total_virtual_machines,
-            )
+            delta = runner_scaler.reconcile()
         except ReconcileError:
             logger.exception(FAILED_TO_RECONCILE_RUNNERS_MSG)
             self.unit.status = ActiveStatus(ACTIVE_STATUS_RECONCILIATION_FAILED_MSG)
@@ -480,19 +468,15 @@ class GithubRunnerCharm(CharmBase):
         runner_scaler = create_runner_scaler(state, self.app.name, self.unit.name)
         runner_scaler.flush(FlushMode.FLUSH_BUSY)
 
-    def _reconcile_openstack_runners(
-        self, runner_scaler: RunnerScaler, base_num: int, max_num: int
-    ) -> None:
+    def _reconcile_openstack_runners(self, runner_scaler: RunnerScaler) -> None:
         """Reconcile the current runners state and intended runner state for OpenStack mode.
 
         Args:
             runner_scaler: Scaler used to scale the amount of runners.
-            base_num: Target number of runners.
-            max_num: Target number of runners.
         """
         self.unit.status = MaintenanceStatus("Reconciling runners")
         try:
-            runner_scaler.reconcile(base_quantity=base_num, max_quantity=max_num)
+            runner_scaler.reconcile()
         except ReconcileError:
             logger.exception(FAILED_TO_RECONCILE_RUNNERS_MSG)
             self.unit.status = ActiveStatus(ACTIVE_STATUS_RECONCILIATION_FAILED_MSG)
@@ -532,8 +516,6 @@ class GithubRunnerCharm(CharmBase):
         runner_scaler.flush()
         self._reconcile_openstack_runners(
             runner_scaler,
-            base_num=state.runner_config.base_virtual_machines,
-            max_num=state.runner_config.max_total_virtual_machines,
         )
 
     @catch_charm_errors
@@ -560,8 +542,6 @@ class GithubRunnerCharm(CharmBase):
         runner_scaler.flush(flush_mode=FlushMode.FLUSH_IDLE)
         self._reconcile_openstack_runners(
             runner_scaler,
-            base_num=state.runner_config.base_virtual_machines,
-            max_num=state.runner_config.max_total_virtual_machines,
         )
 
     def _get_set_image_ready_status(self) -> bool:

--- a/tests/integration/test_runner_manager_openstack.py
+++ b/tests/integration/test_runner_manager_openstack.py
@@ -33,7 +33,6 @@ from github_runner_manager.manager.github_runner_manager import GitHubRunnerStat
 from github_runner_manager.manager.runner_manager import (
     FlushMode,
     RunnerManager,
-    RunnerManagerConfig,
 )
 from github_runner_manager.metrics import events
 from github_runner_manager.openstack_cloud import constants, health_checks
@@ -168,7 +167,7 @@ async def openstack_runner_manager_fixture(
     service_config = SupportServiceConfig(
         proxy_config=proxy_config,
         dockerhub_mirror=None,
-        ssh_debug_connections=None,
+        ssh_debug_connections=[],
         repo_policy_compliance=None,
     )
 
@@ -198,8 +197,11 @@ async def runner_manager_fixture(
     Import of log_dir_base_path to monkeypatch the runner logs path with tmp_path.
     """
     github_configuration = GitHubConfiguration(token=token, path=github_path)
-    config = RunnerManagerConfig("test_runner", github_configuration)
-    yield RunnerManager(openstack_runner_manager, config)
+    yield RunnerManager(
+        manager_name="test_runner",
+        github_configuration=github_configuration,
+        cloud_runner_manager=openstack_runner_manager,
+    )
 
 
 @pytest_asyncio.fixture(scope="function", name="runner_manager_with_one_runner")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -632,14 +632,14 @@ def test__on_image_relation_image_ready(monkeypatch: pytest.MonkeyPatch):
     state_mock = MagicMock()
     harness.charm._setup_state = MagicMock(return_value=state_mock)
     harness.charm._get_set_image_ready_status = MagicMock(return_value=True)
-    runner_manager_mock = MagicMock()
-    monkeypatch.setattr("charm.create_runner_scaler", MagicMock(return_value=runner_manager_mock))
+    runner_scaler_mock = MagicMock()
+    monkeypatch.setattr("charm.create_runner_scaler", MagicMock(return_value=runner_scaler_mock))
 
     harness.charm._on_image_relation_changed(MagicMock())
 
     assert harness.charm.unit.status.name == ActiveStatus.name
-    runner_manager_mock.flush.assert_called_once()
-    runner_manager_mock.reconcile.assert_called_once()
+    runner_scaler_mock.flush.assert_called_once()
+    runner_scaler_mock.reconcile.assert_called_once()
 
 
 def test__on_image_relation_joined():

--- a/tests/unit/test_factories.py
+++ b/tests/unit/test_factories.py
@@ -1,11 +1,6 @@
 #  Copyright 2025 Canonical Ltd.
 #  See LICENSE file for licensing details.
 
-import getpass
-import grp
-import os
-from unittest.mock import MagicMock
-
 import pytest
 from github_runner_manager.configuration import (
     ApplicationConfiguration,
@@ -21,21 +16,10 @@ from github_runner_manager.configuration import (
     SupportServiceConfig,
 )
 from github_runner_manager.configuration.github import GitHubConfiguration, GitHubOrg
-from github_runner_manager.manager.cloud_runner_manager import (
-    GitHubRunnerConfig,
-)
-from github_runner_manager.manager.runner_manager import (
-    RunnerManagerConfig,
-)
 from github_runner_manager.openstack_cloud.configuration import (
     OpenStackConfiguration,
     OpenStackCredentials,
 )
-from github_runner_manager.openstack_cloud.openstack_runner_manager import (
-    OpenStackRunnerManagerConfig,
-    OpenStackServerConfig,
-)
-from github_runner_manager.reactive.types_ import ReactiveProcessConfig
 from pydantic import MongoDsn
 from pydantic.networks import IPv4Address
 
@@ -207,142 +191,4 @@ def test_create_openstack_configuration(complete_charm_state: charm_state.CharmS
             project_domain_name="project_domain_name",
             region_name="region",
         ),
-    )
-
-
-def test_create_runner_scaler(complete_charm_state: charm_state.CharmState, monkeypatch):
-    """
-    arrange: Prepare a fully populated CharmState.
-    act: Call create_runner_scaller.
-    assert: The RunnerScaler was created with the expected configuration.
-    """
-    state = complete_charm_state
-
-    monkeypatch.setattr("github_runner_manager.constants.RUNNER_MANAGER_USER", getpass.getuser())
-    monkeypatch.setattr(
-        "github_runner_manager.constants.RUNNER_MANAGER_GROUP", grp.getgrgid(os.getgid())
-    )
-
-    runner_scaler_mock = MagicMock()
-    monkeypatch.setattr(
-        "factories.RunnerScaler",
-        runner_scaler_mock,
-    )
-
-    runner_scaler = factories.create_runner_scaler(state, "app_name", "unit_name")
-
-    assert runner_scaler
-    runner_scaler_mock.assert_called_once()
-
-    # A few comprobations on key data
-    # This "invasive" code will be deleted in the following PRs when the interface changes.
-    runner_manager = runner_scaler_mock.call_args.kwargs["runner_manager"]
-    assert runner_manager._config == RunnerManagerConfig(
-        name="app_name",
-        github_configuration=GitHubConfiguration(
-            token="githubtoken", path=GitHubOrg(org="canonical", group="group")
-        ),
-    )
-    assert runner_manager._cloud._config == OpenStackRunnerManagerConfig(
-        prefix="unit_name",
-        credentials=OpenStackCredentials(
-            auth_url="auth_url",
-            project_name="project_name",
-            username="username",
-            password="password",
-            user_domain_name="user_domain_name",
-            project_domain_name="project_domain_name",
-            region_name="region",
-        ),
-        server_config=OpenStackServerConfig(image="image_id", flavor="flavor", network="network"),
-        runner_config=GitHubRunnerConfig(
-            github_path=GitHubOrg(org="canonical", group="group"),
-            labels=["label1", "label2", "arm64", "noble", "flavorlabel"],
-        ),
-        service_config=SupportServiceConfig(
-            proxy_config=ProxyConfig(
-                http="http://httpproxy.example.com:3128",
-                https="http://httpsproxy.example.com:3128",
-                no_proxy="127.0.0.1",
-                use_aproxy=False,
-            ),
-            dockerhub_mirror="https://docker.example.com",
-            ssh_debug_connections=[
-                SSHDebugConnection(
-                    host=IPv4Address("10.10.10.10"),
-                    port=3000,
-                    rsa_fingerprint="SHA256:rsa",
-                    ed25519_fingerprint="SHA256:ed25519",
-                )
-            ],
-            repo_policy_compliance=RepoPolicyComplianceConfig(
-                token="token",
-                url="https://compliance.example.com",
-            ),
-        ),
-    )
-    reactive_process_config = runner_scaler_mock.call_args.kwargs["reactive_process_config"]
-    assert reactive_process_config
-    assert reactive_process_config == ReactiveProcessConfig(
-        queue=QueueConfig(
-            mongodb_uri=MongoDsn(
-                "mongodb://user:password@localhost:27017",
-                scheme="mongodb",
-                user="user",
-                password="password",
-                host="localhost",
-                host_type="int_domain",
-                port="27017",
-            ),
-            queue_name="app_name",
-        ),
-        runner_manager=RunnerManagerConfig(
-            name="app_name",
-            github_configuration=GitHubConfiguration(
-                token="githubtoken", path=GitHubOrg(org="canonical", group="group")
-            ),
-        ),
-        cloud_runner_manager=OpenStackRunnerManagerConfig(
-            prefix="unit_name",
-            credentials=OpenStackCredentials(
-                auth_url="auth_url",
-                project_name="project_name",
-                username="username",
-                password="password",
-                user_domain_name="user_domain_name",
-                project_domain_name="project_domain_name",
-                region_name="region",
-            ),
-            server_config=OpenStackServerConfig(
-                image="image_id", flavor="flavor", network="network"
-            ),
-            runner_config=GitHubRunnerConfig(
-                github_path=GitHubOrg(org="canonical", group="group"),
-                labels=["label1", "label2", "arm64", "noble", "flavorlabel"],
-            ),
-            service_config=SupportServiceConfig(
-                proxy_config=ProxyConfig(
-                    http="http://httpproxy.example.com:3128",
-                    https="http://httpsproxy.example.com:3128",
-                    no_proxy="127.0.0.1",
-                    use_aproxy=False,
-                ),
-                dockerhub_mirror="https://docker.example.com",
-                ssh_debug_connections=[
-                    SSHDebugConnection(
-                        host=IPv4Address("10.10.10.10"),
-                        port=3000,
-                        rsa_fingerprint="SHA256:rsa",
-                        ed25519_fingerprint="SHA256:ed25519",
-                    )
-                ],
-                repo_policy_compliance=RepoPolicyComplianceConfig(
-                    token="token",
-                    url="https://compliance.example.com",
-                ),
-            ),
-        ),
-        github_token="githubtoken",
-        #  Pending to review why the x64 is necessary, but it is currently in use.
-        supported_labels={"label1", "arm64", "flavorlabel", "label2", "x64", "noble"},
     )


### PR DESCRIPTION
Applicable spec: ISD201

### Overview

<!-- A high level overview of the change -->

This PR is another in the list for the simplification of the interface between the charm and the application. 

With this PR, the "interface" for the charm and the library is:
- ApplicationConfiguration
- OpenStackConfiguration
- The RunnerScaler public API
  - The reconcile method loses its arguments, are they are in the ApplicationConfiguration.

For that, the RunnerScaler is now instantiated in the library, not in the charm.

A few other minor changes are also in this PR, specially:
- Removing the dataclass RunnerManagerConfig. It only has two fields, and following OO best practices, that information is better contained in the RunnerManager class.


### Rationale
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->