### PR TITLE
Use Just-In-Time tokens for GitHub runner registration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,3 +9,4 @@ jobs:
     secrets: inherit
     with:
       self-hosted-runner: true
+      self-hosted-runner-label: edge

--- a/.github/workflows/test_github_runner_manager.yaml
+++ b/.github/workflows/test_github_runner_manager.yaml
@@ -9,4 +9,5 @@ jobs:
     secrets: inherit
     with:
       self-hosted-runner: true
+      self-hosted-runner-label: edge
       working-directory: ./github-runner-manager/

--- a/github-runner-manager/src/github_runner_manager/constants.py
+++ b/github-runner-manager/src/github_runner_manager/constants.py
@@ -4,7 +4,7 @@
 """Constants for the library."""
 
 GITHUB_SELF_HOSTED_ARCH_LABELS = {"x64", "arm64"}
-GITHUB_DEFAULT_LABELS = {"x64", "arm64"}
+GITHUB_DEFAULT_LABELS = {"self-hosted", "linux"}
 
 # Pending to be removed when the application works in standalone mode.
 RUNNER_MANAGER_USER = "runner-manager"

--- a/github-runner-manager/src/github_runner_manager/constants.py
+++ b/github-runner-manager/src/github_runner_manager/constants.py
@@ -4,6 +4,7 @@
 """Constants for the library."""
 
 GITHUB_SELF_HOSTED_ARCH_LABELS = {"x64", "arm64"}
+GITHUB_DEFAULT_LABELS = {"x64", "arm64"}
 
 # Pending to be removed when the application works in standalone mode.
 RUNNER_MANAGER_USER = "runner-manager"

--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -175,8 +175,6 @@ class GithubClient:
             The registration token.
         """
         token: RegistrationToken
-        instance_id  # pylint: disable=pointless-statement
-        labels  # pylint: disable=pointless-statement
         if isinstance(path, GitHubRepo):
             # JAVI not sure about this
             runner_group_id = 1
@@ -201,7 +199,7 @@ class GithubClient:
         else:
             assert_never(token)
 
-        return token["token"]
+        return token["encoded_jit_config"]
 
     def _get_runner_group_id(self, org: GitHubOrg) -> int:
         """TODO. JUST TO TEST.

--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -206,10 +206,10 @@ class GithubClient:
         Once this function is implemented in the ghapi library, we should
         use that instead. See https://github.com/AnswerDotAI/ghapi/issues/189.
 
-        No pagination is used, so if there are more than 30 groups, this
+        No pagination is used, so if there are more than 100 groups, this
         function could fail.
         """
-        url = f"https://api.github.com/orgs/{org.org}/actions/runner-groups"
+        url = f"https://api.github.com/orgs/{org.org}/actions/runner-groups?per_page=100"
         headers = {
             "Accept": "application/vnd.github+json",
             "Authorization": f"Bearer {self._token}",
@@ -224,7 +224,10 @@ class GithubClient:
                     return group["id"]
         except TypeError as exc:
             raise GithubApiError(f"Cannot get runner_group_id for group {org.group}.") from exc
-        raise GithubApiError(f"Cannot get runner_group_id for group {org.group}")
+        raise GithubApiError(
+            f"Cannot get runner_group_id for group {org.group}."
+            " The group does not exist or there are more than 100 groups."
+        )
 
     @catch_http_errors
     def delete_runner(self, path: GitHubPath, runner_id: int) -> None:

--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -213,7 +213,7 @@ class GithubClient:
         url = f"https://api.github.com/orgs/{org.org}/actions/runner-groups"
         headers = {
             "Accept": "application/vnd.github+json",
-            "Authorization:": "Bearer {self._token}",
+            "Authorization": f"Bearer {self._token}",
             "X-GitHub-Api-Version": "2022-11-28",
         }
         r = requests.get(url, headers=headers, timeout=30)
@@ -224,10 +224,8 @@ class GithubClient:
                 if group["name"] == org.group:
                     return group["id"]
         except TypeError as exc:
-            raise GithubApiError(
-                f"Cannot get runner_group_id for group {org.group_name}."
-            ) from exc
-        raise GithubApiError(f"Cannot get runner_group_id for group {org.group_name}")
+            raise GithubApiError(f"Cannot get runner_group_id for group {org.group}.") from exc
+        raise GithubApiError(f"Cannot get runner_group_id for group {org.group}")
 
     @catch_http_errors
     def delete_runner(self, path: GitHubPath, runner_id: int) -> None:

--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -178,12 +178,11 @@ class GithubClient:
         if isinstance(path, GitHubRepo):
             # The supposition is that the runner_group_id 1 is the default.
             # If the repo does not belong to an org, there is no way to get the runner_group_id.
-            runner_group_id = 1
             token = self._client.actions.generate_runner_jitconfig_for_repo(
                 owner=path.owner,
                 repo=path.repo,
                 name=instance_id,
-                runner_group_id=runner_group_id,
+                runner_group_id=1,
                 labels=labels,
             )
         elif isinstance(path, GitHubOrg):
@@ -216,9 +215,9 @@ class GithubClient:
             "Authorization": f"Bearer {self._token}",
             "X-GitHub-Api-Version": "2022-11-28",
         }
-        r = requests.get(url, headers=headers, timeout=30)
-        r.raise_for_status()
-        data = r.json()
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+        data = response.json()
         try:
             for group in data["runner_groups"]:
                 if group["name"] == org.group:

--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -193,7 +193,7 @@ class GithubClient:
             token = self._client.actions.generate_runner_jitconfig_for_org(
                 org=path.org,
                 name=instance_id,
-                runner_group_id=1,
+                runner_group_id=runner_group_id,
                 labels=labels,
             )
         else:

--- a/github-runner-manager/src/github_runner_manager/manager/cloud_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/cloud_runner_manager.py
@@ -173,19 +173,16 @@ class CloudRunnerManager(abc.ABC):
         """Get the name prefix of the self-hosted runners."""
 
     @abc.abstractmethod
-    def create_runner(self, registration_token: str) -> InstanceId:
+    def generate_instance_id(self) -> InstanceId:
+        """TODO."""
+
+    @abc.abstractmethod
+    def create_runner(self, instance_id: InstanceId, registration_token: str) -> None:
         """Create a self-hosted runner.
 
         Args:
+            instance_id: TODO
             registration_token: The GitHub registration token for registering runners.
-        """
-
-    @abc.abstractmethod
-    def get_runner(self, instance_id: InstanceId) -> CloudRunnerInstance | None:
-        """Get a self-hosted runner by instance id.
-
-        Args:
-            instance_id: The instance id.
         """
 
     @abc.abstractmethod

--- a/github-runner-manager/src/github_runner_manager/manager/cloud_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/cloud_runner_manager.py
@@ -163,12 +163,12 @@ class CloudRunnerManager(abc.ABC):
         """Generate an intance_id to name a runner."""
 
     @abc.abstractmethod
-    def create_runner(self, instance_id: InstanceId, registration_token: str) -> None:
+    def create_runner(self, instance_id: InstanceId, registration_jittoken: str) -> None:
         """Create a self-hosted runner.
 
         Args:
             instance_id: Instance ID for the runner.
-            registration_token: The GitHub registration token for registering runners.
+            registration_jittoken: The JIT GitHub registration token for registering runners.
         """
 
     @abc.abstractmethod

--- a/github-runner-manager/src/github_runner_manager/manager/cloud_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/cloud_runner_manager.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Iterator, Sequence, Tuple
 
-from github_runner_manager.configuration.github import GitHubPath
 from github_runner_manager.metrics.runner import RunnerMetrics
 
 logger = logging.getLogger(__name__)
@@ -128,19 +127,6 @@ class CloudInitStatus(str, Enum):
     ERROR = "error"
     DEGRADED = "degraded"
     DISABLED = "disabled"
-
-
-@dataclass
-class GitHubRunnerConfig:
-    """Configuration for GitHub runner spawned.
-
-    Attributes:
-        github_path: The GitHub organization or repository for runners to connect to.
-        labels: The labels to add to runners.
-    """
-
-    github_path: GitHubPath
-    labels: list[str]
 
 
 @dataclass

--- a/github-runner-manager/src/github_runner_manager/manager/cloud_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/cloud_runner_manager.py
@@ -160,14 +160,14 @@ class CloudRunnerManager(abc.ABC):
 
     @abc.abstractmethod
     def generate_instance_id(self) -> InstanceId:
-        """TODO."""
+        """Generate an intance_id to name a runner."""
 
     @abc.abstractmethod
     def create_runner(self, instance_id: InstanceId, registration_token: str) -> None:
         """Create a self-hosted runner.
 
         Args:
-            instance_id: TODO
+            instance_id: Instance ID for the runner.
             registration_token: The GitHub registration token for registering runners.
         """
 

--- a/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
@@ -94,15 +94,19 @@ class GitHubRunnerManager:  # pragma: no cover
         for runner in runner_list:
             self.github.delete_runner(self._path, runner.id)
 
-    def get_registration_token(self) -> str:
+    def get_registration_token(self, instance_id: str, labels: list[str]) -> str:
         """Get registration token from GitHub.
 
         This token is used for registering self-hosted runners.
 
+        Args:
+            instance_id: TODO
+            labels: TODO
+
         Returns:
             The registration token.
         """
-        return self.github.get_runner_registration_token(self._path)
+        return self.github.get_runner_registration_token(self._path, instance_id, labels)
 
     def get_removal_token(self) -> str:
         """Get removal token from GitHub.

--- a/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
@@ -94,8 +94,8 @@ class GitHubRunnerManager:  # pragma: no cover
         for runner in runner_list:
             self.github.delete_runner(self._path, runner.id)
 
-    def get_registration_token(self, instance_id: str, labels: list[str]) -> str:
-        """Get registration token from GitHub.
+    def get_registration_jittoken(self, instance_id: str, labels: list[str]) -> str:
+        """Get registration JIT token from GitHub.
 
         This token is used for registering self-hosted runners.
 

--- a/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
@@ -100,13 +100,13 @@ class GitHubRunnerManager:  # pragma: no cover
         This token is used for registering self-hosted runners.
 
         Args:
-            instance_id: TODO
-            labels: TODO
+            instance_id: Instance ID of the runner.
+            labels: Labels for the runner.
 
         Returns:
             The registration token.
         """
-        return self.github.get_runner_registration_token(self._path, instance_id, labels)
+        return self.github.get_runner_registration_jittoken(self._path, instance_id, labels)
 
     def get_removal_token(self) -> str:
         """Get removal token from GitHub.

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -125,7 +125,7 @@ class RunnerManager:
         # This is quite ugly. labels should not be hidden inside OpenStack configuration.
         # It will be refactor in the multiple image/flavor PRs.
 
-        labels = self._cloud._config.runner_config.labels  # pylint: disable=protected-access
+        labels = self._labels
         # TODO THIS LABELS ARE INVALID, THERE IS NO self-hosted NOR linux!! ADD THEM MANUALLY
         labels += ["self-hosted", "linux"]
         create_runner_args = [

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -121,7 +121,10 @@ class RunnerManager:
 
         # This is quite ugly. labels should not be hidden inside OpenStack configuration.
         # It will be refactor in the multiple image/flavor PRs.
+
         labels = self._cloud._config.runner_config.labels  # pylint: disable=protected-access
+        # TODO THIS LABELS ARE INVALID, THERE IS NO self-hosted NOR linux!! ADD THEM MANUALLY
+        labels += ["self-hosted", "linux"]
         create_runner_args = [
             RunnerManager._CreateRunnerArgs(self._cloud, self._github, labels) for _ in range(num)
         ]

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -130,10 +130,9 @@ class RunnerManager:
             List of instance ID of the runners.
         """
         logger.info("Creating %s runners", num)
-        registration_token = self._github.get_registration_token()
 
         create_runner_args = [
-            RunnerManager._CreateRunnerArgs(self._cloud, registration_token) for _ in range(num)
+            RunnerManager._CreateRunnerArgs(self._cloud, self._github) for _ in range(num)
         ]
         return RunnerManager._spawn_runners(create_runner_args)
 
@@ -381,13 +380,16 @@ class RunnerManager:
     class _CreateRunnerArgs:
         """Arguments for the _create_runner function.
 
+        This is dangerous, we are using managers created in the main process in forked process,
+        at some point this could bite us.
+
         Attrs:
             cloud_runner_manager: For managing the cloud instance of the runner.
-            registration_token: The GitHub provided-token for registering runners.
+            github_runner_manager: TODO
         """
 
         cloud_runner_manager: CloudRunnerManager
-        registration_token: str
+        github_runner_manager: GitHubRunnerManager
 
     @staticmethod
     def _create_runner(args: _CreateRunnerArgs) -> InstanceId:
@@ -401,4 +403,5 @@ class RunnerManager:
         Returns:
             The instance ID of the runner created.
         """
-        return args.cloud_runner_manager.create_runner(registration_token=args.registration_token)
+        registration_token = args.github_runner_manager.get_registration_token()
+        return args.cloud_runner_manager.create_runner(registration_token=registration_token)

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -401,10 +401,10 @@ class RunnerManager:
             The instance ID of the runner created.
         """
         instance_id = args.cloud_runner_manager.generate_instance_id()
-        registration_token = args.github_runner_manager.get_registration_token(
+        registration_jittoken = args.github_runner_manager.get_registration_jittoken(
             instance_id, args.labels
         )
         args.cloud_runner_manager.create_runner(
-            instance_id=instance_id, registration_token=registration_token
+            instance_id=instance_id, registration_jittoken=registration_jittoken
         )
         return instance_id

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -123,7 +123,7 @@ class RunnerManager:
         """
         logger.info("Creating %s runners", num)
 
-        labels = self._labels
+        labels = list(self._labels)
         # This labels are added by default by the github agent, but with JIT tokens
         # we have to add them manually.
         labels += constants.GITHUB_DEFAULT_LABELS

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -376,7 +376,7 @@ class RunnerManager:
     class _CreateRunnerArgs:
         """Arguments for the _create_runner function.
 
-        This arguments are used in the forked processes and should be reviewed.
+        These arguments are used in the forked processes and should be reviewed.
 
         Attrs:
             cloud_runner_manager: For managing the cloud instance of the runner.

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -92,6 +92,7 @@ class RunnerManager:
         manager_name: str,
         github_configuration: GitHubConfiguration,
         cloud_runner_manager: CloudRunnerManager,
+        labels: list[str],
     ):
         """Construct the object.
 
@@ -99,6 +100,7 @@ class RunnerManager:
             manager_name: Name of the manager.
             github_configuration: Configuration for GitHub.
             cloud_runner_manager: For managing the cloud instance of the runner.
+            labels: Labels for the runners created.
         """
         self.manager_name = manager_name
         self._cloud = cloud_runner_manager
@@ -107,6 +109,7 @@ class RunnerManager:
             prefix=self.name_prefix,
             github_configuration=github_configuration,
         )
+        self._labels = labels
 
     def create_runners(self, num: int) -> tuple[InstanceId, ...]:
         """Create runners.

--- a/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
@@ -19,7 +19,6 @@ from github_runner_manager.errors import (
     ReconcileError,
 )
 from github_runner_manager.manager.cloud_runner_manager import (
-    GitHubRunnerConfig,
     HealthState,
 )
 from github_runner_manager.manager.github_runner_manager import GitHubRunnerState
@@ -132,14 +131,10 @@ class RunnerScaler:
             )
             base_quantity = combination.base_virtual_machines
 
-        runner_config = GitHubRunnerConfig(
-            github_path=application_configuration.github_config.path, labels=labels
-        )
         openstack_runner_manager_config = OpenStackRunnerManagerConfig(
             prefix=openstack_configuration.vm_prefix,
             credentials=openstack_configuration.credentials,
             server_config=server_config,
-            runner_config=runner_config,
             service_config=application_configuration.service_config,
         )
         runner_manager = RunnerManager(
@@ -148,6 +143,7 @@ class RunnerScaler:
             cloud_runner_manager=OpenStackRunnerManager(
                 config=openstack_runner_manager_config,
             ),
+            labels=labels,
         )
 
         max_quantity = 0
@@ -163,6 +159,7 @@ class RunnerScaler:
                 cloud_runner_manager=openstack_runner_manager_config,
                 github_token=application_configuration.github_config.token,
                 supported_labels=supported_labels,
+                labels=labels,
             )
             max_quantity = reactive_config.max_total_virtual_machines
         return cls(

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -78,7 +78,7 @@ class OpenstackInstance:
             for address in network_addresses
         ]
         self.created_at = datetime.strptime(server.created_at, "%Y-%m-%dT%H:%M:%SZ")
-        self.instance_id = server.name[len(prefix) + 1 :]
+        self.instance_id = server.name
         self.server_id = server.id
         self.server_name = server.name
         self.status = server.status
@@ -155,8 +155,7 @@ class OpenstackCloud:
     """Client to interact with OpenStack cloud.
 
     The OpenStack server name is managed by this cloud. Caller refers to the instances via
-    instance_id. If the caller needs the server name, e.g., for logging, it can be queried with
-    get_server_name.
+    instance_id. It is the same as the server name.
     """
 
     def __init__(self, credentials: OpenStackCredentials, prefix: str, system_user: str):
@@ -194,16 +193,15 @@ class OpenstackCloud:
         Returns:
             The OpenStack instance created.
         """
-        full_name = self.get_server_name(instance_id)
-        logger.info("Creating openstack server with %s", full_name)
+        logger.info("Creating openstack server with %s", instance_id)
 
         with _get_openstack_connection(credentials=self._credentials) as conn:
             security_group = OpenstackCloud._ensure_security_group(conn)
-            keypair = self._setup_keypair(conn, full_name)
+            keypair = self._setup_keypair(conn, instance_id)
 
             try:
                 server = conn.create_server(
-                    name=full_name,
+                    name=instance_id,
                     image=image,
                     key_name=keypair.name,
                     flavor=flavor,
@@ -215,17 +213,17 @@ class OpenstackCloud:
                     wait=True,
                 )
             except openstack.exceptions.ResourceTimeout as err:
-                logger.exception("Timeout creating openstack server %s", full_name)
+                logger.exception("Timeout creating openstack server %s", instance_id)
                 logger.info(
                     "Attempting clean up of openstack server %s that timeout during creation",
-                    full_name,
+                    instance_id,
                 )
-                self._delete_instance(conn, full_name)
-                raise OpenStackError(f"Timeout creating openstack server {full_name}") from err
+                self._delete_instance(conn, instance_id)
+                raise OpenStackError(f"Timeout creating openstack server {instance_id}") from err
             except openstack.exceptions.SDKException as err:
-                logger.exception("Failed to create openstack server %s", full_name)
+                logger.exception("Failed to create openstack server %s", instance_id)
                 self._delete_keypair(conn, instance_id)
-                raise OpenStackError(f"Failed to create openstack server {full_name}") from err
+                raise OpenStackError(f"Failed to create openstack server {instance_id}") from err
 
             return OpenstackInstance(server, self.prefix)
 
@@ -239,11 +237,10 @@ class OpenstackCloud:
         Returns:
             The OpenStack instance if found.
         """
-        full_name = self.get_server_name(instance_id)
-        logger.info("Getting openstack server with %s", full_name)
+        logger.info("Getting openstack server with %s", instance_id)
 
         with _get_openstack_connection(credentials=self._credentials) as conn:
-            server = OpenstackCloud._get_and_ensure_unique_server(conn, full_name)
+            server = OpenstackCloud._get_and_ensure_unique_server(conn, instance_id)
             if server is not None:
                 return OpenstackInstance(server, self.prefix)
         return None
@@ -255,13 +252,12 @@ class OpenstackCloud:
         Args:
             instance_id: The instance ID of the instance to delete.
         """
-        full_name = self.get_server_name(instance_id)
-        logger.info("Deleting openstack server with %s", full_name)
+        logger.info("Deleting openstack server with %s", instance_id)
 
         with _get_openstack_connection(credentials=self._credentials) as conn:
-            self._delete_instance(conn, full_name)
+            self._delete_instance(conn, instance_id)
 
-    def _delete_instance(self, conn: OpenstackConnection, full_name: str) -> None:
+    def _delete_instance(self, conn: OpenstackConnection, instance_id: str) -> None:
         """Delete a openstack instance.
 
         Raises:
@@ -269,18 +265,18 @@ class OpenstackCloud:
 
         Args:
             conn: The openstack connection to use.
-            full_name: The full name of the server.
+            instance_id: The full name of the server.
         """
         try:
-            server = OpenstackCloud._get_and_ensure_unique_server(conn, full_name)
+            server = OpenstackCloud._get_and_ensure_unique_server(conn, instance_id)
             if server is not None:
                 conn.delete_server(name_or_id=server.id)
-            self._delete_keypair(conn, full_name)
+            self._delete_keypair(conn, instance_id)
         except (
             openstack.exceptions.SDKException,
             openstack.exceptions.ResourceTimeout,
         ) as err:
-            raise OpenStackError(f"Failed to remove openstack runner {full_name}") from err
+            raise OpenStackError(f"Failed to remove openstack runner {instance_id}") from err
 
     @_catch_openstack_errors
     def get_ssh_connection(self, instance: OpenstackInstance) -> SSHConnection:
@@ -366,18 +362,6 @@ class OpenstackCloud:
             exclude_list = [server.name for server in instances]
             self._cleanup_key_files(exclude_list)
             self._cleanup_openstack_keypairs(conn, exclude_list)
-
-    @_catch_openstack_errors
-    def get_server_name(self, instance_id: str) -> str:
-        """Get server name on OpenStack.
-
-        Args:
-            instance_id: ID used to identify a instance.
-
-        Returns:
-            The OpenStack server name.
-        """
-        return f"{self.prefix}-{instance_id}"
 
     def _cleanup_key_files(self, exclude_instances: Iterable[str]) -> None:
         """Delete all SSH key files except the specified instances.

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -170,7 +170,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
         return self._config.prefix
 
     def generate_instance_id(self) -> InstanceId:
-        r"""TODO.
+        r"""Generate an intance_id to name a runner.
 
         The GitHub runner name convention is as following:
         A valid runner name is 64 characters or less in length and does not include '"', '/', ':',
@@ -189,7 +189,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
         """Create a self-hosted runner.
 
         Args:
-            instance_id: TODO
+            instance_id: Instance ID for the runner to create.
             registration_token: The GitHub registration token for registering runners.
 
         Raises:

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -185,12 +185,12 @@ class OpenStackRunnerManager(CloudRunnerManager):
         """
         return f"{self.name_prefix}-{secrets.token_hex(6)}"
 
-    def create_runner(self, instance_id: InstanceId, registration_token: str) -> None:
+    def create_runner(self, instance_id: InstanceId, registration_jittoken: str) -> None:
         """Create a self-hosted runner.
 
         Args:
             instance_id: Instance ID for the runner to create.
-            registration_token: The GitHub registration token for registering runners.
+            registration_jittoken: The JIT GitHub registration token for registering runners.
 
         Raises:
             MissingServerConfigError: Unable to create runner due to missing configuration.
@@ -205,7 +205,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
         start_timestamp = time.time()
         self._init_metrics_storage(name=instance_id, install_start_timestamp=start_timestamp)
 
-        cloud_init = self._generate_cloud_init(registration_token=registration_token)
+        cloud_init = self._generate_cloud_init(registration_jittoken=registration_jittoken)
         try:
             instance = self._openstack_cloud.launch_instance(
                 instance_id=instance_id,
@@ -457,13 +457,13 @@ class OpenStackRunnerManager(CloudRunnerManager):
             healthy=tuple(healthy), unhealthy=tuple(unhealthy), unknown=tuple(unknown)
         )
 
-    def _generate_cloud_init(self, registration_token: str) -> str:
+    def _generate_cloud_init(self, registration_jittoken: str) -> str:
         """Generate cloud init userdata.
 
         This is the script the openstack server runs on startup.
 
         Args:
-            registration_token: The GitHub runner registration token.
+            registration_jittoken: The JIT GitHub runner registration token.
 
         Returns:
             The cloud init userdata for openstack instance.
@@ -506,7 +506,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
             else None
         )
         return jinja.get_template("openstack-userdata.sh.j2").render(
-            token=registration_token,
+            jittoken=registration_jittoken,
             env_contents=env_contents,
             pre_job_contents=pre_job_contents,
             metrics_exchange_path=str(METRICS_EXCHANGE_PATH),

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -173,10 +173,27 @@ class OpenStackRunnerManager(CloudRunnerManager):
         """
         return self._config.prefix
 
-    def create_runner(self, registration_token: str) -> InstanceId:
+    def generate_instance_id(self) -> InstanceId:
+        r"""TODO.
+
+        The GitHub runner name convention is as following:
+        A valid runner name is 64 characters or less in length and does not include '"', '/', ':',
+        '<', '>', '\', '|', '*' and '?'.
+
+        The collision rate calculation:
+        alphanumeric 12 chars long (26 alphabet + 10 digits = 36)
+        36^12 is big enough for our use-case.
+
+        Returns:
+            Instance ID of the runner.
+        """
+        return f"{self.name_prefix}-{secrets.token_hex(6)}"
+
+    def create_runner(self, instance_id: InstanceId, registration_token: str) -> None:
         """Create a self-hosted runner.
 
         Args:
+            instance_id: TODO
             registration_token: The GitHub registration token for registering runners.
 
         Raises:
@@ -190,12 +207,10 @@ class OpenStackRunnerManager(CloudRunnerManager):
             raise MissingServerConfigError("Missing server configuration to create runners")
 
         start_timestamp = time.time()
-        instance_id = OpenStackRunnerManager._generate_instance_id()
-        instance_name = self._openstack_cloud.get_server_name(instance_id=instance_id)
-        self._init_metrics_storage(name=instance_name, install_start_timestamp=start_timestamp)
+        self._init_metrics_storage(name=instance_id, install_start_timestamp=start_timestamp)
 
         cloud_init = self._generate_cloud_init(
-            instance_name=instance_name, registration_token=registration_token
+            instance_id=instance_id, registration_token=registration_token
         )
         try:
             instance = self._openstack_cloud.launch_instance(
@@ -206,7 +221,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
                 cloud_init=cloud_init,
             )
         except OpenStackError as err:
-            raise RunnerCreateError(f"Failed to create {instance_name} openstack runner") from err
+            raise RunnerCreateError(f"Failed to create {instance_id} openstack runner") from err
 
         logger.debug("Waiting for runner process to startup: %s", instance.server_name)
         self._wait_runner_startup(instance)
@@ -215,40 +230,6 @@ class OpenStackRunnerManager(CloudRunnerManager):
 
         logger.info("Runner %s created successfully", instance.server_name)
         return instance_id
-
-    def get_runner(self, instance_id: InstanceId) -> CloudRunnerInstance | None:
-        """Get a self-hosted runner by instance id.
-
-        Args:
-            instance_id: The instance id.
-
-        Returns:
-            Information on the runner instance.
-        """
-        logger.debug("Getting runner info %s", instance_id)
-        instance = self._openstack_cloud.get_instance(instance_id)
-        logger.debug(
-            "Runner info fetched, checking health %s %s", instance_id, instance.server_name
-        )
-
-        try:
-            healthy = health_checks.check_runner(
-                openstack_cloud=self._openstack_cloud, instance=instance
-            )
-            logger.debug("Runner health check completed %s %s", instance.server_name, healthy)
-        except OpenstackHealthCheckError:
-            logger.exception(HEALTH_CHECK_ERROR_LOG_MSG, instance.server_name)
-            healthy = None
-        return (
-            CloudRunnerInstance(
-                name=instance.server_name,
-                instance_id=instance_id,
-                health=HealthState.from_value(healthy),
-                state=CloudRunnerState.from_openstack_server_status(instance.status),
-            )
-            if instance is not None
-            else None
-        )
 
     def get_runners(
         self, states: Sequence[CloudRunnerState] | None = None
@@ -303,7 +284,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
         if instance is None:
             logger.warning(
                 "Unable to delete instance %s as it is not found",
-                self._openstack_cloud.get_server_name(instance_id),
+                instance_id,
             )
             return None
 
@@ -482,13 +463,13 @@ class OpenStackRunnerManager(CloudRunnerManager):
             healthy=tuple(healthy), unhealthy=tuple(unhealthy), unknown=tuple(unknown)
         )
 
-    def _generate_cloud_init(self, instance_name: str, registration_token: str) -> str:
+    def _generate_cloud_init(self, instance_id: str, registration_token: str) -> str:
         """Generate cloud init userdata.
 
         This is the script the openstack server runs on startup.
 
         Args:
-            instance_name: The name of the instance.
+            instance_id: The name of the instance.
             registration_token: The GitHub runner registration token.
 
         Returns:
@@ -540,7 +521,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
             runner_group=runner_group,
             token=registration_token,
             instance_labels=",".join(runner_config.labels),
-            instance_name=instance_name,
+            instance_id=instance_id,
             env_contents=env_contents,
             pre_job_contents=pre_job_contents,
             metrics_exchange_path=str(METRICS_EXCHANGE_PATH),
@@ -696,23 +677,6 @@ class OpenStackRunnerManager(CloudRunnerManager):
 
         logger.info("Runner %s found to be healthy", instance.server_name)
 
-    @staticmethod
-    def _generate_instance_id() -> InstanceId:
-        r"""Generate an instance id suffix compliant to the GitHub runner naming convention.
-
-        The GitHub runner name convention is as following:
-        A valid runner name is 64 characters or less in length and does not include '"', '/', ':',
-        '<', '>', '\', '|', '*' and '?'.
-
-        The collision rate calculation:
-        alphanumeric 12 chars long (26 alphabet + 10 digits = 36)
-        36^12 is big enough for our use-case.
-
-        Return:
-            The id.
-        """
-        return secrets.token_hex(6)
-
     def _init_metrics_storage(self, name: str, install_start_timestamp: float) -> None:
         """Create metrics storage for runner.
 
@@ -848,12 +812,12 @@ class OpenStackRunnerManager(CloudRunnerManager):
 
     @staticmethod
     def _run_runner_removal_script(
-        instance_name: str, ssh_conn: SSHConnection, remove_token: str
+        instance_id: str, ssh_conn: SSHConnection, remove_token: str
     ) -> None:
         """Run Github runner removal script.
 
         Args:
-            instance_name: The name of the runner instance.
+            instance_id: The name of the runner instance.
             ssh_conn: The SSH connection to the runner instance.
             remove_token: The GitHub instance removal token.
 
@@ -872,17 +836,17 @@ class OpenStackRunnerManager(CloudRunnerManager):
                     "Unable to run removal script on instance %s, "
                     "exit code: %s, stdout: %s, stderr: %s"
                 ),
-                instance_name,
+                instance_id,
                 result.return_code,
                 result.stdout,
                 result.stderr,
             )
-            raise _GithubRunnerRemoveError(f"Failed to remove runner {instance_name} from Github.")
+            raise _GithubRunnerRemoveError(f"Failed to remove runner {instance_id} from Github.")
         except (
             TimeoutError,
             paramiko.ssh_exception.NoValidConnectionsError,
             paramiko.ssh_exception.SSHException,
         ) as exc:
             raise _GithubRunnerRemoveError(
-                f"Failed to remove runner {instance_name} from Github."
+                f"Failed to remove runner {instance_id} from Github."
             ) from exc

--- a/github-runner-manager/src/github_runner_manager/reactive/runner.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/runner.py
@@ -48,6 +48,7 @@ def main() -> None:
         manager_name=runner_config.manager_name,
         github_configuration=runner_config.github_configuration,
         cloud_runner_manager=openstack_runner_manager,
+        labels=runner_config.labels,
     )
     github_client = GithubClient(token=runner_config.github_token)
     consume(

--- a/github-runner-manager/src/github_runner_manager/reactive/types_.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/types_.py
@@ -22,6 +22,7 @@ class ReactiveProcessConfig(BaseModel):
         cloud_runner_manager: The OpenStack runner manager configuration.
         github_token: str
         supported_labels: The supported labels for the runner.
+        labels: Labels to use for the runners.
     """
 
     queue: QueueConfig
@@ -30,3 +31,4 @@ class ReactiveProcessConfig(BaseModel):
     cloud_runner_manager: OpenStackRunnerManagerConfig
     github_token: str
     supported_labels: set[str]
+    labels: list[str]

--- a/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
@@ -59,12 +59,12 @@ su - ubuntu -c "cd ~/actions-runner && ./config.sh \
     --url {{ github_url }} \
     --runnergroup '{{ runner_group }}' \
     --token {{ token }} --ephemeral --unattended \
-    --labels {{ instance_labels }} --name {{ instance_name }}"
+    --labels {{ instance_labels }} --name {{ instance_id }}"
 {% else %}
 su - ubuntu -c "cd ~/actions-runner && ./config.sh \
     --url {{ github_url }} \
     --token {{ token }} --ephemeral --unattended \
-    --labels {{ instance_labels }} --name {{ instance_name }}"
+    --labels {{ instance_labels }} --name {{ instance_id }}"
 {% endif %}
 
 

--- a/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
@@ -53,20 +53,6 @@ cat << 'EOF' | su - ubuntu -c 'tee /home/ubuntu/actions-runner/pre-job.sh'
 {{ pre_job_contents | safe }}
 EOF
 
-# Create the runner and start the configuration experience
-{% if runner_group %}
-su - ubuntu -c "cd ~/actions-runner && ./config.sh \
-    --url {{ github_url }} \
-    --runnergroup '{{ runner_group }}' \
-    --token {{ token }} --ephemeral --unattended \
-    --labels {{ instance_labels }} --name {{ instance_id }}"
-{% else %}
-su - ubuntu -c "cd ~/actions-runner && ./config.sh \
-    --url {{ github_url }} \
-    --token {{ token }} --ephemeral --unattended \
-    --labels {{ instance_labels }} --name {{ instance_id }}"
-{% endif %}
-
 
 write_post_metrics(){
     # Expects the exit code of the run.sh script as the first argument.
@@ -107,6 +93,6 @@ date +%s >  {{ metrics_exchange_path}}/runner-installed.timestamp
 
 # Run runner
 # We want to capture the exit code of the run.sh script and write the post-job metrics.
-(set +e; su - ubuntu -c "cd ~/actions-runner && /home/ubuntu/actions-runner/run.sh"; write_post_metrics $?)
+(set +e; su - ubuntu -c "cd ~/actions-runner && /home/ubuntu/actions-runner/run.sh --jitconfig {{ token }}"; write_post_metrics $?)
 
 su - ubuntu -c "touch /home/ubuntu/run-completed"

--- a/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
@@ -93,6 +93,6 @@ date +%s >  {{ metrics_exchange_path}}/runner-installed.timestamp
 
 # Run runner
 # We want to capture the exit code of the run.sh script and write the post-job metrics.
-(set +e; su - ubuntu -c "cd ~/actions-runner && /home/ubuntu/actions-runner/run.sh --jitconfig {{ token }}"; write_post_metrics $?)
+(set +e; su - ubuntu -c "cd ~/actions-runner && /home/ubuntu/actions-runner/run.sh --jitconfig {{ jittoken }}"; write_post_metrics $?)
 
 su - ubuntu -c "touch /home/ubuntu/run-completed"

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -303,7 +303,7 @@ class MockCloudRunnerManager(CloudRunnerManager):
         return self.prefix
 
     def generate_instance_id(self) -> InstanceId:
-        """TODO.
+        """Generate an intance_id to name a runner.
 
         Returns:
             Instance ID of the runner.
@@ -314,7 +314,7 @@ class MockCloudRunnerManager(CloudRunnerManager):
         """Create a self-hosted runner.
 
         Args:
-            instance_id: TODO
+            instance_id: Instance ID for the runner to create.
             registration_token: The GitHub registration token for registering runners.
         """
         name = f"{self.name_prefix}-{instance_id}"
@@ -422,8 +422,8 @@ class MockGitHubRunnerManager:
         """Get the registration token for registering runners on GitHub.
 
         Args:
-            instance_id: TODO
-            labels: TODO
+            instance_id: Instance ID of the runner.
+            labels: Labels for the runner.
 
         Returns:
             The registration token.

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -296,7 +296,6 @@ class MockCloudRunnerManager(CloudRunnerManager):
         self.prefix = f"mock_{secrets.token_hex(4)}"
         self.state = state
         self._config = MagicMock()
-        self._config.runner_config.labels = ["label1", "label2"]
 
     @property
     def name_prefix(self) -> str:

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -295,7 +295,6 @@ class MockCloudRunnerManager(CloudRunnerManager):
         """
         self.prefix = f"mock_{secrets.token_hex(4)}"
         self.state = state
-        self._config = MagicMock()
 
     @property
     def name_prefix(self) -> str:

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -295,39 +295,32 @@ class MockCloudRunnerManager(CloudRunnerManager):
         """
         self.prefix = f"mock_{secrets.token_hex(4)}"
         self.state = state
+        self._config = MagicMock()
+        self._config.runner_config.labels = ["label1", "label2"]
 
     @property
     def name_prefix(self) -> str:
         """Get the name prefix of the self-hosted runners."""
         return self.prefix
 
-    def create_runner(self, registration_token: str) -> InstanceId:
+    def generate_instance_id(self) -> InstanceId:
+        """TODO.
+
+        Returns:
+            Instance ID of the runner.
+        """
+        return secrets.token_hex(6)
+
+    def create_runner(self, instance_id: InstanceId, registration_token: str) -> None:
         """Create a self-hosted runner.
 
         Args:
+            instance_id: TODO
             registration_token: The GitHub registration token for registering runners.
-
-        Returns:
-            The instance id of the runner created.
         """
-        name = f"{self.name_prefix}-{secrets.token_hex(6)}"
+        name = f"{self.name_prefix}-{instance_id}"
         runner = MockRunner(name)
-        self.state.runners[runner.instance_id] = runner
-        return runner.instance_id
-
-    def get_runner(self, instance_id: InstanceId) -> CloudRunnerInstance | None:
-        """Get a self-hosted runner by instance id.
-
-        Args:
-            instance_id: The instance id.
-
-        Returns:
-            The runner instance if found else None.
-        """
-        runner = self.state.runners.get(instance_id, None)
-        if runner is not None:
-            return runner.to_cloud_runner()
-        return None
+        self.state.runners[instance_id] = runner
 
     def get_runners(
         self, states: Sequence[CloudRunnerState] | None = None
@@ -426,8 +419,12 @@ class MockGitHubRunnerManager:
         self.state = state
         self.path = path
 
-    def get_registration_token(self) -> str:
+    def get_registration_token(self, instance_id: str, labels: list[str]) -> str:
         """Get the registration token for registering runners on GitHub.
+
+        Args:
+            instance_id: TODO
+            labels: TODO
 
         Returns:
             The registration token.

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -309,12 +309,12 @@ class MockCloudRunnerManager(CloudRunnerManager):
         """
         return secrets.token_hex(6)
 
-    def create_runner(self, instance_id: InstanceId, registration_token: str) -> None:
+    def create_runner(self, instance_id: InstanceId, registration_jittoken: str) -> None:
         """Create a self-hosted runner.
 
         Args:
             instance_id: Instance ID for the runner to create.
-            registration_token: The GitHub registration token for registering runners.
+            registration_jittoken: The GitHub registration token for registering runners.
         """
         name = f"{self.name_prefix}-{instance_id}"
         runner = MockRunner(name)
@@ -417,8 +417,8 @@ class MockGitHubRunnerManager:
         self.state = state
         self.path = path
 
-    def get_registration_token(self, instance_id: str, labels: list[str]) -> str:
-        """Get the registration token for registering runners on GitHub.
+    def get_registration_jittoken(self, instance_id: str, labels: list[str]) -> str:
+        """Get the registration JIT token for registering runners on GitHub.
 
         Args:
             instance_id: Instance ID of the runner.

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_cloud.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_cloud.py
@@ -58,6 +58,6 @@ def test_raises_openstack_error(
             "github_runner_manager.openstack_cloud.openstack_cloud.openstack.connect",
             openstack_connect_mock,
         )
-        with pytest.raises(OpenStackError) as exc:
+        with pytest.raises(OpenStackError) as innerexc:
             getattr(cloud, public_method)(*args)
-        assert "Failed OpenStack API call" in str(exc.value)
+        assert "Failed OpenStack API call" in str(innerexc.value)

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
@@ -209,7 +209,7 @@ def test_cleanup_ignores_runners_with_health_check_errors(
 
     assert openstack_cloud_mock.delete_instance.call_count == unhealthy_count
     for name in names:
-        instance_id = name[len(OPENSTACK_INSTANCE_PREFIX) + 1 :]
+        instance_id = name
         if instance_id.startswith("unhealthy"):
             openstack_cloud_mock.delete_instance.assert_any_call(instance_id)
     assert runner_metrics_mock.extract.call_count == 1

--- a/github-runner-manager/tests/unit/test_github_client.py
+++ b/github-runner-manager/tests/unit/test_github_client.py
@@ -384,7 +384,10 @@ def test_get_registration_jittoken_org(
                 """Mocked raise_for_status."""
                 pass
 
-        assert url == f"https://api.github.com/orgs/{github_repo.org}/actions/runner-groups"
+        assert (
+            url
+            == f"https://api.github.com/orgs/{github_repo.org}/actions/runner-groups?per_page=100"
+        )
         assert headers["Authorization"] == "Bearer token"
         return _Response()
 

--- a/github-runner-manager/tests/unit/test_github_client.py
+++ b/github-runner-manager/tests/unit/test_github_client.py
@@ -10,8 +10,9 @@ from unittest.mock import MagicMock
 from urllib.error import HTTPError
 
 import pytest
+import requests
 
-from github_runner_manager.configuration.github import GitHubRepo
+from github_runner_manager.configuration.github import GitHubOrg, GitHubRepo
 from github_runner_manager.errors import GithubApiError, JobNotFoundError, TokenError
 from github_runner_manager.github_client import GithubClient
 from github_runner_manager.types_.github import JobConclusion, JobInfo, JobStatus
@@ -287,3 +288,137 @@ def test_catch_http_errors_token_issues(github_client: GithubClient):
 
     with pytest.raises(TokenError):
         github_client.get_runner_remove_token(github_repo)
+
+
+def test_get_registration_jittoken_repo(github_client: GithubClient):
+    """
+    arrange: A mocked GitHub client that replies with information about jitconfig for repo.
+    act: Call get_runner_registration_jittoken.
+    assert: The jittoken is extracted from the returned value.
+    """
+    github_repo = GitHubRepo(owner=secrets.token_hex(16), repo=secrets.token_hex(16))
+    github_client._client.actions.generate_runner_jitconfig_for_repo.return_value = {
+        "runner": {
+            "id": 113,
+            "name": "test-runner-99999999",
+            "os": "unknown",
+            "status": "offline",
+            "busy": False,
+            "labels": [
+                {"id": 0, "name": "label1", "type": "read-only"},
+                {"id": 0, "name": "label2", "type": "read-only"},
+            ],
+            "runner_group_id": 1,
+        },
+        "encoded_jit_config": "hugestringinhere",
+    }
+
+    instance_id = "test-runner-99999999"
+    labels = ["label1", "label2"]
+    jittoken = github_client.get_runner_registration_jittoken(
+        path=github_repo, instance_id=instance_id, labels=labels
+    )
+
+    assert jittoken == "hugestringinhere"
+
+
+def test_get_registration_jittoken_org(
+    github_client: GithubClient, monkeypatch: pytest.MonkeyPatch
+):
+    """
+    arrange: A mocked GitHub client that replies with information about jitconfig for org.
+       The requests library is patched to return information about github runner groups.
+    act: Call get_runner_registration_jittoken for the org.
+    assert: The API for the jittoken is called with the correct arguments, like the runner_group_id
+       and the jittoken is extracted from the returned value.
+    """
+    github_repo = GitHubOrg(org="theorg", group="my group name")
+
+    def _mock_get(url, headers, *args, **kwargs):
+        """Mock for requests.get."""
+
+        class _Response:
+            """Mocked Response for requests.get."""
+
+            @staticmethod
+            def json():
+                """Json response for requests.get mock.
+
+                Returns:
+                   The JSON response from the API.
+                """
+                return {
+                    "total_count": 2,
+                    "runner_groups": [
+                        {
+                            "id": 1,
+                            "name": "Default",
+                            "visibility": "all",
+                            "allows_public_repositories": True,
+                            "default": True,
+                            "workflow_restrictions_read_only": False,
+                            "restricted_to_workflows": False,
+                            "selected_workflows": [],
+                            "runners_url": "https://api.github.com/orgs/theorg/....",
+                            "hosted_runners_url": "https://api.github.com/orgs/theorg/....",
+                            "inherited": False,
+                        },
+                        {
+                            "id": 3,
+                            "name": "my group name",
+                            "visibility": "all",
+                            "allows_public_repositories": True,
+                            "default": False,
+                            "workflow_restrictions_read_only": False,
+                            "restricted_to_workflows": False,
+                            "selected_workflows": [],
+                            "runners_url": "https://api.github.com/orgs/theorg/....",
+                            "hosted_runners_url": "https://api.github.com/orgs/theorg/....",
+                            "inherited": False,
+                        },
+                    ],
+                }
+
+            def raise_for_status(self):
+                """Mocked raise_for_status."""
+                pass
+
+        assert url == f"https://api.github.com/orgs/{github_repo.org}/actions/runner-groups"
+        assert headers["Authorization"] == "Bearer token"
+        return _Response()
+
+    monkeypatch.setattr(requests, "get", _mock_get)
+
+    def _mock_generate_runner_jitconfig_for_org(org, name, runner_group_id, labels):
+        """Mocked generate_runner_jitconfig_for_org."""
+        assert org == "theorg"
+        assert runner_group_id == 3
+        assert labels == ["label1", "label2"]
+        return {
+            "runner": {
+                "id": 18,
+                "name": "test-runner-3438",
+                "os": "unknown",
+                "status": "offline",
+                "busy": False,
+                "labels": [
+                    {"id": 0, "name": "self-hosted", "type": "read-only"},
+                    {"id": 0, "name": "X64", "type": "read-only"},
+                    {"id": 0, "name": "no-gpu", "type": "read-only"},
+                ],
+                "runner_group_id": 3,
+            },
+            "encoded_jit_config": "anotherhugetoken",
+        }
+
+    github_client._client.actions.generate_runner_jitconfig_for_org.side_effect = (
+        _mock_generate_runner_jitconfig_for_org
+    )
+
+    instance_id = "test-runner-99999999"
+    labels = ["label1", "label2"]
+    jittoken = github_client.get_runner_registration_jittoken(
+        path=github_repo, instance_id=instance_id, labels=labels
+    )
+
+    assert jittoken == "anotherhugetoken"

--- a/github-runner-manager/tests/unit/test_github_client.py
+++ b/github-runner-manager/tests/unit/test_github_client.py
@@ -332,6 +332,7 @@ def test_get_registration_jittoken_org(
     assert: The API for the jittoken is called with the correct arguments, like the runner_group_id
        and the jittoken is extracted from the returned value.
     """
+    # The code that this test executes is not covered by integration tests.
     github_repo = GitHubOrg(org="theorg", group="my group name")
 
     def _mock_get(url, headers, *args, **kwargs):
@@ -392,6 +393,7 @@ def test_get_registration_jittoken_org(
     def _mock_generate_runner_jitconfig_for_org(org, name, runner_group_id, labels):
         """Mocked generate_runner_jitconfig_for_org."""
         assert org == "theorg"
+        assert name == "test-runner-99999999"
         assert runner_group_id == 3
         assert labels == ["label1", "label2"]
         return {

--- a/github-runner-manager/tests/unit/test_runner_scaler.py
+++ b/github-runner-manager/tests/unit/test_runner_scaler.py
@@ -33,7 +33,6 @@ from github_runner_manager.configuration.github import (
 from github_runner_manager.errors import CloudError, ReconcileError
 from github_runner_manager.manager.cloud_runner_manager import (
     CloudRunnerState,
-    GitHubRunnerConfig,
     InstanceId,
 )
 from github_runner_manager.manager.github_runner_manager import GitHubRunnerState
@@ -119,7 +118,10 @@ def runner_manager_fixture(
     )
 
     runner_manager = RunnerManager(
-        "mock_runners", GitHubConfiguration(token="mock_token", path=github_path), mock_cloud
+        "mock_runners",
+        GitHubConfiguration(token="mock_token", path=github_path),
+        mock_cloud,
+        labels=["label1", "label2", "arm64", "noble", "flavorlabel"],
     )
     runner_manager._github = mock_github
     return runner_manager
@@ -281,6 +283,7 @@ def test_build_runner_scaler(
     assert runner_scaler._manager.manager_name == "app_name"
     assert runner_scaler._manager._github._path == GitHubOrg(org="canonical", group="group")
     assert runner_scaler._manager._github.github._token == "githubtoken"
+    assert runner_scaler._manager._labels == ["label1", "label2", "arm64", "noble", "flavorlabel"]
     assert runner_scaler._manager._cloud._config == OpenStackRunnerManagerConfig(
         prefix="unit_name",
         credentials=OpenStackCredentials(
@@ -293,10 +296,6 @@ def test_build_runner_scaler(
             region_name="region",
         ),
         server_config=OpenStackServerConfig(image="image_id", flavor="flavor", network="network"),
-        runner_config=GitHubRunnerConfig(
-            github_path=GitHubOrg(org="canonical", group="group"),
-            labels=["label1", "label2", "arm64", "noble", "flavorlabel"],
-        ),
         service_config=SupportServiceConfig(
             proxy_config=ProxyConfig(
                 http="http://httpproxy.example.com:3128",
@@ -344,10 +343,6 @@ def test_build_runner_scaler(
             server_config=OpenStackServerConfig(
                 image="image_id", flavor="flavor", network="network"
             ),
-            runner_config=GitHubRunnerConfig(
-                github_path=GitHubOrg(org="canonical", group="group"),
-                labels=["label1", "label2", "arm64", "noble", "flavorlabel"],
-            ),
             service_config=SupportServiceConfig(
                 proxy_config=ProxyConfig(
                     http="http://httpproxy.example.com:3128",
@@ -372,6 +367,7 @@ def test_build_runner_scaler(
         ),
         github_token="githubtoken",
         supported_labels={"label1", "arm64", "flavorlabel", "label2", "x64", "noble"},
+        labels=["label1", "label2", "arm64", "noble", "flavorlabel"],
     )
 
 

--- a/tests/integration/test_reactive.py
+++ b/tests/integration/test_reactive.py
@@ -2,6 +2,7 @@
 #  See LICENSE file for licensing details.
 
 """Testing reactive mode. This is only supported for the OpenStack cloud."""
+import asyncio
 import json
 import re
 from typing import AsyncIterator
@@ -199,6 +200,9 @@ async def test_reactive_mode_scale_down(
     )
 
     await wait_for_status(run, "in_progress")
+
+    # Give the runner manager some time to check the runners is ok and ack the message.
+    await asyncio.sleep(60)
 
     # 1. Scale down the number of virtual machines to 0 and call reconcile.
     await app.set_config({VIRTUAL_MACHINES_CONFIG_NAME: "0"})

--- a/tests/integration/test_runner_manager_openstack.py
+++ b/tests/integration/test_runner_manager_openstack.py
@@ -185,6 +185,7 @@ async def runner_manager_fixture(
     token: str,
     log_dir_base_path: dict[str, Path],
     github_path: GitHubPath,
+    runner_label: str,
 ) -> AsyncGenerator[RunnerManager, None]:
     """Get RunnerManager instance.
 

--- a/tests/integration/test_runner_manager_openstack.py
+++ b/tests/integration/test_runner_manager_openstack.py
@@ -27,7 +27,6 @@ from github_runner_manager.configuration.github import (
 )
 from github_runner_manager.manager.cloud_runner_manager import (
     CloudRunnerState,
-    GitHubRunnerConfig,
 )
 from github_runner_manager.manager.github_runner_manager import GitHubRunnerState
 from github_runner_manager.manager.runner_manager import (
@@ -160,10 +159,6 @@ async def openstack_runner_manager_fixture(
         flavor=flavor_name,
         network=network_name,
     )
-    runner_config = GitHubRunnerConfig(
-        github_path=github_path,
-        labels=["openstack_test", runner_label],
-    )
     service_config = SupportServiceConfig(
         proxy_config=proxy_config,
         dockerhub_mirror=None,
@@ -176,7 +171,6 @@ async def openstack_runner_manager_fixture(
         prefix=f"{app_name}-0",
         credentials=credentials,
         server_config=server_config,
-        runner_config=runner_config,
         service_config=service_config,
     )
 
@@ -201,6 +195,7 @@ async def runner_manager_fixture(
         manager_name="test_runner",
         github_configuration=github_configuration,
         cloud_runner_manager=openstack_runner_manager,
+        labels=["openstack_test", runner_label],
     )
 
 

--- a/tests/unit/mock_runner_managers.py
+++ b/tests/unit/mock_runner_managers.py
@@ -104,7 +104,6 @@ class MockCloudRunnerManager(CloudRunnerManager):
         self.state = state
         # Pending to remove and refactor from here.
         self._config = MagicMock()
-        self._config.runner_config.labels = ["label1", "label2"]
 
     @property
     def name_prefix(self) -> str:

--- a/tests/unit/mock_runner_managers.py
+++ b/tests/unit/mock_runner_managers.py
@@ -108,11 +108,11 @@ class MockCloudRunnerManager(CloudRunnerManager):
         """Get the name prefix of the self-hosted runners."""
         return self.prefix
 
-    def create_runner(self, registration_token: str) -> InstanceId:
+    def create_runner(self, registration_jittoken: str) -> InstanceId:
         """Create a self-hosted runner.
 
         Args:
-            registration_token: The GitHub registration token for registering runners.
+            registration_jittoken: The GitHub registration token for registering runners.
 
         Returns:
             The instance id of the runner created.
@@ -219,8 +219,8 @@ class MockGitHubRunnerManager:
         self.state = state
         self.path = path
 
-    def get_registration_token(self, instance_id: str, labels: list[str]) -> str:
-        """Get the registration token for registering runners on GitHub.
+    def get_registration_jittoken(self, instance_id: str, labels: list[str]) -> str:
+        """Get the registration JIT token for registering runners on GitHub.
 
         Args:
             instance_id: Instance ID of the runner.

--- a/tests/unit/mock_runner_managers.py
+++ b/tests/unit/mock_runner_managers.py
@@ -102,6 +102,9 @@ class MockCloudRunnerManager(CloudRunnerManager):
         """
         self.prefix = f"mock_{secrets.token_hex(4)}"
         self.state = state
+        # Pending to remove and refactor from here.
+        self._config = MagicMock()
+        self._config.runner_config.labels = ["label1", "label2"]
 
     @property
     def name_prefix(self) -> str:
@@ -121,20 +124,6 @@ class MockCloudRunnerManager(CloudRunnerManager):
         runner = MockRunner(name)
         self.state.runners[runner.instance_id] = runner
         return runner.instance_id
-
-    def get_runner(self, instance_id: InstanceId) -> CloudRunnerInstance | None:
-        """Get a self-hosted runner by instance id.
-
-        Args:
-            instance_id: The instance id.
-
-        Returns:
-            The runner instance if found else None.
-        """
-        runner = self.state.runners.get(instance_id, None)
-        if runner is not None:
-            return runner.to_cloud_runner()
-        return None
 
     def get_runners(
         self, states: Sequence[CloudRunnerState] | None = None
@@ -233,8 +222,12 @@ class MockGitHubRunnerManager:
         self.state = state
         self.path = path
 
-    def get_registration_token(self) -> str:
+    def get_registration_token(self, instance_id: str, labels: list[str]) -> str:
         """Get the registration token for registering runners on GitHub.
+
+        Args:
+            instance_id: TODO
+            labels: TODO
 
         Returns:
             The registration token.

--- a/tests/unit/mock_runner_managers.py
+++ b/tests/unit/mock_runner_managers.py
@@ -102,8 +102,6 @@ class MockCloudRunnerManager(CloudRunnerManager):
         """
         self.prefix = f"mock_{secrets.token_hex(4)}"
         self.state = state
-        # Pending to remove and refactor from here.
-        self._config = MagicMock()
 
     @property
     def name_prefix(self) -> str:

--- a/tests/unit/mock_runner_managers.py
+++ b/tests/unit/mock_runner_managers.py
@@ -225,8 +225,8 @@ class MockGitHubRunnerManager:
         """Get the registration token for registering runners on GitHub.
 
         Args:
-            instance_id: TODO
-            labels: TODO
+            instance_id: Instance ID of the runner.
+            labels: Labels for the runner.
 
         Returns:
             The registration token.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

This PR uses [JIT token](https://github.blog/changelog/2023-06-02-github-actions-just-in-time-self-hosted-runners/) for runner registration instead of normal registration tokens.

The main advantage of JIT tokens is that they can only be used one, so there is no risk if they are leaked.

Several changes have been done to the project, as to request a JIT token, it is necessary to send as parameters:
- The runner name.
- The labels. No labels are added by default, so "self-hosted" and "linux" have to be added manually.
- The runner_group_id (the charm currently has as a config option the group name, not the id).

As there is one JIT token per runner, a JIT token has to be requested per runner, and it is done just before creating the runner (that can be in a forked process).

To get the runner_group_id from the group name, a call has to be done to the GitHub API. This call is not currently supported by ghapi. See [issue](https://github.com/AnswerDotAI/ghapi/issues/189).

To simplify the process, the instance_id is now the same as the instance_name (all is instance_id), as the name is used for both OpenStack and GitHub.

The method `CloudRunnerInstance.get_runner` has been deleted, as it is not used not tested.


Runners with JIT for orgs have been tested with an org in here:
![image](https://github.com/user-attachments/assets/07300e64-0821-40d3-97ef-dcd3da87b791)


### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->