### PR TITLE
Add 48 to snap refresh and show in expected quantity the base_quantity

### DIFF
--- a/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
@@ -261,7 +261,7 @@ class RunnerScaler:
         metric_stats = {}
         start_timestamp = time.time()
 
-        expected_runner_quantity = self._max_quantity if self._reactive_config is None else None
+        expected_runner_quantity = self._base_quantity if self._reactive_config is None else None
 
         try:
             if self._reactive_config is not None:

--- a/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
@@ -7,7 +7,7 @@ hostnamectl set-hostname github-runner
 # Write .env contents
 su - ubuntu -c 'cd ~/actions-runner && echo "{{ env_contents }}" > .env'
 
-snap refresh --hold=24h
+snap refresh --hold=48h
 snap watch --last=auto-refresh?
 
 {% if aproxy_address %}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Update to 48 the hold for snaps and fix the expected_runner_quantity to be the base_quantity (not the max that ir reactvie related).

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->