### PR TITLE
Fix delete offline in github when building reactive

### DIFF
--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -136,7 +136,7 @@ class GithubClient:
                 )
                 for item in page["runners"]
             ]
-        return remote_runners_list
+        return [SelfHostedRunner(runner) for runner in remote_runners_list]
 
     @catch_http_errors
     def get_runner_remove_token(self, path: GitHubPath) -> str:

--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -13,8 +13,8 @@ from typing import Callable, ParamSpec, TypeVar
 from urllib.error import HTTPError
 
 import requests
-from ghapi.all import GhApi
-from ghapi.page import paged, pages
+from ghapi.all import GhApi, pages
+from ghapi.page import paged
 from typing_extensions import assert_never
 
 from github_runner_manager.configuration.github import (

--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -136,6 +136,9 @@ class GithubClient:
                 )
                 for item in page["runners"]
             ]
+        # Pydantic does not correctly parse labels, they are of type fastcore.foundation.L.
+        for runner in remote_runners_list:
+            runner["labels"] = list(runner["labels"])
         return [SelfHostedRunner.parse_obj(runner) for runner in remote_runners_list]
 
     @catch_http_errors

--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -13,8 +13,8 @@ from typing import Callable, ParamSpec, TypeVar
 from urllib.error import HTTPError
 
 import requests
-from ghapi.all import GhApi, pages
-from ghapi.page import paged
+from ghapi.all import GhApi
+from ghapi.page import paged, pages
 from typing_extensions import assert_never
 
 from github_runner_manager.configuration.github import (
@@ -136,7 +136,7 @@ class GithubClient:
                 )
                 for item in page["runners"]
             ]
-        return [SelfHostedRunner(runner) for runner in remote_runners_list]
+        return [SelfHostedRunner.parse_obj(runner) for runner in remote_runners_list]
 
     @catch_http_errors
     def get_runner_remove_token(self, path: GitHubPath) -> str:

--- a/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
@@ -94,10 +94,10 @@ class GitHubRunnerManager:  # pragma: no cover
         )
 
     def delete_runners(self, runners: list[SelfHostedRunner]) -> None:
-        """TODO.
+        """Delete runners in GitHub.
 
         Args:
-            runners: TODO
+            runners: list of runners to delete.
         """
         for runner in runners:
             self.github.delete_runner(self._path, runner.id)

--- a/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
@@ -78,7 +78,8 @@ class GitHubRunnerManager:  # pragma: no cover
             for runner in runner_list
             if InstanceID.name_has_prefix(self._prefix, runner.name)
         ]
-        # Calculate instance_id
+        # Calculate instance_id, as it is not calculated by the GithubClient as it
+        # does not have information about the prefix.
         for runner in runner_list:
             runner.calculate_instance_id(self._prefix)
 

--- a/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
@@ -72,16 +72,7 @@ class GitHubRunnerManager:  # pragma: no cover
         Returns:
             Information on the runners.
         """
-        runner_list = self.github.get_runner_github_info(self._path)
-        runner_list = [
-            runner
-            for runner in runner_list
-            if InstanceID.name_has_prefix(self._prefix, runner.name)
-        ]
-        # Calculate instance_id, as it is not calculated by the GithubClient as it
-        # does not have information about the prefix.
-        for runner in runner_list:
-            runner.calculate_instance_id(self._prefix)
+        runner_list = self.github.get_runner_github_info(self._path, self._prefix)
 
         if states is None:
             return tuple(runner_list)

--- a/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
@@ -102,16 +102,6 @@ class GitHubRunnerManager:  # pragma: no cover
         for runner in runners:
             self.github.delete_runner(self._path, runner.id)
 
-    def delete_runners_by_state(self, states: Iterable[GitHubRunnerState] | None = None) -> None:
-        """Delete the self-hosted runners of certain states.
-
-        Args:
-            states: Filter the runners for these states. If None, all runners are deleted.
-        """
-        runner_list = self.get_runners(states)
-        for runner in runner_list:
-            self.github.delete_runner(self._path, runner.id)
-
     def get_registration_jittoken(self, instance_id: InstanceID, labels: list[str]) -> str:
         """Get registration JIT token from GitHub.
 

--- a/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
@@ -78,6 +78,9 @@ class GitHubRunnerManager:  # pragma: no cover
             for runner in runner_list
             if InstanceID.name_has_prefix(self._prefix, runner.name)
         ]
+        # Calculate instance_id
+        for runner in runner_list:
+            runner.calculate_instance_id(self._prefix)
 
         if states is None:
             return tuple(runner_list)
@@ -89,7 +92,16 @@ class GitHubRunnerManager:  # pragma: no cover
             if GitHubRunnerManager._is_runner_in_state(runner, state_set)
         )
 
-    def delete_runners(self, states: Iterable[GitHubRunnerState] | None = None) -> None:
+    def delete_runners(self, runners: list[SelfHostedRunner]) -> None:
+        """TODO.
+
+        Args:
+            runners: TODO
+        """
+        for runner in runners:
+            self.github.delete_runner(self._path, runner.id)
+
+    def delete_runners_by_state(self, states: Iterable[GitHubRunnerState] | None = None) -> None:
         """Delete the self-hosted runners of certain states.
 
         Args:

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -249,8 +249,7 @@ class RunnerManager:
         # We clean ACTIVE units that are offline. This is a race condition, as it can be running
         # cloud init before starting the runner (reactive case) or runners that are restarting.
         # We do not treat this case until better information is obtained from get_runners.
-        # Currently it returns UNHEALTHY if the runner is running cloud init before running
-        # the GitHub agent.
+        # If the unit is ACTIVE but stuck we could leave a runner forever.
         cloud_instances_created = self.get_runners(cloud_states=[CloudRunnerState.CREATED])
         cloud_instances_created_ids = [
             cloud_instance.instance_id for cloud_instance in cloud_instances_created

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -155,7 +155,7 @@ class RunnerManager:
         logger.info("Getting runners...")
         github_infos = self._github.get_runners(github_states)
         cloud_infos = self._cloud.get_runners(cloud_states)
-        github_infos_map = {info.name: info for info in github_infos}
+        github_infos_map = {info.instance_id.name: info for info in github_infos}
         cloud_infos_map = {info.name: info for info in cloud_infos}
         logger.info(
             "Found following runners: %s", cloud_infos_map.keys() | github_infos_map.keys()

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -247,8 +247,10 @@ class RunnerManager:
         # and the in the RunnerInstance.
 
         # We clean ACTIVE units that are offline. This is a race condition, as it can be running
-        # cloud init before starting the runner (reactive case). We do not treat this case
-        # until better information is obtained from get_runners. Currently it returns UNHEALTHY.
+        # cloud init before starting the runner (reactive case) or runners that are restarting.
+        # We do not treat this case until better information is obtained from get_runners.
+        # Currently it returns UNHEALTHY if the runner is running cloud init before running
+        # the GitHub agent.
         cloud_instances_created = self.get_runners(cloud_states=[CloudRunnerState.CREATED])
         cloud_instances_created_ids = [
             cloud_instance.instance_id for cloud_instance in cloud_instances_created

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -290,6 +290,10 @@ class RunnerManager:
             ):
                 continue
             github_runners_to_delete.append(github_runner)
+        logger.info(
+            "Offline github runners to delete: %s:",
+            [runner.instance_id for runner in github_runners_to_delete],
+        )
         self._github.delete_runners(github_runners_to_delete)
 
     @staticmethod

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -275,13 +275,11 @@ class RunnerManager:
                 continue
 
             # reactive runners.
-            # If there is no cloud runner, we remove  the GitHub runner.
-            # There can be a small race condition, the time
-            # it takes the reactive process between getting the JIT token and
-            # launching the runner, but rather delete it than getting runners
-            # stuck in GitHub as offline.
+            # If there is no cloud runner, we do not remove  the GitHub runner.
+            # Although this could leave GitHub runners as offline forever, the
+            # other risk is to kill runners starting. Pending to analyze how to
+            # not leave runners in GitHub.
             if github_runner.instance_id not in cloud_instances_map:
-                github_runners_to_delete.append(github_runner)
                 continue
             cloud_runner = cloud_instances_map[github_runner.instance_id]
             if cloud_runner.cloud_state == CloudRunnerState.CREATED or (

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -249,7 +249,8 @@ class RunnerManager:
         # We clean ACTIVE units that are offline. This is a race condition, as it can be running
         # cloud init before starting the runner (reactive case) or runners that are restarting.
         # We do not treat this case until better information is obtained from get_runners.
-        # If the unit is ACTIVE but stuck we could leave a runner forever.
+        # get_runners returns unhealthy if the GitHub agent is not running and cloud init
+        # is running. If the unit is ACTIVE but stuck we could leave a runner forever.
         cloud_instances_created = self.get_runners(cloud_states=[CloudRunnerState.CREATED])
         cloud_instances_created_ids = [
             cloud_instance.instance_id for cloud_instance in cloud_instances_created

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -242,7 +242,16 @@ class RunnerManager:
         Returns:
             Stats on metrics events issued during the cleanup of runners.
         """
-        self._github.delete_runners([GitHubRunnerState.OFFLINE])
+        # get_runners only get runners in the cloud provider, which can be
+        # misleading. Pending to tackle and put the logic of this function to
+        # get_runners and the runners themselves.
+        # The cloud state ACTIVE is problematic, as it can be creating the the instance,
+        # in which case get_runners returns unhealthy unit currently. To not leave runners
+        # in an incorrect state, we just leave the units in BUILD state until a better
+        # information is obtained from get_runners.
+        # instances_created = self.get_runners(cloud_states=[CloudRunnerState.CREATED])
+        github_runner_list = self._github.get_runners([GitHubRunnerState.OFFLINE])
+        self._github.delete_runners(github_runner_list)
         remove_token = self._github.get_removal_token()
         deleted_runner_metrics = self._cloud.cleanup(remove_token)
         return self._issue_runner_metrics(metrics=deleted_runner_metrics)

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -257,9 +257,9 @@ class RunnerManager:
         ]
         github_runners = self._github.get_runners([GitHubRunnerState.OFFLINE])
         runners_to_delete = [
-            ghrunner
-            for ghrunner in github_runners
-            if ghrunner.instance_id not in cloud_instances_created_ids
+            gh_runner
+            for gh_runner in github_runners
+            if gh_runner.instance_id not in cloud_instances_created_ids
         ]
         self._github.delete_runners(runners_to_delete)
         remove_token = self._github.get_removal_token()

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -275,10 +275,9 @@ class RunnerManager:
                 continue
 
             # reactive runners.
-            # If there is no cloud runner, we do not remove  the GitHub runner.
-            # Although this could leave GitHub runners as offline forever, the
-            # other risk is to kill runners starting. Pending to analyze how to
-            # not leave runners in GitHub.
+            # If there is no cloud runner, we do not remove  the GitHub runner,
+            # as it can be a reactive runner being in the creation phase. The risk
+            # is that some offline runners could be left for a while in GitHub.
             if github_runner.instance_id not in cloud_instances_map:
                 continue
             cloud_runner = cloud_instances_map[github_runner.instance_id]

--- a/github-runner-manager/src/github_runner_manager/reactive/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/runner_manager.py
@@ -87,6 +87,7 @@ def reconcile(
     delete_metric_stats = {}
 
     if get_queue_size(reactive_process_config.queue) == 0:
+        logger.info("Reactive reconcile. Flushing on empty queue")
         flush_metric_stats = runner_manager.flush_runners(FlushMode.FLUSH_IDLE)
 
     # Only count runners which are online on GitHub to prevent machines to be just in

--- a/github-runner-manager/src/github_runner_manager/types_/github.py
+++ b/github-runner-manager/src/github_runner_manager/types_/github.py
@@ -12,6 +12,8 @@ from typing import List, Literal, Optional
 
 from pydantic import BaseModel
 
+from github_runner_manager.manager.models import InstanceID
+
 
 class GitHubRunnerStatus(str, Enum):
     """Status of runner on GitHub.
@@ -66,6 +68,7 @@ class SelfHostedRunner(BaseModel):
         os: Operation system of the runner.
         name: Name of the runner.
         status: The Github runner status.
+        instance_id: TODO
     """
 
     busy: bool
@@ -74,18 +77,15 @@ class SelfHostedRunner(BaseModel):
     os: str
     name: str
     status: GitHubRunnerStatus
+    instance_id: InstanceID | None
 
+    def calculate_instance_id(self, prefix: str) -> None:
+        """TODO.
 
-class SelfHostedRunnerList(BaseModel):
-    """Information on a collection of self-hosted runners.
-
-    Attributes:
-        total_count: Total number of runners.
-        runners: List of runners.
-    """
-
-    total_count: int
-    runners: list[SelfHostedRunner]
+        Args:
+            prefix: TODO
+        """
+        self.instance_id = InstanceID.build_from_name(prefix, self.name)
 
 
 class RegistrationToken(BaseModel):

--- a/github-runner-manager/src/github_runner_manager/types_/github.py
+++ b/github-runner-manager/src/github_runner_manager/types_/github.py
@@ -68,7 +68,7 @@ class SelfHostedRunner(BaseModel):
         os: Operation system of the runner.
         name: Name of the runner.
         status: The Github runner status.
-        instance_id: TODO
+        instance_id: InstanceID of the runner.
     """
 
     busy: bool
@@ -80,10 +80,10 @@ class SelfHostedRunner(BaseModel):
     instance_id: InstanceID | None
 
     def calculate_instance_id(self, prefix: str) -> None:
-        """TODO.
+        """Calculate the instance ID from the name.
 
         Args:
-            prefix: TODO
+            prefix: Prefix to use for the instance ID.
         """
         self.instance_id = InstanceID.build_from_name(prefix, self.name)
 

--- a/github-runner-manager/src/github_runner_manager/types_/github.py
+++ b/github-runner-manager/src/github_runner_manager/types_/github.py
@@ -66,7 +66,6 @@ class SelfHostedRunner(BaseModel):
         id: Unique identifier of the runner.
         labels: Labels of the runner.
         os: Operation system of the runner.
-        name: Name of the runner.
         status: The Github runner status.
         instance_id: InstanceID of the runner.
     """
@@ -75,17 +74,24 @@ class SelfHostedRunner(BaseModel):
     id: int
     labels: list[SelfHostedRunnerLabel]
     os: str
-    name: str
     status: GitHubRunnerStatus
-    instance_id: InstanceID | None
+    instance_id: InstanceID
 
-    def calculate_instance_id(self, prefix: str) -> None:
-        """Calculate the instance ID from the name.
+    @classmethod
+    def build_from_github(cls, github_dict: dict, instance_id: InstanceID) -> "SelfHostedRunner":
+        """Build a SelfHostedRunner from the GitHub runner information and the InstanceID.
 
         Args:
-            prefix: Prefix to use for the instance ID.
+            github_dict: GitHub dictionary from the list_self_hosted_runners endpoint.
+            instance_id: InstanceID for the runner.
+
+        Returns:
+            A SelfHostedRunner from the input data.
         """
-        self.instance_id = InstanceID.build_from_name(prefix, self.name)
+        # Pydantic does not correctly parse labels, they are of type fastcore.foundation.L.
+        github_dict["labels"] = list(github_dict["labels"])
+        github_dict["instance_id"] = instance_id
+        return cls.parse_obj(github_dict)
 
 
 class RegistrationToken(BaseModel):

--- a/github-runner-manager/tests/unit/manager/test_runner_manager.py
+++ b/github-runner-manager/tests/unit/manager/test_runner_manager.py
@@ -1,0 +1,90 @@
+#  Copyright 2025 Canonical Ltd.
+#  See LICENSE file for licensing details.
+
+"""Unit tests for the the runner_manager."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from github_runner_manager.configuration.github import GitHubConfiguration, GitHubRepo
+from github_runner_manager.manager.cloud_runner_manager import (
+    CloudRunnerInstance,
+    CloudRunnerState,
+    HealthState,
+)
+from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.runner_manager import RunnerManager
+from github_runner_manager.types_.github import GitHubRunnerStatus, SelfHostedRunner
+
+
+@pytest.mark.parametrize(
+    "cloud_state,removal_called",
+    [
+        pytest.param(None, True, id="GitHub runner offline without cloud runner"),
+        pytest.param(
+            CloudRunnerState.CREATED,
+            False,
+            id="Github runner offline with cloud runner in BUILD state.",
+        ),
+        pytest.param(
+            CloudRunnerState.ACTIVE, True, id="Github runner offline with ACTIVE cloud runner."
+        ),
+        pytest.param(
+            CloudRunnerState.DELETED, True, id="Github runner offline with DELETED cloud runner."
+        ),
+    ],
+)
+def test_cleanup_removes_created_runners(
+    cloud_state: CloudRunnerState | None, removal_called: bool, monkeypatch: pytest.MonkeyPatch
+):
+    """
+    arrange: TODO.
+    act: TODO
+    assert: TODO
+    """
+    instance_id = InstanceID.build("prefix-0")
+    github_runner = SelfHostedRunner(
+        id=1,
+        name=instance_id.name,
+        labels=[],
+        status=GitHubRunnerStatus.OFFLINE,
+        busy=True,
+        os="unknown",
+        instance_id=instance_id,
+    )
+    cloud_instances: tuple[CloudRunnerInstance, ...] = ()
+    if cloud_state:
+        cloud_instances = (
+            CloudRunnerInstance(
+                name=instance_id.name,
+                instance_id=instance_id,
+                health=HealthState.HEALTHY,
+                state=cloud_state,
+            ),
+        )
+
+    cloud_runner_manager = MagicMock()
+    cloud_runner_manager.get_runners.return_value = cloud_instances
+    github_org = GitHubRepo(owner="owner", repo="repo")
+    github_configuration = GitHubConfiguration(token="token", path=github_org)
+    runner_manager = RunnerManager(
+        "managername",
+        github_configuration=github_configuration,
+        cloud_runner_manager=cloud_runner_manager,
+        labels=["label1", "label2"],
+    )
+
+    github_client = MagicMock()
+    monkeypatch.setattr(runner_manager, "_github", github_client)
+    github_client.get_runners.return_value = [github_runner]
+    github_client.get_removal_token.return_value = "removaltoken"
+
+    stats = runner_manager.cleanup()
+
+    if removal_called:
+        github_client.delete_runners.assert_called_with([github_runner])
+    else:
+        github_client.delete_runners.assert_called_with([])
+
+    assert not stats

--- a/github-runner-manager/tests/unit/manager/test_runner_manager.py
+++ b/github-runner-manager/tests/unit/manager/test_runner_manager.py
@@ -35,13 +35,14 @@ from github_runner_manager.types_.github import GitHubRunnerStatus, SelfHostedRu
         ),
     ],
 )
-def test_cleanup_removes_created_runners(
+def test_cleanup_removes_offline_expected_runners(
     cloud_state: CloudRunnerState | None, removal_called: bool, monkeypatch: pytest.MonkeyPatch
 ):
     """
-    arrange: TODO.
-    act: TODO
-    assert: TODO
+    arrange: Given a runner with offline state in GitHub.
+       Also given an optional runner in the cloud provider with an state.
+    act: Call cleanup in the RunnerManager instance.
+    assert: If appropriate, the offline runner should be deleted.
     """
     instance_id = InstanceID.build("prefix-0")
     github_runner = SelfHostedRunner(

--- a/github-runner-manager/tests/unit/manager/test_runner_manager.py
+++ b/github-runner-manager/tests/unit/manager/test_runner_manager.py
@@ -81,11 +81,9 @@ def test_cleanup_removes_offline_expected_runners(
     github_client.get_runners.return_value = [github_runner]
     github_client.get_removal_token.return_value = "removaltoken"
 
-    stats = runner_manager.cleanup()
+    runner_manager.cleanup()
 
     if removal_called:
         github_client.delete_runners.assert_called_with([github_runner])
     else:
         github_client.delete_runners.assert_called_with([])
-
-    assert not stats

--- a/github-runner-manager/tests/unit/manager/test_runner_manager.py
+++ b/github-runner-manager/tests/unit/manager/test_runner_manager.py
@@ -47,7 +47,6 @@ def test_cleanup_removes_offline_expected_runners(
     instance_id = InstanceID.build("prefix-0")
     github_runner = SelfHostedRunner(
         id=1,
-        name=instance_id.name,
         labels=[],
         status=GitHubRunnerStatus.OFFLINE,
         busy=True,

--- a/github-runner-manager/tests/unit/manager/test_runner_manager.py
+++ b/github-runner-manager/tests/unit/manager/test_runner_manager.py
@@ -21,8 +21,12 @@ from github_runner_manager.types_.github import GitHubRunnerStatus, SelfHostedRu
 @pytest.mark.parametrize(
     "cloud_state,health,reactive,removal_called",
     [
-        pytest.param(None, None, reactive, True, id="Any GitHub runner offline should be deleted.")
-        for reactive in (True, False)
+        pytest.param(
+            None, None, False, True, id="Non reactive GitHub runner offline should be deleted."
+        ),
+        pytest.param(
+            None, None, True, False, id="Reactive GitHub runner offline should be deleted."
+        ),
     ]
     + [
         pytest.param(

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -450,7 +450,7 @@ class MockGitHubRunnerManager:
                 id=random.randint(1, 1000000),
                 labels=[],
                 os="linux",
-                name=runner.name,
+                instance_id=InstanceID.build_from_name(self.name_prefix, runner.name),
                 status=(
                     GitHubRunnerStatus.OFFLINE
                     if runner.github_state == GitHubRunnerState.OFFLINE

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -310,7 +310,7 @@ class MockCloudRunnerManager(CloudRunnerManager):
         """
         name = f"{self.name_prefix}-{instance_id}"
         runner = MockRunner(name)
-        self.state.runners[str(instance_id)] = runner
+        self.state.runners[instance_id] = runner
 
     def get_runners(
         self, states: Sequence[CloudRunnerState] | None = None
@@ -344,7 +344,7 @@ class MockCloudRunnerManager(CloudRunnerManager):
         Returns:
             Any runner metrics produced during deletion.
         """
-        runner = self.state.runners.pop(str(instance_id), None)
+        runner = self.state.runners.pop(instance_id, None)
         if runner is not None:
             return iter([MagicMock()])
         return iter([])
@@ -430,20 +430,20 @@ class MockGitHubRunnerManager:
         return "mock_remove_token"
 
     def get_runners(
-        self, github_states: Iterable[GitHubRunnerState] | None = None
+        self, states: Iterable[GitHubRunnerState] | None = None
     ) -> tuple[SelfHostedRunner, ...]:
         """Get the runners.
 
         Args:
-            github_states: The states to filter for.
+            states: The states to filter for.
 
         Returns:
             List of runners.
         """
-        if github_states is None:
-            github_states = [member.value for member in GitHubRunnerState]
+        if states is None:
+            states = [member.value for member in GitHubRunnerState]
 
-        github_state_set = set(github_states)
+        github_state_set = set(states)
         return tuple(
             SelfHostedRunner(
                 busy=runner.github_state == GitHubRunnerState.BUSY,
@@ -461,15 +461,15 @@ class MockGitHubRunnerManager:
             if runner.github_state in github_state_set
         )
 
-    def delete_runners(self, states: Iterable[GitHubRunnerState]) -> None:
+    def delete_runners(self, runners: list[SelfHostedRunner]) -> None:
         """Delete the runners.
 
         Args:
-            states: The states to filter the runners to delete.
+            runners: Runners to delete
         """
-        github_states = set(states)
+        runners_names_to_delete = {runner.name for runner in runners}
         self.state.runners = {
             instance_id: runner
             for instance_id, runner in self.state.runners.items()
-            if runner.github_state not in github_states
+            if instance_id.name not in runners_names_to_delete
         }

--- a/github-runner-manager/tests/unit/test_github_client.py
+++ b/github-runner-manager/tests/unit/test_github_client.py
@@ -263,12 +263,17 @@ def test_github_api_http_error(github_client: GithubClient, job_stats_raw: JobSt
 
 
 def test_get_runner_github_info(github_client: GithubClient, monkeypatch: pytest.MonkeyPatch):
+    """
+    arrange: A mocked Github Client that returns two runners, one for the requested prefix.
+    act: Call get_runner_github_info with the prefix.
+    assert: A correct runners is returned, the one matching the prefix.
+    """
     response = {
-        "total_count": 1,
+        "total_count": 2,
         "runners": [
             {
                 "id": 311,
-                "name": "test-ytnhlcjc-0-n-e8bc54023ae1",
+                "name": "current-unit-0-n-e8bc54023ae1",
                 "os": "linux",
                 "status": "offline",
                 "busy": True,
@@ -278,7 +283,20 @@ def test_get_runner_github_info(github_client: GithubClient, monkeypatch: pytest
                     {"id": 0, "name": "self-hosted", "type": "read-only"},
                     {"id": 0, "name": "linux", "type": "read-only"},
                 ],
-            }
+            },
+            {
+                "id": 312,
+                "name": "anotherunit-0-n-e8bc54023ae1",
+                "os": "linux",
+                "status": "offline",
+                "busy": True,
+                "labels": [
+                    {"id": 0, "name": "openstack_test", "type": "read-only"},
+                    {"id": 0, "name": "test-ae7a1fbcd0c1", "type": "read-only"},
+                    {"id": 0, "name": "self-hosted", "type": "read-only"},
+                    {"id": 0, "name": "linux", "type": "read-only"},
+                ],
+            },
         ],
     }
 
@@ -290,12 +308,12 @@ def test_get_runner_github_info(github_client: GithubClient, monkeypatch: pytest
     monkeypatch.setattr(github_runner_manager.github_client, "pages", pages)
 
     github_repo = GitHubRepo(owner=secrets.token_hex(16), repo=secrets.token_hex(16))
-    runners = github_client.get_runner_github_info(path=github_repo)
+    runners = github_client.get_runner_github_info(path=github_repo, prefix="current-unit-0")
 
     assert len(runners) == 1
     runner0 = runners[0]
     assert runner0.id == response["runners"][0]["id"]  # type: ignore
-    assert runner0.name == response["runners"][0]["name"]  # type: ignore
+    assert runner0.instance_id.name == response["runners"][0]["name"]  # type: ignore
     assert runner0.busy == response["runners"][0]["busy"]  # type: ignore
     assert runner0.status == response["runners"][0]["status"]  # type: ignore
 

--- a/github-runner-manager/tests/unit/test_github_client.py
+++ b/github-runner-manager/tests/unit/test_github_client.py
@@ -12,6 +12,7 @@ from urllib.error import HTTPError
 import pytest
 import requests
 
+import github_runner_manager.github_client
 from github_runner_manager.configuration.github import GitHubOrg, GitHubRepo
 from github_runner_manager.errors import GithubApiError, JobNotFoundError, TokenError
 from github_runner_manager.github_client import GithubClient
@@ -259,6 +260,44 @@ def test_github_api_http_error(github_client: GithubClient, job_stats_raw: JobSt
             workflow_run_id=secrets.token_hex(16),
             runner_name=job_stats_raw.runner_name,
         )
+
+
+def test_get_runner_github_info(github_client: GithubClient, monkeypatch: pytest.MonkeyPatch):
+    response = {
+        "total_count": 1,
+        "runners": [
+            {
+                "id": 311,
+                "name": "test-ytnhlcjc-0-n-e8bc54023ae1",
+                "os": "linux",
+                "status": "offline",
+                "busy": True,
+                "labels": [
+                    {"id": 0, "name": "openstack_test", "type": "read-only"},
+                    {"id": 0, "name": "test-ae7a1fbcd0c1", "type": "read-only"},
+                    {"id": 0, "name": "self-hosted", "type": "read-only"},
+                    {"id": 0, "name": "linux", "type": "read-only"},
+                ],
+            }
+        ],
+    }
+
+    github_client._client.last_page.return_value = 1
+    github_client._client.actions.list_self_hosted_runners_for_repo.side_effect = response
+
+    pages = MagicMock()
+    pages.return_value = [response]
+    monkeypatch.setattr(github_runner_manager.github_client, "pages", pages)
+
+    github_repo = GitHubRepo(owner=secrets.token_hex(16), repo=secrets.token_hex(16))
+    runners = github_client.get_runner_github_info(path=github_repo)
+
+    assert len(runners) == 1
+    runner0 = runners[0]
+    assert runner0.id == response["runners"][0]["id"]  # type: ignore
+    assert runner0.name == response["runners"][0]["name"]  # type: ignore
+    assert runner0.busy == response["runners"][0]["busy"]  # type: ignore
+    assert runner0.status == response["runners"][0]["status"]  # type: ignore
 
 
 def test_catch_http_errors(github_client: GithubClient):

--- a/tests/integration/test_reactive.py
+++ b/tests/integration/test_reactive.py
@@ -2,7 +2,6 @@
 #  See LICENSE file for licensing details.
 
 """Testing reactive mode. This is only supported for the OpenStack cloud."""
-import asyncio
 import json
 import re
 from typing import AsyncIterator
@@ -94,9 +93,6 @@ async def test_reactive_mode_spawns_runner(
         mongodb_uri,
         app.name,
     )
-
-    # TODO This is a bug. The reconcile deletes servers in BUILD state.
-    await asyncio.sleep(300)
 
     # This reconcile call is to check that we are not killing machines that are under
     # construction in a subsequent reconciliation.
@@ -208,10 +204,6 @@ async def test_reactive_mode_scale_down(
     )
 
     await wait_for_status(run, "in_progress")
-
-    # Give the runner manager some time to check the runners is ok and ack the message.
-    # TODO This is a bug. The reconcile deletes servers in BUILD state.
-    await asyncio.sleep(300)
 
     # 1. Scale down the number of virtual machines to 0 and call reconcile.
     await app.set_config({MAX_TOTAL_VIRTUAL_MACHINES_CONFIG_NAME: "0"})


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

A GitHub runner in offline mode is not necessarily offline, that means:
- A reactive runner in BUILD state in OpenStack is correct (it is in the creation process).
- A reactive runner that is ACTIVE, running the cloud init commands before running run.sh is correct.
- A runner ACTIVE that is rebooting/restarting the network is correct (busy runner that is offline).

Only the two first cases is tackled in this PR, as it is probably the most taxing. The other case will be fixed in future refactoring PRs.

Besides, in the GitHub client, typing was wrong (a dictionary was still being returned). Fixed to return the proper pydantic class. It could be reasonable to have both a typed dict for GitHub and then another "typed" class to use in the business logic, but that is not tackled in this PR.


### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->