### PR TITLE
Fix backward compatibility in instance names

### DIFF
--- a/github-runner-manager/src/github_runner_manager/manager/models.py
+++ b/github-runner-manager/src/github_runner_manager/manager/models.py
@@ -43,12 +43,12 @@ class InstanceID:
            Name of the instance
         """
         if self.reactive is True:
-            reactive_indicator = "r-"
+            runner_type = "r-"
         elif self.reactive is False:
-            reactive_indicator = "n-"
+            runner_type = "n-"
         else:
-            reactive_indicator = ""
-        return f"{self.prefix}-{reactive_indicator}{self.suffix}"
+            runner_type = ""
+        return f"{self.prefix}-{runner_type}{self.suffix}"
 
     @classmethod
     def build_from_name(cls, prefix: str, name: str) -> "InstanceID":

--- a/github-runner-manager/src/github_runner_manager/manager/models.py
+++ b/github-runner-manager/src/github_runner_manager/manager/models.py
@@ -32,7 +32,7 @@ class InstanceID:
     """
 
     prefix: str
-    reactive: bool
+    reactive: bool | None
     suffix: str
 
     @property
@@ -42,7 +42,13 @@ class InstanceID:
         Returns:
            Name of the instance
         """
-        return f"{self.prefix}-{'r' if self.reactive else 'n'}-{self.suffix}"
+        if self.reactive is True:
+            reactive_indicator = "r-"
+        elif self.reactive is False:
+            reactive_indicator = "n-"
+        else:
+            reactive_indicator = ""
+        return f"{self.prefix}-{reactive_indicator}{self.suffix}"
 
     @classmethod
     def build_from_name(cls, prefix: str, name: str) -> "InstanceID":
@@ -66,7 +72,7 @@ class InstanceID:
         # The separator from prefix and suffix indicates whether the runner is reactive.
         # To maintain backwards compatibility, if there is no r- or n- (reactive or
         # non-reactive), we assume non-reactive and keep the full suffix.
-        reactive = False
+        reactive = None
         separator = suffix[:2]
         if separator == "r-":
             reactive = True

--- a/github-runner-manager/tests/unit/manager/test_models.py
+++ b/github-runner-manager/tests/unit/manager/test_models.py
@@ -74,3 +74,19 @@ def test_build_instance_id_fails_when_very_long_name():
     prefix = "github-runner-operator-for-runners-using-openstack-amd64-with-flavor-with60-cores"
     with pytest.raises(InstanceIDInvalidError):
         _ = InstanceID.build(prefix)
+
+
+def test_backward_compatible_names():
+    """
+    arrange: A prefix and a unit name without reactive information.
+    act: Create the instance ID from the prefix and name.
+    assert: New name from the instance is the same as the original name. Also prefix and suffix.
+    """
+    prefix = "unit-0"
+    name = "unit-0-96950f351751"
+
+    instance_id = InstanceID.build_from_name(prefix, name)
+
+    assert instance_id.prefix == prefix
+    assert instance_id.suffix == "96950f351751"
+    assert instance_id.name == name


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Fix backward compatibility with previous unit names.

Otherwise, the old runners should be deleted manually when upgrading.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->