### PR TITLE
Do not call get all runners in github when creating runner failed in the cloud

### DIFF
--- a/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/github_runner_manager.py
@@ -93,7 +93,9 @@ class GitHubRunnerManager:  # pragma: no cover
         for runner in runners:
             self.github.delete_runner(self._path, runner.id)
 
-    def get_registration_jittoken(self, instance_id: InstanceID, labels: list[str]) -> str:
+    def get_registration_jittoken(
+        self, instance_id: InstanceID, labels: list[str]
+    ) -> tuple[str, SelfHostedRunner]:
         """Get registration JIT token from GitHub.
 
         This token is used for registering self-hosted runners.
@@ -103,7 +105,7 @@ class GitHubRunnerManager:  # pragma: no cover
             labels: Labels for the runner.
 
         Returns:
-            The registration token.
+            The registration token and the runner.
         """
         return self.github.get_runner_registration_jittoken(self._path, instance_id, labels)
 

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -455,8 +455,8 @@ class RunnerManager:
             RunnerError: On error creating OpenStack runner.
         """
         instance_id = InstanceID.build(args.cloud_runner_manager.name_prefix, args.reactive)
-        registration_jittoken = args.github_runner_manager.get_registration_jittoken(
-            instance_id, args.labels
+        registration_jittoken, github_runner = (
+            args.github_runner_manager.get_registration_jittoken(instance_id, args.labels)
         )
         try:
             args.cloud_runner_manager.create_runner(
@@ -466,11 +466,6 @@ class RunnerManager:
             # try to clean the runner in GitHub. This is necessary, as for reactive runners
             # we do not know in the clean up if the runner is offline because if failed or
             # because it is being created.
-            github_runners_offline = args.github_runner_manager.get_runners(
-                [GitHubRunnerState.OFFLINE]
-            )
-            for github_runner in github_runners_offline:
-                if github_runner.instance_id == instance_id:
-                    args.github_runner_manager.delete_runners([github_runner])
+            args.github_runner_manager.delete_runners([github_runner])
             raise
         return instance_id

--- a/github-runner-manager/src/github_runner_manager/types_/github.py
+++ b/github-runner-manager/src/github_runner_manager/types_/github.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, TypedDict
 
 from pydantic import BaseModel
 
@@ -87,23 +87,11 @@ class SelfHostedRunner(BaseModel):
 
         Returns:
             A SelfHostedRunner from the input data.
-        """
         # Pydantic does not correctly parse labels, they are of type fastcore.foundation.L.
+        """
         github_dict["labels"] = list(github_dict["labels"])
         github_dict["instance_id"] = instance_id
         return cls.parse_obj(github_dict)
-
-
-class RegistrationToken(BaseModel):
-    """Token used for registering GitHub runners.
-
-    Attributes:
-        token: Token for registering GitHub runners.
-        expires_at: Time the token expires at.
-    """
-
-    token: str
-    expires_at: str
 
 
 class RemoveToken(BaseModel):
@@ -179,3 +167,49 @@ class JobInfo(BaseModel):
     started_at: datetime
     conclusion: Optional[JobConclusion]
     status: JobStatus
+
+
+class JITConfig(TypedDict, total=True):
+    """JIT Config Token reply from GitHub API.
+
+    Attributes:
+        encoded_jit_config: The Token that identifies the runner.
+        runner: Information about the runner associated with the JIT token.
+    """
+
+    encoded_jit_config: str
+    runner: "JITConfigRunner"
+
+
+class JITConfigRunner(TypedDict, total=True):
+    """Runner Information returned when requesting a JIT token.
+
+    Attributes:
+        id: Id of the runner.
+        status: Status of the runner.
+        name: Name of the runner.
+        os: OS of the runner.
+        busy: Whether the runner is busy.
+        labels: Labels of the runner.
+    """
+
+    id: int
+    status: GitHubRunnerStatus
+    name: str
+    os: str
+    busy: bool
+    labels: "list[JITConfigRunnerLabel]"
+
+
+class JITConfigRunnerLabel(TypedDict, total=True):
+    """Labels for a runner returned when requesting a JIT token.
+
+    Attributes:
+        id: ID of the label.
+        name: Name of the label.
+        type: Type of label.
+    """
+
+    id: int
+    name: str
+    type: str

--- a/github-runner-manager/tests/unit/manager/test_runner_manager.py
+++ b/github-runner-manager/tests/unit/manager/test_runner_manager.py
@@ -187,7 +187,7 @@ def test_failed_runner_in_openstack_cleans_github(monkeypatch: pytest.MonkeyPatc
         """Return a registration token."""
         nonlocal github_runner
         github_runner.instance_id = instance_id
-        return "token"
+        return "token", github_runner
 
     github_client.get_registration_jittoken.side_effect = _get_reg_token
     cloud_runner_manager.create_runner.side_effect = RunnerCreateError("")

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -19,7 +19,7 @@ from github_runner_manager.manager.models import InstanceID
 from github_runner_manager.metrics.runner import RunnerMetrics
 from github_runner_manager.types_.github import (
     GitHubRunnerStatus,
-    RegistrationToken,
+    JITConfig,
     RemoveToken,
     RunnerApplication,
     SelfHostedRunner,
@@ -122,7 +122,7 @@ class MockGhapiActions:
         Returns:
             Registration token stub.
         """
-        return RegistrationToken(
+        return JITConfig(
             {"token": self.registration_token_repo, "expires_at": "2020-01-22T12:13:35.123-08:00"}
         )
 
@@ -135,7 +135,7 @@ class MockGhapiActions:
         Returns:
             Registration token stub.
         """
-        return RegistrationToken(
+        return JITConfig(
             {"token": self.registration_token_org, "expires_at": "2020-01-22T12:13:35.123-08:00"}
         )
 
@@ -409,7 +409,9 @@ class MockGitHubRunnerManager:
         self.state = state
         self.path = path
 
-    def get_registration_jittoken(self, instance_id: str, labels: list[str]) -> str:
+    def get_registration_jittoken(
+        self, instance_id: str, labels: list[str]
+    ) -> tuple[str, SelfHostedRunner]:
         """Get the registration JIT token for registering runners on GitHub.
 
         Args:
@@ -417,9 +419,9 @@ class MockGitHubRunnerManager:
             labels: Labels for the runner.
 
         Returns:
-            The registration token.
+            The registration token and the SelfHostedRunner
         """
-        return "mock_registration_token"
+        return "mock_registration_token", MagicMock(spec=SelfHostedRunner)
 
     def get_removal_token(self) -> str:
         """Get the remove token for removing runners on GitHub.

--- a/tests/unit/mock.py
+++ b/tests/unit/mock.py
@@ -9,7 +9,7 @@ import hashlib
 import logging
 import secrets
 
-from github_runner_manager.types_.github import RegistrationToken, RemoveToken, RunnerApplication
+from github_runner_manager.types_.github import JITConfig, RemoveToken, RunnerApplication
 
 from errors import RunnerError
 
@@ -141,7 +141,7 @@ class MockGhapiActions:
         Returns:
             Registration token stub.
         """
-        return RegistrationToken(
+        return JITConfig(
             {"token": self.registration_token_repo, "expires_at": "2020-01-22T12:13:35.123-08:00"}
         )
 
@@ -154,7 +154,7 @@ class MockGhapiActions:
         Returns:
             Registration token stub.
         """
-        return RegistrationToken(
+        return JITConfig(
             {"token": self.registration_token_org, "expires_at": "2020-01-22T12:13:35.123-08:00"}
         )
 


### PR DESCRIPTION
…cloud

Applicable spec: <link>

### Overview

Calling "pages" in 

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->