### PR TITLE
Optimize get unique server

### DIFF
--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -352,11 +352,12 @@ class OpenstackCloud:
         logger.info("Getting all openstack servers managed by the charm")
 
         with _get_openstack_connection(credentials=self._credentials) as conn:
-            instance_list = self._get_openstack_instances(conn)
+            instance_list = list(self._get_openstack_instances(conn))
             server_names = set(server.name for server in instance_list)
 
             server_list = [
-                OpenstackCloud._get_and_ensure_unique_server(conn, name) for name in server_names
+                OpenstackCloud._get_and_ensure_unique_server(conn, name, instance_list)
+                for name in server_names
             ]
             return tuple(
                 OpenstackInstance(server, self.prefix)
@@ -440,7 +441,7 @@ class OpenstackCloud:
 
     @staticmethod
     def _get_and_ensure_unique_server(
-        conn: OpenstackConnection, name: str
+        conn: OpenstackConnection, name: str, all_servers: list[OpenstackServer] | None = None
     ) -> OpenstackServer | None:
         """Get the latest server of the name and ensure it is unique.
 
@@ -450,11 +451,16 @@ class OpenstackCloud:
         Args:
             conn: The connection to OpenStack.
             name: The name of the OpenStack name.
+            all_servers: Optionally the list of servers to not request it to openstack again.
 
         Returns:
             A server with the name.
         """
-        servers: list[OpenstackServer] = conn.search_servers(name)
+        servers: list[OpenstackServer]
+        if not all_servers:
+            servers = conn.search_servers(name)
+        else:
+            servers = [server for server in all_servers if server.name == name]
 
         if not servers:
             return None


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Currently it can take up to several minutes because we are requesting the same list of servers for each runner. In an unit with 17 units it is about 4 minutes.

For the function _get_and_ensure_unique_server, if the caller has the list of openstack instances, it can be used and that way there is no need to go to openstack every time.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->