### PR TITLE
Refactor platform interface. Use of metadata for tagging runners.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-04-09
+
+- Remove update-dependencies action. This actions is not needed for external cloud providers.
+
 ### 2025-03-27
 
 - Add proxy configuration options for charm to facilitate its use in corporate environments.

--- a/github-runner-manager/src/github_runner_manager/manager/cloud_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/cloud_runner_manager.py
@@ -136,7 +136,7 @@ class CloudRunnerInstance:
     Attributes:
         name: Name of the instance hosting the runner.
         instance_id: ID of the instance.
-        metadata: TODO.
+        metadata: Metadata of the runner.
         health: Health state of the runner.
         state: State of the instance hosting the runner.
     """
@@ -208,21 +208,21 @@ class RunnerMetrics(BaseModel):
     """Metrics for a runner.
 
     Attributes:
+        instance_id: The name of the runner.
+        metadata: Runner metadata.
         installation_start_timestamp: The UNIX time stamp of the time at which the runner
             installation started.
         installed_timestamp: The UNIX time stamp of the time at which the runner was installed.
         pre_job: The metrics for the pre-job phase.
         post_job: The metrics for the post-job phase.
-        instance_id: The name of the runner.
-        metadata: TODO.
     """
 
+    instance_id: InstanceID
+    metadata: RunnerMetadata
     installation_start_timestamp: NonNegativeFloat | None
     installed_timestamp: NonNegativeFloat
     pre_job: PreJobMetrics | None
     post_job: PostJobMetrics | None
-    instance_id: InstanceID
-    metadata: RunnerMetadata
 
 
 class CloudRunnerManager(abc.ABC):
@@ -239,13 +239,13 @@ class CloudRunnerManager(abc.ABC):
 
     @abc.abstractmethod
     def create_runner(
-        self, metadata: RunnerMetadata, instance_id: InstanceID, runner_token: str
+        self, instance_id: InstanceID, metadata: RunnerMetadata, runner_token: str
     ) -> CloudRunnerInstance:
         """Create a self-hosted runner.
 
         Args:
-            metadata: TODO.
             instance_id: Instance ID for the runner.
+            metadata: Runner Metadata.
             runner_token: The one time token the runner.
         """
 

--- a/github-runner-manager/src/github_runner_manager/manager/models.py
+++ b/github-runner-manager/src/github_runner_manager/manager/models.py
@@ -157,7 +157,7 @@ class InstanceID:
 
 @dataclass
 class RunnerMetadata:
-    """This class container information about the runner and the platform it runs in.
+    """This class contains information about the runner and the platform it runs in.
 
     The information in this class is needed to link cloud runners with their
     platform ones.

--- a/github-runner-manager/src/github_runner_manager/manager/models.py
+++ b/github-runner-manager/src/github_runner_manager/manager/models.py
@@ -4,7 +4,7 @@
 """Module containing the main classes for business logic."""
 
 import secrets
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 INSTANCE_SUFFIX_LENGTH = 12
 
@@ -153,3 +153,26 @@ class InstanceID:
             String with the representation of the InstanceID.
         """
         return f"InstanceID({self.name!r})"
+
+
+@dataclass
+class RunnerMetadata:
+    """TODO.
+
+    Attributes:
+        platform_name: TODO
+        runner_id: TODO
+        url: TODO for runner?? for platform? what does this mean??
+    """
+
+    platform_name: str = "github"
+    runner_id: str | None = None
+    url: str | None = None
+
+    def as_dict(self) -> dict[str, str]:
+        """TODO.
+
+        Returns:
+            TODO.
+        """
+        return {k: v for k, v in asdict(self).items() if v is not None}

--- a/github-runner-manager/src/github_runner_manager/manager/models.py
+++ b/github-runner-manager/src/github_runner_manager/manager/models.py
@@ -157,12 +157,15 @@ class InstanceID:
 
 @dataclass
 class RunnerMetadata:
-    """TODO.
+    """This class container information about the runner and the platform it runs in.
+
+    The information in this class is needed to link cloud runners with their
+    platform ones.
 
     Attributes:
-        platform_name: TODO
-        runner_id: TODO
-        url: TODO for runner?? for platform? what does this mean??
+        platform_name: Platform name where the runner resides (github, jobmanager...)
+        runner_id: Id of the runner in the platform
+        url: URL for the runner.
     """
 
     platform_name: str = "github"
@@ -170,9 +173,9 @@ class RunnerMetadata:
     url: str | None = None
 
     def as_dict(self) -> dict[str, str]:
-        """TODO.
+        """Return the metadata as a dict.
 
         Returns:
-            TODO.
+            metadata as a dict.
         """
         return {k: v for k, v in asdict(self).items() if v is not None}

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -53,6 +53,7 @@ class RunnerInstance:
     Attributes:
         name: Full name of the runner. Managed by the cloud runner manager.
         instance_id: ID of the runner. Managed by the runner manager.
+        metadata: Metadata for the runner.
         health: The health state of the runner.
         github_state: State on github.
         cloud_state: State on cloud.
@@ -60,6 +61,7 @@ class RunnerInstance:
 
     name: str
     instance_id: InstanceID
+    metadata: RunnerMetadata
     health: HealthState
     github_state: PlatformRunnerState | None
     cloud_state: CloudRunnerState
@@ -73,6 +75,7 @@ class RunnerInstance:
         """
         self.name = cloud_instance.name
         self.instance_id = cloud_instance.instance_id
+        self.metadata = cloud_instance.metadata
         self.health = cloud_instance.health
         self.github_state = (
             PlatformRunnerState.from_runner(github_info) if github_info is not None else None

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -3,6 +3,7 @@
 
 """Module for managing the GitHub self-hosted runners hosted on cloud instances."""
 
+import copy
 import logging
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -17,14 +18,11 @@ from github_runner_manager.manager.cloud_runner_manager import (
     CloudRunnerState,
     HealthState,
 )
-from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
 from github_runner_manager.metrics import events as metric_events
 from github_runner_manager.metrics import github as github_metrics
 from github_runner_manager.metrics import runner as runner_metrics
 from github_runner_manager.metrics.runner import RunnerMetrics
-from github_runner_manager.platform.github_provider import (
-    GitHubRunnerPlatform,
-)
 from github_runner_manager.platform.platform_provider import (
     PlatformProvider,
     PlatformRunnerState,
@@ -111,11 +109,14 @@ class RunnerManager:
         self._platform: PlatformProvider = platform_provider
         self._labels = labels
 
-    def create_runners(self, num: int, reactive: bool = False) -> tuple[InstanceID, ...]:
+    def create_runners(
+        self, num: int, metadata: RunnerMetadata, reactive: bool = False
+    ) -> tuple[InstanceID, ...]:
         """Create runners.
 
         Args:
             num: Number of runners to create.
+            metadata: Metadata information for the runner.
             reactive: If the runner is reactive.
 
         Returns:
@@ -128,7 +129,14 @@ class RunnerManager:
         # we have to add them manually.
         labels += constants.GITHUB_DEFAULT_LABELS
         create_runner_args = [
-            RunnerManager._CreateRunnerArgs(self._cloud, self._platform, labels, reactive)
+            RunnerManager._CreateRunnerArgs(
+                cloud_runner_manager=self._cloud,
+                platform_provider=self._platform,
+                # Be careful as the metadata may be manipulated when creating the runner
+                metadata=copy.copy(metadata),
+                labels=labels,
+                reactive=reactive,
+            )
             for _ in range(num)
         ]
         return RunnerManager._spawn_runners(create_runner_args)
@@ -396,6 +404,7 @@ class RunnerManager:
                     job_metrics = github_metrics.job(
                         platform_provider=self._platform,
                         pre_job_metrics=extracted_metrics.pre_job,
+                        metadata=extracted_metrics.metadata,
                         runner=extracted_metrics.instance_id,
                     )
                 except GithubMetricsError:
@@ -427,13 +436,15 @@ class RunnerManager:
 
         Attrs:
             cloud_runner_manager: For managing the cloud instance of the runner.
-            github_runner_manager: To manage self-hosted runner on the GitHub side.
+            platform_provider: To manage self-hosted runner on the Platform side.
+            metadata: TODO.
             labels: List of labels to add to the runners.
             reactive: If the runner is reactive.
         """
 
         cloud_runner_manager: CloudRunnerManager
-        github_runner_manager: GitHubRunnerPlatform
+        platform_provider: PlatformProvider
+        metadata: RunnerMetadata
         labels: list[str]
         reactive: bool
 
@@ -453,17 +464,22 @@ class RunnerManager:
             RunnerError: On error creating OpenStack runner.
         """
         instance_id = InstanceID.build(args.cloud_runner_manager.name_prefix, args.reactive)
-        registration_jittoken, github_runner = args.github_runner_manager.get_runner_token(
-            instance_id, args.labels
+        runner_token, github_runner = args.platform_provider.get_runner_token(
+            metadata=args.metadata, instance_id=instance_id, labels=args.labels
         )
+
+        # Update the runner id if necessary
+        if not args.metadata.runner_id:
+            args.metadata.runner_id = str(github_runner.id)
+
         try:
             args.cloud_runner_manager.create_runner(
-                instance_id=instance_id, registration_jittoken=registration_jittoken
+                metadata=args.metadata, instance_id=instance_id, runner_token=runner_token
             )
         except RunnerError:
             # try to clean the runner in GitHub. This is necessary, as for reactive runners
             # we do not know in the clean up if the runner is offline because if failed or
             # because it is being created.
-            args.github_runner_manager.delete_runners([github_runner])
+            args.platform_provider.delete_runners([github_runner])
             raise
         return instance_id

--- a/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
@@ -32,10 +32,10 @@ from github_runner_manager.metrics import events as metric_events
 from github_runner_manager.openstack_cloud.configuration import (
     OpenStackConfiguration,
 )
+from github_runner_manager.openstack_cloud.models import OpenStackServerConfig
 from github_runner_manager.openstack_cloud.openstack_runner_manager import (
     OpenStackRunnerManager,
     OpenStackRunnerManagerConfig,
-    OpenStackServerConfig,
 )
 from github_runner_manager.platform.github_provider import GitHubRunnerPlatform
 from github_runner_manager.platform.platform_provider import PlatformRunnerState

--- a/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_scaler.py
@@ -26,6 +26,7 @@ from github_runner_manager.manager.runner_manager import (
     IssuedMetricEventsStats,
     RunnerInstance,
     RunnerManager,
+    RunnerMetadata,
 )
 from github_runner_manager.metrics import events as metric_events
 from github_runner_manager.openstack_cloud.configuration import (
@@ -327,7 +328,7 @@ class RunnerScaler:
         runner_diff = expected_quantity - len(runners)
         if runner_diff > 0:
             try:
-                self._manager.create_runners(runner_diff)
+                self._manager.create_runners(num=runner_diff, metadata=RunnerMetadata())
             except MissingServerConfigError:
                 logging.exception(
                     "Unable to spawn runner due to missing server configuration, "

--- a/github-runner-manager/src/github_runner_manager/metrics/events.py
+++ b/github-runner-manager/src/github_runner_manager/metrics/events.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 from pydantic import BaseModel, NonNegativeFloat
 
 from github_runner_manager.errors import IssueMetricEventError
+from github_runner_manager.manager.cloud_runner_manager import CodeInformation
 
 METRICS_LOG_PATH = Path("/var/log/github-runner-metrics.log")
 
@@ -93,18 +94,6 @@ class RunnerStart(Event):
     github_event: str
     idle: NonNegativeFloat
     queue_duration: Optional[NonNegativeFloat]
-
-
-class CodeInformation(BaseModel):
-    """Information about a status code.
-
-    This could e.g. be an exit code or a http status code.
-
-    Attributes:
-        code: The status code.
-    """
-
-    code: int
 
 
 class RunnerStop(Event):

--- a/github-runner-manager/src/github_runner_manager/metrics/github.py
+++ b/github-runner-manager/src/github_runner_manager/metrics/github.py
@@ -27,7 +27,7 @@ def job(
         platform_provider: The platform provider.
         pre_job_metrics: The pre-job metrics.
         runner: The runner instance id.
-        metadata: TODO.
+        metadata: Metadata for the runner.
 
     Raises:
         GithubMetricsError: If the job for given workflow run is not found.

--- a/github-runner-manager/src/github_runner_manager/metrics/github.py
+++ b/github-runner-manager/src/github_runner_manager/metrics/github.py
@@ -5,7 +5,7 @@
 import logging
 
 from github_runner_manager.errors import GithubMetricsError
-from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
 from github_runner_manager.metrics.runner import PreJobMetrics
 from github_runner_manager.metrics.type import GithubJobMetrics
 from github_runner_manager.platform.platform_provider import JobNotFoundError, PlatformProvider
@@ -14,7 +14,10 @@ logger = logging.getLogger(__name__)
 
 
 def job(
-    platform_provider: PlatformProvider, pre_job_metrics: PreJobMetrics, runner: InstanceID
+    platform_provider: PlatformProvider,
+    pre_job_metrics: PreJobMetrics,
+    runner: InstanceID,
+    metadata: RunnerMetadata,
 ) -> GithubJobMetrics:
     """Calculate the job metrics for a runner.
 
@@ -24,6 +27,7 @@ def job(
         platform_provider: The platform provider.
         pre_job_metrics: The pre-job metrics.
         runner: The runner instance id.
+        metadata: TODO.
 
     Raises:
         GithubMetricsError: If the job for given workflow run is not found.
@@ -33,6 +37,7 @@ def job(
     """
     try:
         job_info = platform_provider.get_job_info(
+            metadata=metadata,
             repository=pre_job_metrics.repository,
             workflow_run_id=pre_job_metrics.workflow_run_id,
             runner=runner,

--- a/github-runner-manager/src/github_runner_manager/metrics/runner.py
+++ b/github-runner-manager/src/github_runner_manager/metrics/runner.py
@@ -8,19 +8,24 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
 from json import JSONDecodeError
 from typing import Optional, Type
 
 import paramiko
 import paramiko.ssh_exception
 from fabric import Connection as SSHConnection
-from pydantic import BaseModel, Field, NonNegativeFloat, ValidationError
+from pydantic import ValidationError
 
 from github_runner_manager.errors import (
     IssueMetricEventError,
     RunnerMetricsError,
     SSHError,
+)
+from github_runner_manager.manager.cloud_runner_manager import (
+    CloudRunnerInstance,
+    PostJobMetrics,
+    PreJobMetrics,
+    RunnerMetrics,
 )
 from github_runner_manager.manager.models import InstanceID
 from github_runner_manager.metrics import events as metric_events
@@ -38,81 +43,6 @@ MAX_METRICS_FILE_SIZE = 1024
 
 class PullFileError(Exception):
     """Represents an error while pulling a file from the runner instance."""
-
-
-class PreJobMetrics(BaseModel):
-    """Metrics for the pre-job phase of a runner.
-
-    Attributes:
-        timestamp: The UNIX time stamp of the time at which the event was originally issued.
-        workflow: The workflow name.
-        workflow_run_id: The workflow run id.
-        repository: The repository path in the format '<owner>/<repo>'.
-        event: The github event.
-    """
-
-    timestamp: NonNegativeFloat
-    workflow: str
-    workflow_run_id: str
-    repository: str = Field(None, regex=r"^.+/.+$")
-    event: str
-
-
-class PostJobStatus(str, Enum):
-    """The status of the post-job phase of a runner.
-
-    Attributes:
-        NORMAL: Represents a normal post-job.
-        ABNORMAL: Represents an error with post-job.
-        REPO_POLICY_CHECK_FAILURE: Represents an error with repo-policy-compliance check.
-    """
-
-    NORMAL = "normal"
-    ABNORMAL = "abnormal"
-    REPO_POLICY_CHECK_FAILURE = "repo-policy-check-failure"
-
-
-class CodeInformation(BaseModel):
-    """Information about a status code.
-
-    Attributes:
-        code: The status code.
-    """
-
-    code: int
-
-
-class PostJobMetrics(BaseModel):
-    """Metrics for the post-job phase of a runner.
-
-    Attributes:
-        timestamp: The UNIX time stamp of the time at which the event was originally issued.
-        status: The status of the job.
-        status_info: More information about the status.
-    """
-
-    timestamp: NonNegativeFloat
-    status: PostJobStatus
-    status_info: Optional[CodeInformation]
-
-
-class RunnerMetrics(BaseModel):
-    """Metrics for a runner.
-
-    Attributes:
-        installation_start_timestamp: The UNIX time stamp of the time at which the runner
-            installation started.
-        installed_timestamp: The UNIX time stamp of the time at which the runner was installed.
-        pre_job: The metrics for the pre-job phase.
-        post_job: The metrics for the post-job phase.
-        instance_id: The name of the runner.
-    """
-
-    installation_start_timestamp: NonNegativeFloat | None
-    installed_timestamp: NonNegativeFloat
-    pre_job: PreJobMetrics | None
-    post_job: PostJobMetrics | None
-    instance_id: InstanceID
 
 
 def pull_runner_metrics(instance_id: InstanceID, ssh_conn: SSHConnection) -> "PulledMetrics":
@@ -229,17 +159,18 @@ class PulledMetrics:
     post_job_metrics: str | None = None
 
     def to_runner_metrics(
-        self, instance_id: InstanceID, installation_start: datetime
+        self, instance: CloudRunnerInstance, installation_start: datetime
     ) -> RunnerMetrics | None:
         """.
 
         Args:
-           instance_id: InstanceID of the runner.
+           instance: TODO
            installation_start: Creation time of the runner.
 
         Returns:
            The RunnerMetrics object for the runner or None if it can not be built.
         """
+        instance_id = instance.instance_id
         if self.runner_installed is None:
             logger.error(
                 "Invalid pulled metrics. No runner_installed information for %s.", instance_id
@@ -285,6 +216,7 @@ class PulledMetrics:
                     PostJobMetrics(**post_job_metrics) if post_job_metrics else None
                 ),
                 instance_id=instance_id,
+                metadata=instance.metadata,
             )
         except ValueError:
             logger.exception(

--- a/github-runner-manager/src/github_runner_manager/metrics/runner.py
+++ b/github-runner-manager/src/github_runner_manager/metrics/runner.py
@@ -164,7 +164,7 @@ class PulledMetrics:
         """.
 
         Args:
-           instance: TODO
+           instance: Cloud runner instance.
            installation_start: Creation time of the runner.
 
         Returns:

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/models.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/models.py
@@ -1,0 +1,43 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module containing OpenStack models."""
+
+from dataclasses import dataclass
+
+from github_runner_manager.configuration import SupportServiceConfig
+from github_runner_manager.openstack_cloud.configuration import (
+    OpenStackCredentials,
+)
+
+
+@dataclass
+class OpenStackServerConfig:
+    """Configuration for OpenStack server.
+
+    Attributes:
+        image: The image name for runners to use.
+        flavor: The flavor name for runners to use.
+        network: The network name for runners to use.
+    """
+
+    image: str
+    flavor: str
+    network: str
+
+
+@dataclass
+class OpenStackRunnerManagerConfig:
+    """Configuration for OpenStack runner manager.
+
+    Attributes:
+        prefix: The prefix of the runner names.
+        credentials: The OpenStack authorization information.
+        server_config: The configuration for OpenStack server.
+        service_config: The configuration for supporting services.
+    """
+
+    prefix: str
+    credentials: OpenStackCredentials
+    server_config: OpenStackServerConfig | None
+    service_config: SupportServiceConfig

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -48,7 +48,7 @@ class OpenstackInstance:
             OpenstackCloud.
         server_id: ID of server assigned by OpenStack.
         status: Status of the server.
-        metadata: TODO
+        metadata: Medatada of the server.
     """
 
     addresses: list[str]
@@ -74,6 +74,7 @@ class OpenstackInstance:
         self.instance_id = InstanceID.build_from_name(prefix, server.name)
         self.server_id = server.id
         self.status = server.status
+        # To be backwards compatible, we need a default RunnerMetadata.
         self.metadata = RunnerMetadata(**server.metadata) if server.metadata else RunnerMetadata()
 
 
@@ -189,7 +190,7 @@ class OpenstackCloud:
         """Create an OpenStack instance.
 
         Args:
-            metadata: TODO.
+            metadata: Metadata for the runner.
             instance_id: The instance ID to form the instance name.
             image: The image used to create the instance.
             flavor: The flavor used to create the instance.

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -24,7 +24,7 @@ from openstack.network.v2.security_group import SecurityGroup as OpenstackSecuri
 from paramiko.ssh_exception import NoValidConnectionsError
 
 from github_runner_manager.errors import KeyfileError, OpenStackError, SSHError
-from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
 from github_runner_manager.openstack_cloud.configuration import OpenStackCredentials
 from github_runner_manager.openstack_cloud.constants import CREATE_SERVER_TIMEOUT
 
@@ -48,6 +48,7 @@ class OpenstackInstance:
             OpenstackCloud.
         server_id: ID of server assigned by OpenStack.
         status: Status of the server.
+        metadata: TODO
     """
 
     addresses: list[str]
@@ -55,6 +56,7 @@ class OpenstackInstance:
     instance_id: InstanceID
     server_id: str
     status: str
+    metadata: RunnerMetadata
 
     def __init__(self, server: OpenstackServer, prefix: str):
         """Construct the object.
@@ -72,6 +74,7 @@ class OpenstackInstance:
         self.instance_id = InstanceID.build_from_name(prefix, server.name)
         self.server_id = server.id
         self.status = server.status
+        self.metadata = RunnerMetadata(**server.metadata) if server.metadata else RunnerMetadata()
 
 
 P = ParamSpec("P")
@@ -175,11 +178,18 @@ class OpenstackCloud:
     # Ignore "Too many arguments" as 6 args should be fine. Move to a dataclass if new args are
     # added.
     def launch_instance(  # pylint: disable=too-many-arguments, too-many-positional-arguments
-        self, instance_id: InstanceID, image: str, flavor: str, network: str, cloud_init: str
+        self,
+        metadata: RunnerMetadata,
+        instance_id: InstanceID,
+        image: str,
+        flavor: str,
+        network: str,
+        cloud_init: str,
     ) -> OpenstackInstance:
         """Create an OpenStack instance.
 
         Args:
+            metadata: TODO.
             instance_id: The instance ID to form the instance name.
             image: The image used to create the instance.
             flavor: The flavor used to create the instance.
@@ -197,7 +207,8 @@ class OpenstackCloud:
         with _get_openstack_connection(credentials=self._credentials) as conn:
             security_group = OpenstackCloud._ensure_security_group(conn)
             keypair = self._setup_keypair(conn, instance_id)
-
+            meta = metadata.as_dict()
+            meta["prefix"] = self.prefix
             try:
                 server = conn.create_server(
                     name=instance_id.name,
@@ -210,6 +221,7 @@ class OpenstackCloud:
                     auto_ip=False,
                     timeout=CREATE_SERVER_TIMEOUT,
                     wait=True,
+                    meta=meta,
                 )
             except openstack.exceptions.ResourceTimeout as err:
                 logger.exception("Timeout creating openstack server %s", instance_id)

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -32,7 +32,7 @@ from github_runner_manager.manager.cloud_runner_manager import (
     CloudRunnerManager,
     CloudRunnerState,
 )
-from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
 from github_runner_manager.manager.runner_manager import HealthState
 from github_runner_manager.metrics import runner as runner_metrics
 from github_runner_manager.openstack_cloud import health_checks
@@ -157,23 +157,30 @@ class OpenStackRunnerManager(CloudRunnerManager):
         """
         return self._config.prefix
 
-    def create_runner(self, instance_id: InstanceID, registration_jittoken: str) -> None:
+    def create_runner(
+        self, metadata: RunnerMetadata, instance_id: InstanceID, runner_token: str
+    ) -> CloudRunnerInstance:
         """Create a self-hosted runner.
 
         Args:
+            metadata: TODO.
             instance_id: Instance ID for the runner to create.
-            registration_jittoken: The JIT GitHub registration token for registering runners.
+            runner_token: The token for the runner.
 
         Raises:
             MissingServerConfigError: Unable to create runner due to missing configuration.
             RunnerCreateError: Unable to create runner due to OpenStack issues.
+
+        Returns:
+            The newly created runner instance.
         """
         if (server_config := self._config.server_config) is None:
             raise MissingServerConfigError("Missing server configuration to create runners")
 
-        cloud_init = self._generate_cloud_init(registration_jittoken=registration_jittoken)
+        cloud_init = self._generate_cloud_init(runner_token=runner_token)
         try:
             instance = self._openstack_cloud.launch_instance(
+                metadata=metadata,
                 instance_id=instance_id,
                 image=server_config.image,
                 flavor=server_config.flavor,
@@ -189,6 +196,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
         self._wait_runner_running(instance)
 
         logger.info("Runner %s created successfully", instance.instance_id)
+        return self._build_cloud_runner_instance(instance)
 
     def get_runners(
         self, states: Sequence[CloudRunnerState] | None = None
@@ -212,19 +220,25 @@ class OpenStackRunnerManager(CloudRunnerManager):
             except OpenstackHealthCheckError:
                 logger.exception(HEALTH_CHECK_ERROR_LOG_MSG, instance.instance_id.name)
                 healthy = None
-            runners.append(
-                CloudRunnerInstance(
-                    name=instance.instance_id.name,
-                    instance_id=instance.instance_id,
-                    health=HealthState.from_value(healthy),
-                    state=CloudRunnerState.from_openstack_server_status(instance.status),
-                )
-            )
+            runners.append(self._build_cloud_runner_instance(instance, healthy))
         if states is None:
             return tuple(runners)
 
         state_set = set(states)
         return tuple(runner for runner in runners if runner.state in state_set)
+
+    def _build_cloud_runner_instance(
+        self, instance: OpenstackInstance, healthy: bool | None = None
+    ) -> CloudRunnerInstance:
+        """TODO."""
+        metadata = instance.metadata
+        return CloudRunnerInstance(
+            name=instance.instance_id.name,
+            metadata=metadata,
+            instance_id=instance.instance_id,
+            health=HealthState.from_value(healthy),
+            state=CloudRunnerState.from_openstack_server_status(instance.status),
+        )
 
     def delete_runner(
         self, instance_id: InstanceID, remove_token: str
@@ -247,13 +261,14 @@ class OpenStackRunnerManager(CloudRunnerManager):
             )
             return None
 
+        pulled_metrics = self._delete_runner(instance, remove_token)
         logger.debug(
             "Metrics extracted, deleting instance %s %s", instance_id, instance.instance_id
         )
-        pulled_metrics = self._delete_runner(instance, remove_token)
         logger.debug("Instance deleted successfully %s %s", instance_id, instance.instance_id)
         logger.debug("Extract metrics for runner %s %s", instance_id, instance.instance_id)
-        return pulled_metrics.to_runner_metrics(instance.instance_id, instance.created_at)
+        cloud_instance = self._build_cloud_runner_instance(instance)
+        return pulled_metrics.to_runner_metrics(cloud_instance, instance.created_at)
 
     def flush_runners(
         self, remove_token: str, busy: bool = False
@@ -309,7 +324,8 @@ class OpenStackRunnerManager(CloudRunnerManager):
         extracted_runner_metrics = []
         for runner in runners.unhealthy:
             pulled_metrics = self._delete_runner(runner, remove_token)
-            runner_metric = pulled_metrics.to_runner_metrics(runner.instance_id, runner.created_at)
+            cloud_runner = self._build_cloud_runner_instance(runner)
+            runner_metric = pulled_metrics.to_runner_metrics(cloud_runner, runner.created_at)
             if not runner_metric:
                 logger.error("No metrics returned after deleting %s", runner.instance_id)
             else:
@@ -386,13 +402,13 @@ class OpenStackRunnerManager(CloudRunnerManager):
             healthy=tuple(healthy), unhealthy=tuple(unhealthy), unknown=tuple(unknown)
         )
 
-    def _generate_cloud_init(self, registration_jittoken: str) -> str:
+    def _generate_cloud_init(self, runner_token: str) -> str:
         """Generate cloud init userdata.
 
         This is the script the openstack server runs on startup.
 
         Args:
-            registration_jittoken: The JIT GitHub runner registration token.
+            runner_token: The JIT GitHub runner registration token.
 
         Returns:
             The cloud init userdata for openstack instance.
@@ -439,7 +455,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
             service_config.runner_proxy_config.proxy_address if service_config.use_aproxy else None
         )
         return jinja.get_template("openstack-userdata.sh.j2").render(
-            jittoken=registration_jittoken,
+            jittoken=runner_token,
             env_contents=env_contents,
             pre_job_contents=pre_job_contents,
             metrics_exchange_path=str(METRICS_EXCHANGE_PATH),

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -158,13 +158,13 @@ class OpenStackRunnerManager(CloudRunnerManager):
         return self._config.prefix
 
     def create_runner(
-        self, metadata: RunnerMetadata, instance_id: InstanceID, runner_token: str
+        self, instance_id: InstanceID, metadata: RunnerMetadata, runner_token: str
     ) -> CloudRunnerInstance:
         """Create a self-hosted runner.
 
         Args:
-            metadata: TODO.
             instance_id: Instance ID for the runner to create.
+            metadata: Metadata for the runner.
             runner_token: The token for the runner.
 
         Raises:
@@ -230,7 +230,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
     def _build_cloud_runner_instance(
         self, instance: OpenstackInstance, healthy: bool | None = None
     ) -> CloudRunnerInstance:
-        """TODO."""
+        """Build a new cloud runner instance from an openstack instance."""
         metadata = instance.metadata
         return CloudRunnerInstance(
             name=instance.instance_id.name,

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -16,7 +16,6 @@ import paramiko
 from fabric import Connection as SSHConnection
 
 from github_runner_manager import constants
-from github_runner_manager.configuration import SupportServiceConfig
 from github_runner_manager.errors import (
     KeyfileError,
     MissingServerConfigError,
@@ -42,9 +41,9 @@ from github_runner_manager.openstack_cloud.constants import (
     RUNNER_LISTENER_PROCESS,
     RUNNER_WORKER_PROCESS,
 )
+from github_runner_manager.openstack_cloud.models import OpenStackRunnerManagerConfig
 from github_runner_manager.openstack_cloud.openstack_cloud import (
     OpenstackCloud,
-    OpenStackCredentials,
     OpenstackInstance,
 )
 from github_runner_manager.repo_policy_compliance_client import RepoPolicyComplianceClient
@@ -66,38 +65,6 @@ HEALTH_CHECK_ERROR_LOG_MSG = "Health check could not be completed for %s"
 
 class _GithubRunnerRemoveError(Exception):
     """Represents an error while SSH into a runner and running the remove script."""
-
-
-@dataclass
-class OpenStackServerConfig:
-    """Configuration for OpenStack server.
-
-    Attributes:
-        image: The image name for runners to use.
-        flavor: The flavor name for runners to use.
-        network: The network name for runners to use.
-    """
-
-    image: str
-    flavor: str
-    network: str
-
-
-@dataclass
-class OpenStackRunnerManagerConfig:
-    """Configuration for OpenStack runner manager.
-
-    Attributes:
-        prefix: The prefix of the runner names.
-        credentials: The OpenStack authorization information.
-        server_config: The configuration for OpenStack server.
-        service_config: The configuration for supporting services.
-    """
-
-    prefix: str
-    credentials: OpenStackCredentials
-    server_config: OpenStackServerConfig | None
-    service_config: SupportServiceConfig
 
 
 @dataclass
@@ -182,9 +149,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
             instance = self._openstack_cloud.launch_instance(
                 metadata=metadata,
                 instance_id=instance_id,
-                image=server_config.image,
-                flavor=server_config.flavor,
-                network=server_config.network,
+                server_config=server_config,
                 cloud_init=cloud_init,
             )
         except OpenStackError as err:

--- a/github-runner-manager/src/github_runner_manager/platform/github_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/github_provider.py
@@ -12,7 +12,7 @@ from pydantic import HttpUrl
 from github_runner_manager.configuration.github import GitHubConfiguration, GitHubRepo
 from github_runner_manager.errors import JobNotFoundError as GithubJobNotFoundError
 from github_runner_manager.github_client import GithubClient
-from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
 from github_runner_manager.platform.platform_provider import (
     JobInfo,
     JobNotFoundError,
@@ -91,13 +91,14 @@ class GitHubRunnerPlatform(PlatformProvider):
             self._client.delete_runner(self._path, runner.id)
 
     def get_runner_token(
-        self, instance_id: InstanceID, labels: list[str]
+        self, metadata: RunnerMetadata, instance_id: InstanceID, labels: list[str]
     ) -> tuple[str, SelfHostedRunner]:
         """Get registration JIT token from GitHub.
 
         This token is used for registering self-hosted runners.
 
         Args:
+            metadata: TODO.
             instance_id: Instance ID of the runner.
             labels: Labels for the runner.
 
@@ -116,10 +117,11 @@ class GitHubRunnerPlatform(PlatformProvider):
         """
         return self._client.get_runner_remove_token(self._path)
 
-    def check_job_been_picked_up(self, job_url: HttpUrl) -> bool:
+    def check_job_been_picked_up(self, metadata: RunnerMetadata, job_url: HttpUrl) -> bool:
         """Check if the job has already been picked up.
 
         Args:
+            metadata: TODO.
             job_url: The URL of the job.
 
         Returns:
@@ -149,10 +151,13 @@ class GitHubRunnerPlatform(PlatformProvider):
         )
         return job_info.status in [*JobPickedUpStates]
 
-    def get_job_info(self, repository: str, workflow_run_id: str, runner: InstanceID) -> JobInfo:
+    def get_job_info(
+        self, metadata: RunnerMetadata, repository: str, workflow_run_id: str, runner: InstanceID
+    ) -> JobInfo:
         """Get the Job info from the provider.
 
         Args:
+            metadata: TODO.
             repository: repository to get the job from.
             workflow_run_id: workflow run id of the job.
             runner: runner to get the job from.

--- a/github-runner-manager/src/github_runner_manager/platform/github_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/github_provider.py
@@ -98,7 +98,7 @@ class GitHubRunnerPlatform(PlatformProvider):
         This token is used for registering self-hosted runners.
 
         Args:
-            metadata: TODO.
+            metadata: Metadata for the runner.
             instance_id: Instance ID of the runner.
             labels: Labels for the runner.
 
@@ -121,7 +121,7 @@ class GitHubRunnerPlatform(PlatformProvider):
         """Check if the job has already been picked up.
 
         Args:
-            metadata: TODO.
+            metadata: Metadata for the runner.
             job_url: The URL of the job.
 
         Returns:
@@ -157,7 +157,7 @@ class GitHubRunnerPlatform(PlatformProvider):
         """Get the Job info from the provider.
 
         Args:
-            metadata: TODO.
+            metadata: Metadata of the runner.
             repository: repository to get the job from.
             workflow_run_id: workflow run id of the job.
             runner: runner to get the job from.

--- a/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
@@ -58,13 +58,13 @@ class JobManagerPlatform(PlatformProvider):
     def get_runner_token(
         self, metadata: RunnerMetadata, instance_id: InstanceID, labels: list[str]
     ) -> tuple[str, SelfHostedRunner]:
-        """Get one time token for a runner.
+        """Get a one time token for a runner.
 
         This token is used for registering self-hosted runners.
 
         Args:
             instance_id: Instance ID of the runner.
-            metadata: TODO.
+            metadata: Metadata for the runner.
             labels: Labels for the runner.
 
         Raises:
@@ -87,7 +87,8 @@ class JobManagerPlatform(PlatformProvider):
 
         Args:
             job_url: The URL of the job.
-            metadata: TODO.
+            metadata: Metadata for the runner.
+
 
         Raises:
             NotImplementedError: Work in progress.
@@ -100,7 +101,7 @@ class JobManagerPlatform(PlatformProvider):
         """Get the Job info from the provider.
 
         Args:
-            metadata: TODO.
+            metadata: Metadata for the runner.
             repository: repository to get the job from.
             workflow_run_id: workflow run id of the job.
             runner: runner to get the job from.

--- a/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
@@ -7,7 +7,7 @@ from typing import Iterable
 
 from pydantic import HttpUrl
 
-from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
 from github_runner_manager.platform.platform_provider import (
     JobInfo,
     PlatformProvider,
@@ -56,14 +56,15 @@ class JobManagerPlatform(PlatformProvider):
         raise NotImplementedError
 
     def get_runner_token(
-        self, instance_id: InstanceID, labels: list[str]
+        self, metadata: RunnerMetadata, instance_id: InstanceID, labels: list[str]
     ) -> tuple[str, SelfHostedRunner]:
-        """Get a token for a runner.
+        """Get one time token for a runner.
 
         This token is used for registering self-hosted runners.
 
         Args:
             instance_id: Instance ID of the runner.
+            metadata: TODO.
             labels: Labels for the runner.
 
         Raises:
@@ -81,21 +82,25 @@ class JobManagerPlatform(PlatformProvider):
         """
         raise NotImplementedError
 
-    def check_job_been_picked_up(self, job_url: HttpUrl) -> bool:
+    def check_job_been_picked_up(self, metadata: RunnerMetadata, job_url: HttpUrl) -> bool:
         """Check if the job has already been picked up.
 
         Args:
             job_url: The URL of the job.
+            metadata: TODO.
 
         Raises:
             NotImplementedError: Work in progress.
         """
         raise NotImplementedError
 
-    def get_job_info(self, repository: str, workflow_run_id: str, runner: InstanceID) -> JobInfo:
+    def get_job_info(
+        self, metadata: RunnerMetadata, repository: str, workflow_run_id: str, runner: InstanceID
+    ) -> JobInfo:
         """Get the Job info from the provider.
 
         Args:
+            metadata: TODO.
             repository: repository to get the job from.
             workflow_run_id: workflow run id of the job.
             runner: runner to get the job from.

--- a/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
@@ -7,11 +7,13 @@ import abc
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum, auto
+
+# Pylint exception needed because of typing forward references.
 from typing import Iterable  # pylint: disable=unused-import
 
 from pydantic import HttpUrl
 
-from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
 from github_runner_manager.types_.github import GitHubRunnerStatus, SelfHostedRunner
 
 
@@ -46,7 +48,7 @@ class PlatformProvider(abc.ABC):
 
     @abc.abstractmethod
     def get_runner_token(
-        self, instance_id: InstanceID, labels: list[str]
+        self, metadata: RunnerMetadata, instance_id: InstanceID, labels: list[str]
     ) -> tuple[str, SelfHostedRunner]:
         """Get one time token for a runner.
 
@@ -54,6 +56,7 @@ class PlatformProvider(abc.ABC):
 
         Args:
             instance_id: Instance ID of the runner.
+            metadata: TODO.
             labels: Labels for the runner.
         """
 
@@ -65,18 +68,22 @@ class PlatformProvider(abc.ABC):
         """
 
     @abc.abstractmethod
-    def check_job_been_picked_up(self, job_url: HttpUrl) -> bool:
+    def check_job_been_picked_up(self, metadata: RunnerMetadata, job_url: HttpUrl) -> bool:
         """Check if the job has already been picked up.
 
         Args:
+            metadata: TODO.
             job_url: The URL of the job.
         """
 
     @abc.abstractmethod
-    def get_job_info(self, repository: str, workflow_run_id: str, runner: InstanceID) -> "JobInfo":
+    def get_job_info(
+        self, metadata: RunnerMetadata, repository: str, workflow_run_id: str, runner: InstanceID
+    ) -> "JobInfo":
         """Get the Job info from the provider.
 
         Args:
+            metadata: TODO.
             repository: repository to get the job from.
             workflow_run_id: workflow run id of the job.
             runner: runner to get the job from.

--- a/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
@@ -50,13 +50,13 @@ class PlatformProvider(abc.ABC):
     def get_runner_token(
         self, metadata: RunnerMetadata, instance_id: InstanceID, labels: list[str]
     ) -> tuple[str, SelfHostedRunner]:
-        """Get one time token for a runner.
+        """Get a one time token for a runner.
 
         This token is used for registering self-hosted runners.
 
         Args:
+            metadata: Metadata for the runner.
             instance_id: Instance ID of the runner.
-            metadata: TODO.
             labels: Labels for the runner.
         """
 
@@ -72,7 +72,7 @@ class PlatformProvider(abc.ABC):
         """Check if the job has already been picked up.
 
         Args:
-            metadata: TODO.
+            metadata: Metadata for the runner.
             job_url: The URL of the job.
         """
 
@@ -83,7 +83,7 @@ class PlatformProvider(abc.ABC):
         """Get the Job info from the provider.
 
         Args:
-            metadata: TODO.
+            metadata: metadata. Always needed at least for the platform selection.
             repository: repository to get the job from.
             workflow_run_id: workflow run id of the job.
             runner: runner to get the job from.

--- a/github-runner-manager/src/github_runner_manager/reactive/consumer.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/consumer.py
@@ -16,6 +16,7 @@ from kombu.exceptions import KombuError
 from kombu.simple import SimpleQueue
 from pydantic import BaseModel, HttpUrl, ValidationError, validator
 
+from github_runner_manager.manager.models import RunnerMetadata
 from github_runner_manager.manager.runner_manager import RunnerManager
 from github_runner_manager.platform.platform_provider import PlatformProvider
 from github_runner_manager.reactive.types_ import QueueConfig
@@ -178,16 +179,17 @@ def _spawn_runner(
         msg: The message to acknowledge or reject.
         platform_provider: Platform provider.
     """
-    if platform_provider.check_job_been_picked_up(job_url=job_url):
+    metadata = RunnerMetadata()
+    if platform_provider.check_job_been_picked_up(metadata=metadata, job_url=job_url):
         msg.ack()
         return
-    instance_ids = runner_manager.create_runners(1, reactive=True)
+    instance_ids = runner_manager.create_runners(1, metadata=metadata, reactive=True)
     if not instance_ids:
         logger.error("Failed to spawn a runner. Will reject the message.")
         msg.reject(requeue=True)
         return
     for _ in range(10):
-        if platform_provider.check_job_been_picked_up(job_url=job_url):
+        if platform_provider.check_job_been_picked_up(metadata=metadata, job_url=job_url):
             msg.ack()
             break
         sleep(30)

--- a/github-runner-manager/src/github_runner_manager/reactive/consumer.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/consumer.py
@@ -137,6 +137,7 @@ def consume(
                     # flavours are sent to the same queue.
                     msg.reject(requeue=False)
                     continue
+                # Defaults as github, needed to select the platform provider.
                 metadata = RunnerMetadata()
                 if platform_provider.check_job_been_picked_up(
                     metadata=metadata, job_url=job_details.url

--- a/github-runner-manager/tests/unit/manager/test_runner_manager.py
+++ b/github-runner-manager/tests/unit/manager/test_runner_manager.py
@@ -13,8 +13,9 @@ from github_runner_manager.manager.cloud_runner_manager import (
     CloudRunnerState,
     HealthState,
 )
-from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
 from github_runner_manager.manager.runner_manager import RunnerManager
+from github_runner_manager.platform.platform_provider import PlatformProvider
 from github_runner_manager.types_.github import GitHubRunnerStatus, SelfHostedRunner
 
 
@@ -110,6 +111,7 @@ def test_cleanup_removes_offline_expected_runners(
             CloudRunnerInstance(
                 name=instance_id.name,
                 instance_id=instance_id,
+                metadata=RunnerMetadata(),
                 health=health,
                 state=cloud_state,
             ),
@@ -147,7 +149,7 @@ def test_failed_runner_in_openstack_cleans_github(monkeypatch: pytest.MonkeyPatc
     cloud_runner_manager = MagicMock()
     cloud_runner_manager.get_runners.return_value = cloud_instances
     cloud_runner_manager.name_prefix = "unit-0"
-    github_provider = MagicMock()
+    github_provider = MagicMock(spec=PlatformProvider)
 
     runner_manager = RunnerManager(
         "managername",
@@ -176,7 +178,7 @@ def test_failed_runner_in_openstack_cleans_github(monkeypatch: pytest.MonkeyPatc
         ),
     ]
 
-    def _get_reg_token(instance_id, labels):
+    def _get_reg_token(instance_id, metadata, labels):
         """Return a registration token."""
         nonlocal github_runner
         github_runner.instance_id = instance_id
@@ -186,5 +188,5 @@ def test_failed_runner_in_openstack_cleans_github(monkeypatch: pytest.MonkeyPatc
     cloud_runner_manager.create_runner.side_effect = RunnerCreateError("")
     github_provider.get_runners.return_value = github_runners
 
-    _ = runner_manager.create_runners(1, True)
+    _ = runner_manager.create_runners(1, RunnerMetadata(), True)
     github_provider.delete_runners.assert_called_once_with([github_runner])

--- a/github-runner-manager/tests/unit/metrics/test_github.py
+++ b/github-runner-manager/tests/unit/metrics/test_github.py
@@ -8,7 +8,7 @@ import pytest
 
 from github_runner_manager.errors import GithubMetricsError, JobNotFoundError
 from github_runner_manager.github_client import GithubClient
-from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
 from github_runner_manager.metrics import github as github_metrics
 from github_runner_manager.metrics.runner import PreJobMetrics
 from github_runner_manager.platform.github_provider import GitHubRunnerPlatform
@@ -52,7 +52,10 @@ def test_job(pre_job_metrics: PreJobMetrics):
         prefix=prefix, path="canonical", github_client=github_client
     )
     job_metrics = github_metrics.job(
-        platform_provider=github_provider, pre_job_metrics=pre_job_metrics, runner=runner
+        platform_provider=github_provider,
+        pre_job_metrics=pre_job_metrics,
+        runner=runner,
+        metadata=RunnerMetadata(),
     )
 
     assert job_metrics.queue_duration == 3600
@@ -75,5 +78,8 @@ def test_job_job_not_found(pre_job_metrics: PreJobMetrics):
 
     with pytest.raises(GithubMetricsError):
         github_metrics.job(
-            platform_provider=github_provider, pre_job_metrics=pre_job_metrics, runner=runner
+            platform_provider=github_provider,
+            metadata=RunnerMetadata(),
+            pre_job_metrics=pre_job_metrics,
+            runner=runner,
         )

--- a/github-runner-manager/tests/unit/metrics/test_runner.py
+++ b/github-runner-manager/tests/unit/metrics/test_runner.py
@@ -10,16 +10,19 @@ from fabric import Connection as SSHConnection
 from invoke.runners import Result
 
 from github_runner_manager.errors import IssueMetricEventError
-from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.cloud_runner_manager import (
+    PostJobMetrics,
+    PostJobStatus,
+    PreJobMetrics,
+    RunnerMetrics,
+)
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
 from github_runner_manager.metrics import events as metric_events
 from github_runner_manager.metrics import runner as runner_metrics
 from github_runner_manager.metrics import type as metrics_type
 from github_runner_manager.metrics.events import RunnerInstalled, RunnerStart, RunnerStop
 from github_runner_manager.metrics.runner import (
-    PostJobMetrics,
-    PreJobMetrics,
     PullFileError,
-    RunnerMetrics,
     ssh_pull_file,
 )
 from github_runner_manager.types_.github import JobConclusion
@@ -60,8 +63,9 @@ def _create_metrics_data(instance_id: InstanceID) -> RunnerMetrics:
             repository="org1/repository1",
             event="push",
         ),
-        post_job=PostJobMetrics(timestamp=3, status=runner_metrics.PostJobStatus.NORMAL),
+        post_job=PostJobMetrics(timestamp=3, status=PostJobStatus.NORMAL),
         instance_id=instance_id,
+        metadata=RunnerMetadata(),
     )
 
 
@@ -168,9 +172,7 @@ def test_issue_events_post_job_before_pre_job(issue_event_mock: MagicMock):
     """
     runner_name = InstanceID.build("prefix")
     runner_metrics_data = _create_metrics_data(runner_name)
-    runner_metrics_data.post_job = PostJobMetrics(
-        timestamp=0, status=runner_metrics.PostJobStatus.NORMAL
-    )
+    runner_metrics_data.post_job = PostJobMetrics(timestamp=0, status=PostJobStatus.NORMAL)
     flavor = secrets.token_hex(16)
     job_metrics = metrics_type.GithubJobMetrics(
         queue_duration=3600, conclusion=JobConclusion.SUCCESS

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from typing import Iterable, Iterator, Sequence
 from unittest.mock import MagicMock
 
+from pydantic import HttpUrl
+
 from github_runner_manager.configuration.github import GitHubPath
 from github_runner_manager.github_client import GithubClient
 from github_runner_manager.manager.cloud_runner_manager import (
@@ -14,9 +16,10 @@ from github_runner_manager.manager.cloud_runner_manager import (
     CloudRunnerManager,
     CloudRunnerState,
 )
-from github_runner_manager.manager.models import InstanceID
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
 from github_runner_manager.metrics.runner import RunnerMetrics
 from github_runner_manager.platform.github_provider import PlatformRunnerState
+from github_runner_manager.platform.platform_provider import JobInfo, PlatformProvider
 from github_runner_manager.types_.github import (
     GitHubRunnerStatus,
     JITConfig,
@@ -222,6 +225,7 @@ class MockRunner:
     Attributes:
         name: The name of the runner.
         instance_id: The instance id of the runner.
+        metadata: TODO.
         cloud_state: The cloud state of the runner.
         github_state: The github state of the runner.
         health: The health state of the runner.
@@ -229,6 +233,7 @@ class MockRunner:
 
     name: str
     instance_id: InstanceID
+    metadata: RunnerMetadata
     cloud_state: CloudRunnerState
     github_state: PlatformRunnerState
     health: bool
@@ -241,6 +246,7 @@ class MockRunner:
         """
         self.name = name
         self.instance_id = secrets.token_hex(6)
+        self.metadata = RunnerMetadata()
         self.cloud_state = CloudRunnerState.ACTIVE
         self.github_state = PlatformRunnerState.IDLE
         self.health = True
@@ -253,6 +259,7 @@ class MockRunner:
         """
         return CloudRunnerInstance(
             name=self.name,
+            metadata=self.metadata,
             instance_id=self.instance_id,
             health=self.health,
             state=self.cloud_state,
@@ -301,12 +308,15 @@ class MockCloudRunnerManager(CloudRunnerManager):
         """Get the name prefix of the self-hosted runners."""
         return self.prefix
 
-    def create_runner(self, instance_id: InstanceID, registration_jittoken: str) -> None:
+    def create_runner(
+        self, metadata: RunnerMetadata, instance_id: InstanceID, runner_token: str
+    ) -> None:
         """Create a self-hosted runner.
 
         Args:
+            metadata: TODO.
             instance_id: Instance ID for the runner to create.
-            registration_jittoken: The GitHub registration token for registering runners.
+            runner_token: The runner token.
         """
         name = f"{self.name_prefix}-{instance_id}"
         runner = MockRunner(name)
@@ -385,7 +395,7 @@ class MockCloudRunnerManager(CloudRunnerManager):
         return [MagicMock()]
 
 
-class MockGitHubRunnerPlatform:
+class MockGitHubRunnerPlatform(PlatformProvider):
     """Mock of GitHubRunnerPlatform.
 
     Attributes:
@@ -410,18 +420,19 @@ class MockGitHubRunnerPlatform:
         self.path = path
 
     def get_runner_token(
-        self, instance_id: str, labels: list[str]
+        self, metadata: RunnerMetadata, instance_id: str, labels: list[str]
     ) -> tuple[str, SelfHostedRunner]:
         """Get the registration JIT token for registering runners on GitHub.
 
         Args:
+            metadata: TODO.
             instance_id: Instance ID of the runner.
             labels: Labels for the runner.
 
         Returns:
             The registration token and the SelfHostedRunner
         """
-        return "mock_registration_token", MagicMock(spec=SelfHostedRunner)
+        return "mock_registration_token", MagicMock(spec=list(SelfHostedRunner.__fields__.keys()))
 
     def get_removal_token(self) -> str:
         """Get the remove token for removing runners on GitHub.
@@ -475,3 +486,31 @@ class MockGitHubRunnerPlatform:
             for instance_id, runner in self.state.runners.items()
             if instance_id.name not in runners_names_to_delete
         }
+
+    def check_job_been_picked_up(self, metadata: RunnerMetadata, job_url: HttpUrl) -> bool:
+        """Check if the job has already been picked up.
+
+        Args:
+            job_url: The URL of the job.
+            metadata: TODO.
+
+        Raises:
+            NotImplementedError: Work in progress.
+        """
+        raise NotImplementedError
+
+    def get_job_info(
+        self, metadata: RunnerMetadata, repository: str, workflow_run_id: str, runner: InstanceID
+    ) -> JobInfo:
+        """Get the Job info from the provider.
+
+        Args:
+            metadata: TODO.
+            repository: repository to get the job from.
+            workflow_run_id: workflow run id of the job.
+            runner: runner to get the job from.
+
+        Raises:
+            NotImplementedError: Work in progress.
+        """
+        raise NotImplementedError

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -225,7 +225,7 @@ class MockRunner:
     Attributes:
         name: The name of the runner.
         instance_id: The instance id of the runner.
-        metadata: TODO.
+        metadata: Metadata of the server.
         cloud_state: The cloud state of the runner.
         github_state: The github state of the runner.
         health: The health state of the runner.
@@ -309,13 +309,13 @@ class MockCloudRunnerManager(CloudRunnerManager):
         return self.prefix
 
     def create_runner(
-        self, metadata: RunnerMetadata, instance_id: InstanceID, runner_token: str
+        self, instance_id: InstanceID, metadata: RunnerMetadata, runner_token: str
     ) -> None:
         """Create a self-hosted runner.
 
         Args:
-            metadata: TODO.
             instance_id: Instance ID for the runner to create.
+            metadata: Metadata for the runner.
             runner_token: The runner token.
         """
         name = f"{self.name_prefix}-{instance_id}"
@@ -425,7 +425,7 @@ class MockGitHubRunnerPlatform(PlatformProvider):
         """Get the registration JIT token for registering runners on GitHub.
 
         Args:
-            metadata: TODO.
+            metadata: Metadata of the server.
             instance_id: Instance ID of the runner.
             labels: Labels for the runner.
 
@@ -491,8 +491,8 @@ class MockGitHubRunnerPlatform(PlatformProvider):
         """Check if the job has already been picked up.
 
         Args:
+            metadata: Metadata of the instance.
             job_url: The URL of the job.
-            metadata: TODO.
 
         Raises:
             NotImplementedError: Work in progress.
@@ -505,7 +505,7 @@ class MockGitHubRunnerPlatform(PlatformProvider):
         """Get the Job info from the provider.
 
         Args:
-            metadata: TODO.
+            metadata: Metadata of the runner.
             repository: repository to get the job from.
             workflow_run_id: workflow run id of the job.
             runner: runner to get the job from.

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_cloud.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_cloud.py
@@ -19,7 +19,7 @@ FAKE_ARG = "fake"
 @pytest.mark.parametrize(
     "public_method, args",
     [
-        pytest.param("launch_instance", (FAKE_ARG,) * 6, id="launch_instance"),
+        pytest.param("launch_instance", (FAKE_ARG,) * 4, id="launch_instance"),
         pytest.param("get_instance", (FAKE_ARG,), id="get_instance"),
         pytest.param("delete_instance", (FAKE_ARG,), id="delete_instance"),
         pytest.param("get_instances", (), id="get_instances"),

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_cloud.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_cloud.py
@@ -19,7 +19,7 @@ FAKE_ARG = "fake"
 @pytest.mark.parametrize(
     "public_method, args",
     [
-        pytest.param("launch_instance", (FAKE_ARG,) * 5, id="launch_instance"),
+        pytest.param("launch_instance", (FAKE_ARG,) * 6, id="launch_instance"),
         pytest.param("get_instance", (FAKE_ARG,), id="get_instance"),
         pytest.param("delete_instance", (FAKE_ARG,), id="delete_instance"),
         pytest.param("get_instances", (), id="get_instances"),

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
@@ -100,7 +100,7 @@ def test_create_runner_with_aproxy(
     openstack_cloud = MagicMock(spec=OpenstackCloud)
     monkeypatch.setattr(runner_manager, "_openstack_cloud", openstack_cloud)
 
-    runner_manager.create_runner(metadata, instance_id, registration_jittoken)
+    runner_manager.create_runner(instance_id, metadata, registration_jittoken)
     openstack_cloud.launch_instance.assert_called_once()
     assert (
         "snap set aproxy proxy=proxy.example.com:3128"
@@ -131,7 +131,7 @@ def test_create_runner_without_aproxy(
     openstack_cloud = MagicMock(spec=OpenstackCloud)
     monkeypatch.setattr(runner_manager, "_openstack_cloud", openstack_cloud)
 
-    runner_manager.create_runner(metadata, instance_id, registration_jittoken)
+    runner_manager.create_runner(instance_id, metadata, registration_jittoken)
     openstack_cloud.launch_instance.assert_called_once()
     assert "aproxy" not in openstack_cloud.launch_instance.call_args.kwargs["cloud_init"]
 

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
@@ -12,15 +12,17 @@ import pytest
 
 from github_runner_manager.configuration import ProxyConfig, SupportServiceConfig
 from github_runner_manager.errors import OpenstackHealthCheckError
-from github_runner_manager.manager.models import InstanceID
-from github_runner_manager.metrics import runner
-from github_runner_manager.metrics.runner import (
+from github_runner_manager.manager.cloud_runner_manager import (
     CodeInformation,
     PostJobMetrics,
     PostJobStatus,
     PreJobMetrics,
-    PullFileError,
     RunnerMetrics,
+)
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
+from github_runner_manager.metrics import runner
+from github_runner_manager.metrics.runner import (
+    PullFileError,
 )
 from github_runner_manager.openstack_cloud import (
     health_checks,
@@ -91,13 +93,14 @@ def test_create_runner_with_aproxy(
     prefix = "test"
     registration_jittoken = "jittoken"
     instance_id = InstanceID.build(prefix=prefix)
+    metadata = RunnerMetadata()
     monkeypatch.setattr(runner_manager, "_wait_runner_startup", MagicMock(return_value=None))
     monkeypatch.setattr(runner_manager, "_wait_runner_running", MagicMock(return_value=None))
 
-    openstack_cloud = MagicMock()
+    openstack_cloud = MagicMock(spec=OpenstackCloud)
     monkeypatch.setattr(runner_manager, "_openstack_cloud", openstack_cloud)
 
-    runner_manager.create_runner(instance_id, registration_jittoken)
+    runner_manager.create_runner(metadata, instance_id, registration_jittoken)
     openstack_cloud.launch_instance.assert_called_once()
     assert (
         "snap set aproxy proxy=proxy.example.com:3128"
@@ -121,13 +124,14 @@ def test_create_runner_without_aproxy(
     prefix = "test"
     registration_jittoken = "jittoken"
     instance_id = InstanceID.build(prefix=prefix)
+    metadata = RunnerMetadata()
     monkeypatch.setattr(runner_manager, "_wait_runner_startup", MagicMock(return_value=None))
     monkeypatch.setattr(runner_manager, "_wait_runner_running", MagicMock(return_value=None))
 
-    openstack_cloud = MagicMock()
+    openstack_cloud = MagicMock(spec=OpenstackCloud)
     monkeypatch.setattr(runner_manager, "_openstack_cloud", openstack_cloud)
 
-    runner_manager.create_runner(instance_id, registration_jittoken)
+    runner_manager.create_runner(metadata, instance_id, registration_jittoken)
     openstack_cloud.launch_instance.assert_called_once()
     assert "aproxy" not in openstack_cloud.launch_instance.call_args.kwargs["cloud_init"]
 
@@ -232,6 +236,7 @@ def _params_test_cleanup_extract_metrics():
                     ),
                     installation_start_timestamp=openstack_created_at,
                     installed_timestamp=openstack_installed_at,
+                    metadata=RunnerMetadata(),
                 ),
             ],
             id="Only installed_timestamp. Metric returned.",
@@ -254,6 +259,7 @@ def _params_test_cleanup_extract_metrics():
                         repository="canonical/github-runner-operator",
                         event="workflow_dispatch",
                     ),
+                    metadata=RunnerMetadata(),
                 ),
             ],
             id="installed_timestamp and pre_job_metrics. Metric returned.",
@@ -264,6 +270,7 @@ def _params_test_cleanup_extract_metrics():
             post_job_metrics_str,
             [
                 RunnerMetrics(
+                    metadata=RunnerMetadata(),
                     instance_id=InstanceID(
                         prefix=OPENSTACK_INSTANCE_PREFIX, reactive=False, suffix="unhealthy"
                     ),

--- a/github-runner-manager/tests/unit/reactive/test_consumer.py
+++ b/github-runner-manager/tests/unit/reactive/test_consumer.py
@@ -5,7 +5,7 @@ import secrets
 from contextlib import closing
 from datetime import datetime, timezone
 from random import randint
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 from kombu import Connection, Message
@@ -68,7 +68,7 @@ def test_consume(labels: Labels, supported_labels: Labels, queue_config: QueueCo
         supported_labels=supported_labels,
     )
 
-    runner_manager_mock.create_runners.assert_called_once_with(1, reactive=True)
+    runner_manager_mock.create_runners.assert_called_once_with(1, metadata=ANY, reactive=True)
 
     _assert_queue_is_empty(queue_config.queue_name)
 

--- a/github-runner-manager/tests/unit/test_runner_scaler.py
+++ b/github-runner-manager/tests/unit/test_runner_scaler.py
@@ -119,7 +119,6 @@ def runner_manager_fixture(
 
     runner_manager = RunnerManager(
         manager_name="mock_runners",
-        # GitHubConfiguration(token="mock_token", path=github_path),
         platform_provider=mock_github,
         cloud_runner_manager=mock_cloud,
         labels=["label1", "label2", "arm64", "noble", "flavorlabel"],

--- a/github-runner-manager/tests/unit/test_runner_scaler.py
+++ b/github-runner-manager/tests/unit/test_runner_scaler.py
@@ -45,9 +45,9 @@ from github_runner_manager.openstack_cloud.configuration import (
     OpenStackConfiguration,
     OpenStackCredentials,
 )
+from github_runner_manager.openstack_cloud.models import OpenStackServerConfig
 from github_runner_manager.openstack_cloud.openstack_runner_manager import (
     OpenStackRunnerManagerConfig,
-    OpenStackServerConfig,
 )
 from github_runner_manager.platform.github_provider import PlatformRunnerState
 from github_runner_manager.reactive.types_ import ReactiveProcessConfig

--- a/src/charm.py
+++ b/src/charm.py
@@ -77,6 +77,7 @@ FAILED_TO_RECONCILE_RUNNERS_MSG = "Failed to reconcile runners"
 FAILED_RECONCILE_ACTION_ERR_MSG = (
     "Failed to reconcile runners. Look at the juju logs for more information."
 )
+UPGRADE_MSG = "Upgrading github-runner charm."
 
 
 logger = logging.getLogger(__name__)
@@ -295,7 +296,7 @@ class GithubRunnerCharm(CharmBase):
     @catch_charm_errors
     def _on_upgrade_charm(self, _: UpgradeCharmEvent) -> None:
         """Handle the update of charm."""
-        logger.info("Reinstalling dependencies...")
+        logger.info(UPGRADE_MSG)
         self._common_install_code()
 
     @catch_charm_errors

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -343,7 +343,7 @@ async def openstack_model_proxy(
             "juju-http-proxy": openstack_http_proxy,
             "juju-https-proxy": openstack_https_proxy,
             "juju-no-proxy": openstack_no_proxy,
-            "logging-config": "<root>=INFO;unit=DEBUG",
+            "logging-config": "<root>=INFO;unit=INFO",
         }
     )
 

--- a/tests/integration/helpers/charm_metrics.py
+++ b/tests/integration/helpers/charm_metrics.py
@@ -14,8 +14,8 @@ from github.GithubException import GithubException
 from github.Repository import Repository
 from github.Workflow import Workflow
 from github.WorkflowJob import WorkflowJob
+from github_runner_manager.manager.cloud_runner_manager import PostJobStatus
 from github_runner_manager.metrics.events import METRICS_LOG_PATH
-from github_runner_manager.metrics.runner import PostJobStatus
 from github_runner_manager.types_.github import JobConclusion
 from juju.application import Application
 from juju.unit import Unit

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -131,7 +131,7 @@ async def deploy_github_runner_charm(
             "juju-http-proxy": http_proxy,
             "juju-https-proxy": https_proxy,
             "juju-no-proxy": no_proxy,
-            "logging-config": "<root>=INFO;unit=DEBUG",
+            "logging-config": "<root>=INFO;unit=INFO",
         }
     )
 

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -24,6 +24,7 @@ from juju.application import Application
 from juju.model import Model
 from juju.unit import Unit
 
+from charm import UPGRADE_MSG
 from charm_state import (
     BASE_VIRTUAL_MACHINES_CONFIG_NAME,
     PATH_CONFIG_NAME,
@@ -392,10 +393,10 @@ async def is_upgrade_charm_event_emitted(unit: Unit) -> bool:
     unit_name_without_slash = unit.name.replace("/", "-")
     juju_unit_log_file = f"/var/log/juju/unit-{unit_name_without_slash}.log"
     ret_code, stdout, stderr = await run_in_unit(
-        unit=unit, command=f"cat {juju_unit_log_file} | grep 'Emitting Juju event upgrade_charm.'"
+        unit=unit, command=f"cat {juju_unit_log_file} | grep '{UPGRADE_MSG}'"
     )
     assert ret_code == 0, f"Failed to read the log file: {stderr}"
-    return stdout is not None and "Emitting Juju event upgrade_charm." in stdout
+    return stdout is not None and UPGRADE_MSG in stdout
 
 
 async def get_file_content(unit: Unit, filepath: pathlib.Path) -> str:

--- a/tests/integration/test_charm_metrics_failure.py
+++ b/tests/integration/test_charm_metrics_failure.py
@@ -10,7 +10,7 @@ import pytest
 import pytest_asyncio
 from github.Branch import Branch
 from github.Repository import Repository
-from github_runner_manager.metrics.runner import PostJobStatus
+from github_runner_manager.manager.cloud_runner_manager import PostJobStatus
 from juju.application import Application
 from juju.model import Model
 

--- a/tests/integration/test_charm_metrics_success.py
+++ b/tests/integration/test_charm_metrics_success.py
@@ -10,7 +10,7 @@ import pytest
 import pytest_asyncio
 from github.Branch import Branch
 from github.Repository import Repository
-from github_runner_manager.metrics.runner import PostJobStatus
+from github_runner_manager.manager.cloud_runner_manager import PostJobStatus
 from juju.application import Application
 from juju.model import Model
 

--- a/tests/integration/test_charm_upgrade.py
+++ b/tests/integration/test_charm_upgrade.py
@@ -52,7 +52,7 @@ async def test_charm_upgrade(
     assert: the charm is upgraded successfully.
     """
     latest_stable_path = tmp_path / "github-runner.charm"
-    latest_stable_revision = 302  # update this value every release to stable.
+    latest_stable_revision = 354  # update this value every release to stable.
     # download the charm
     retcode, stdout, stderr = await ops_test.juju(
         "download",
@@ -96,7 +96,7 @@ async def test_charm_upgrade(
         apps=[application.name, image_builder.name],
         raise_on_error=False,
         wait_for_active=True,
-        timeout=20 * 60,
+        timeout=25 * 60,
         check_freq=30,
     )
     origin = client.CharmOrigin(

--- a/tests/integration/test_reactive.py
+++ b/tests/integration/test_reactive.py
@@ -10,7 +10,7 @@ import pytest
 import pytest_asyncio
 from github import Branch, Repository
 from github.WorkflowRun import WorkflowRun
-from github_runner_manager.metrics.runner import PostJobStatus
+from github_runner_manager.manager.cloud_runner_manager import PostJobStatus
 from github_runner_manager.reactive.consumer import JobDetails
 from juju.application import Application
 from juju.model import Model

--- a/tests/integration/test_runner_manager_openstack.py
+++ b/tests/integration/test_runner_manager_openstack.py
@@ -31,13 +31,11 @@ from github_runner_manager.manager.runner_manager import FlushMode, RunnerManage
 from github_runner_manager.metrics import events
 from github_runner_manager.openstack_cloud import constants, health_checks
 from github_runner_manager.openstack_cloud.models import (
+    OpenStackCredentials,
     OpenStackRunnerManagerConfig,
     OpenStackServerConfig,
 )
-from github_runner_manager.openstack_cloud.openstack_runner_manager import (
-    OpenStackCredentials,
-    OpenStackRunnerManager,
-)
+from github_runner_manager.openstack_cloud.openstack_runner_manager import OpenStackRunnerManager
 from github_runner_manager.platform.github_provider import (
     GitHubRunnerPlatform,
     PlatformRunnerState,

--- a/tests/integration/test_runner_manager_openstack.py
+++ b/tests/integration/test_runner_manager_openstack.py
@@ -318,6 +318,7 @@ async def test_runner_normal_idle_lifecycle(
     runner = runner_list[0]
     assert runner.instance_id == runner_id
     assert runner.cloud_state == CloudRunnerState.ACTIVE
+    assert runner.metadata.platform_name == "github"
     # Update on GitHub-side can take a bit of time.
     await wait_for(
         lambda: runner_manager.get_runners()[0].github_state == PlatformRunnerState.IDLE,

--- a/tests/integration/test_runner_manager_openstack.py
+++ b/tests/integration/test_runner_manager_openstack.py
@@ -26,6 +26,7 @@ from github_runner_manager.configuration.github import (
     parse_github_path,
 )
 from github_runner_manager.manager.cloud_runner_manager import CloudRunnerState
+from github_runner_manager.manager.models import RunnerMetadata
 from github_runner_manager.manager.runner_manager import FlushMode, RunnerManager
 from github_runner_manager.metrics import events
 from github_runner_manager.openstack_cloud import constants, health_checks
@@ -205,7 +206,7 @@ async def runner_manager_fixture(
 
 @pytest_asyncio.fixture(scope="function", name="runner_manager_with_one_runner")
 async def runner_manager_with_one_runner_fixture(runner_manager: RunnerManager) -> RunnerManager:
-    runner_manager.create_runners(1)
+    runner_manager.create_runners(1, RunnerMetadata())
     runner_list = runner_manager.get_runners()
     try:
         await wait_runner_amount(runner_manager, 1)
@@ -301,7 +302,7 @@ async def test_runner_normal_idle_lifecycle(
         4. No runners.
     """
     # 1.
-    runner_id_list = runner_manager.create_runners(1)
+    runner_id_list = runner_manager.create_runners(1, RunnerMetadata())
     assert isinstance(runner_id_list, tuple)
     assert len(runner_id_list) == 1
     runner_id = runner_id_list[0]
@@ -521,7 +522,7 @@ async def test_runner_spawn_two(
         2. No runners.
     """
     # 1.
-    runner_id_list = runner_manager.create_runners(2)
+    runner_id_list = runner_manager.create_runners(2, RunnerMetadata())
     assert isinstance(runner_id_list, tuple)
     assert len(runner_id_list) == 2
 

--- a/tests/integration/test_runner_manager_openstack.py
+++ b/tests/integration/test_runner_manager_openstack.py
@@ -30,11 +30,13 @@ from github_runner_manager.manager.models import RunnerMetadata
 from github_runner_manager.manager.runner_manager import FlushMode, RunnerManager
 from github_runner_manager.metrics import events
 from github_runner_manager.openstack_cloud import constants, health_checks
+from github_runner_manager.openstack_cloud.models import (
+    OpenStackRunnerManagerConfig,
+    OpenStackServerConfig,
+)
 from github_runner_manager.openstack_cloud.openstack_runner_manager import (
     OpenStackCredentials,
     OpenStackRunnerManager,
-    OpenStackRunnerManagerConfig,
-    OpenStackServerConfig,
 )
 from github_runner_manager.platform.github_provider import (
     GitHubRunnerPlatform,


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Several things are tackled in this PR:
- New RunnerMetadata class to have "metadata" about a runner, that is platform name. Mainly id about the runner and the url.
 - Put metadata in the instance, to identify prefix, platform provider (github or jobmanager in the following pr), runner id and possible url for the platform provider.
 - Get that metadata every time one runnes is obtained from openstack, as we may need to use it to select the provider when there are more than one.
 - Put all the classes used in the cloud cloud_runner_manager module (the cloud api) in that file, as they are scattered in metrics modules, but it is really part of the interface. Maybe we can find a better place/naming in a following PR.

As it is now, there is an overlap in InstanceID and RunnerMetadata. Up to now, all matching between instances in cloud and platform are done with the InstanceID, but from now, the RunnerMetadata will be used in more places. Pending to review the uses, and maybe integrating both concepts of removing the InstanceID importance.

The following PR will create a new platform provider that will build upon the common interface for platforms.

### Rationale

This is another refactor for adapting the github-runner to be able to use both platform provider, that is, github and the jobmanager. To know whether a runner uses one provider of the other, we will store information in the openstack metadata. For the jobmanager we would also put there the URL of the job (the runner), so we can use it to get the token, health checks, metrics...

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->