### PR TITLE
Remove SSH creation health checks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2025-04-29
+
+- For reactive runners, once the runner is spawned and online, the number of checks to see if the job has been picked up
+  before acknowledging the webrouter message is reduced -from up to 10 checks to 5, and from up to 5 minutes to 2.5 minutes.
+
 ### 2025-04-22
 
 - Add how-to landing page.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,6 @@
 # Changelog
 
 
-### 2025-04-29
-
-- For reactive runners, once the runner is spawned and online, the number of checks to see if the job has been picked up
-  before acknowledging the webrouter message is reduced -from up to 10 checks to 5, and from up to 5 minutes to 2.5 minutes.
-
 ### 2025-04-28
 
 - Add a visualization of the share of jobs started per application.

--- a/github-runner-manager/src/github_runner_manager/errors.py
+++ b/github-runner-manager/src/github_runner_manager/errors.py
@@ -46,7 +46,7 @@ class TokenError(PlatformClientError):
 
 
 class JobNotFoundError(PlatformClientError):
-    """Represents an error when the job could not be found on GitHub."""
+    """Represents an error when the job could not be found on the platform."""
 
 
 class CloudError(Exception):

--- a/github-runner-manager/src/github_runner_manager/errors.py
+++ b/github-runner-manager/src/github_runner_manager/errors.py
@@ -13,10 +13,6 @@ class RunnerCreateError(RunnerError):
     """Error for runner creation failure."""
 
 
-class RunnerStartError(RunnerError):
-    """Error for runner start failure."""
-
-
 class MissingServerConfigError(RunnerError):
     """Error for unable to create runner due to missing server configurations."""
 

--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -97,26 +97,20 @@ class GithubClient:
         self._client = GhApi(token=self._token)
 
     @catch_http_errors
-    def get_runner_info(self, path: GitHubPath, prefix: str, runner_id: int) -> SelfHostedRunner:
-        """TODO.
-
-        https://docs.github.com/en/rest/actions/self-hosted-runners?
-        apiVersion=2022-11-28#get-a-self-hosted-runner-for-an-organization
-        /orgs/{org}/actions/runners/{runner_id}
-        https://docs.github.com/en/rest/actions/self-hosted-runners?
-        apiVersion=2022-11-28#get-a-self-hosted-runner-for-a-repository
-        /repos/{owner}/{repo}/actions/runners/{runner_id}
+    def get_runner(self, path: GitHubPath, prefix: str, runner_id: int) -> SelfHostedRunner:
+        """Get a specific self-hosted runner information under a repo or org.
 
         Args:
-            path: TODO
-            prefix: TODO
-            runner_id: TODO
+            path: GitHub repository path in the format '<owner>/<repo>', or the GitHub organization
+                name.
+            prefix: Build the InstanceID with this prefix.
+            runner_id: Runner id to get the self hosted runner.
 
         Raises:
-            GithubRunnerNotFoundError: TODO
+            GithubRunnerNotFoundError: If the runner is not found.
 
         Returns:
-            TODO
+            The information for the requested runner.
         """
         try:
             if isinstance(path, GitHubRepo):
@@ -133,8 +127,8 @@ class GithubClient:
         return SelfHostedRunner.build_from_github(raw_runner, instance_id)
 
     @catch_http_errors
-    def get_runner_github_info(self, path: GitHubPath, prefix: str) -> list[SelfHostedRunner]:
-        """Get runner information on GitHub under a repo or org.
+    def list_runners(self, path: GitHubPath, prefix: str) -> list[SelfHostedRunner]:
+        """Get all runners information on GitHub under a repo or org.
 
         Args:
             path: GitHub repository path in the format '<owner>/<repo>', or the GitHub organization

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -27,9 +27,8 @@ from github_runner_manager.metrics.runner import RunnerMetrics
 from github_runner_manager.platform.platform_provider import (
     PlatformProvider,
     PlatformRunnerState,
-    RunnerNotFoundError,
 )
-from github_runner_manager.types_.github import GitHubRunnerStatus, SelfHostedRunner
+from github_runner_manager.types_.github import SelfHostedRunner
 
 logger = logging.getLogger(__name__)
 
@@ -516,18 +515,12 @@ class RunnerManager:
         """TODO."""
         for wait_time in RUNNER_CREATION_WAITING_TIMES:
             time.sleep(wait_time)
-            try:
-                runner = platform_provider.get_runner(metadata, instance_id)
-            except RunnerNotFoundError:
-                # TODO SHOULD WE RAISE RunnerError in here? We expect a runner to be in the
-                # platform, and we will save time...
-                logger.error("JAVI Runner not found")
-                break
-            logger.info("JAVI github runner %s", runner)
+            runner_health = platform_provider.get_runner_health(metadata, instance_id)
+            logger.info("JAVI github runner health %s", runner_health)
             # TODO REVIEW THE ONLINE THING FOR JOBMANAGER. WHAT IS ONLINE
             # AND OFFLINE IN THAT CASE?
-            if runner.status == GitHubRunnerStatus.ONLINE or runner.deletable:
-                logger.info("JAVI nice! runner online!")
+            if runner_health.online or runner_health.deletable:
+                logger.info("JAVI nice! runner online or deletable!. No need to wait!")
                 break
         else:
             logger.info("JAVI grrr runner never got online!")

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -529,7 +529,7 @@ class RunnerManager:
             if runner.status == GitHubRunnerStatus.ONLINE or runner.deletable:
                 logger.info("JAVI nice! runner online!")
                 break
-            time.sleep(60)
+            time.sleep(wait_time)
         else:
             logger.info("JAVI grrr runner never got online!")
             raise RunnerError("Runner did not get online")

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -492,7 +492,7 @@ class RunnerManager:
             # TODO WAIT FOR RUNNER ONLINE IN HERE!
             # TODO THIS CODE SHOULD DISAPPEAR AND ONLY WAIT FOR THE RUNNER IN REACTIVE MOD
             # (TO CHECK IF THE JOB WAS TAKEN)
-            RunnerManager._wait_for_runner_online(
+            RunnerManager.wait_for_runner_online(
                 platform_provider=args.platform_provider,
                 instance_id=instance_id,
                 metadata=args.metadata,
@@ -507,15 +507,27 @@ class RunnerManager:
         return instance_id
 
     @staticmethod
-    def _wait_for_runner_online(
+    def wait_for_runner_online(
         platform_provider: PlatformProvider,
         instance_id: InstanceID,
         metadata: RunnerMetadata,
     ) -> None:
-        """TODO."""
+        """TODO.
+
+        Args:
+            platform_provider: TODO
+            instance_id: TODO
+            metadata: TODO
+
+        Raises:
+            RunnerError: If runner did not come online.
+
+        """
         for wait_time in RUNNER_CREATION_WAITING_TIMES:
             time.sleep(wait_time)
-            runner_health = platform_provider.get_runner_health(metadata, instance_id)
+            runner_health = platform_provider.get_runner_health(
+                metadata=metadata, instance_id=instance_id
+            )
             logger.info("JAVI github runner health %s", runner_health)
             # TODO REVIEW THE ONLINE THING FOR JOBMANAGER. WHAT IS ONLINE
             # AND OFFLINE IN THAT CASE?

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -528,9 +528,13 @@ class RunnerManager:
         """
         for wait_time in RUNNER_CREATION_WAITING_TIMES:
             time.sleep(wait_time)
-            runner_health = platform_provider.get_runner_health(
-                metadata=metadata, instance_id=instance_id
-            )
+            try:
+                runner_health = platform_provider.get_runner_health(
+                    metadata=metadata, instance_id=instance_id
+                )
+            except PlatformApiError as exc:
+                logger.error("Error getting the runner health: %s", exc)
+                continue
             if runner_health.online or runner_health.deletable:
                 break
         else:

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -529,7 +529,6 @@ class RunnerManager:
             if runner.status == GitHubRunnerStatus.ONLINE or runner.deletable:
                 logger.info("JAVI nice! runner online!")
                 break
-            time.sleep(wait_time)
         else:
             logger.info("JAVI grrr runner never got online!")
             raise RunnerError("Runner did not get online")

--- a/github-runner-manager/src/github_runner_manager/platform/github_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/github_provider.py
@@ -11,13 +11,14 @@ from pydantic import HttpUrl
 
 from github_runner_manager.configuration.github import GitHubConfiguration, GitHubRepo
 from github_runner_manager.errors import JobNotFoundError as GithubJobNotFoundError
-from github_runner_manager.github_client import GithubClient
+from github_runner_manager.github_client import GithubClient, GithubRunnerNotFoundError
 from github_runner_manager.manager.models import InstanceID, RunnerContext, RunnerMetadata
 from github_runner_manager.platform.platform_provider import (
     JobInfo,
     JobNotFoundError,
     PlatformProvider,
     PlatformRunnerState,
+    RunnerNotFoundError,
 )
 from github_runner_manager.types_.github import SelfHostedRunner
 
@@ -57,6 +58,32 @@ class GitHubRunnerPlatform(PlatformProvider):
             path=github_configuration.path,
             github_client=GithubClient(github_configuration.token),
         )
+
+    def get_runner(
+        self,
+        metadata: RunnerMetadata,
+        instance_id: InstanceID,
+    ) -> SelfHostedRunner:
+        """Get info on self-hosted runner.
+
+        Args:
+            metadata: Metadata for the runner.
+            instance_id: Instance ID of the runner.
+
+        Raises:
+            RunnerNotFoundError: Work in progress.
+
+        Returns:
+            TODO
+        """
+        try:
+            runner = self._client.get_runner_info(
+                self._path, self._prefix, int(metadata.runner_id)
+            )
+        except GithubRunnerNotFoundError:
+            raise RunnerNotFoundError from GithubRunnerNotFoundError
+
+        return runner
 
     def get_runners(
         self, states: Iterable[PlatformRunnerState] | None = None

--- a/github-runner-manager/src/github_runner_manager/platform/github_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/github_provider.py
@@ -77,9 +77,7 @@ class GitHubRunnerPlatform(PlatformProvider):
             TODO
         """
         try:
-            runner = self._client.get_runner_info(
-                self._path, self._prefix, int(metadata.runner_id)
-            )
+            runner = self._client.get_runner(self._path, self._prefix, int(metadata.runner_id))
         except GithubRunnerNotFoundError:
             raise RunnerNotFoundError from GithubRunnerNotFoundError
 
@@ -96,7 +94,7 @@ class GitHubRunnerPlatform(PlatformProvider):
         Returns:
             Information on the runners.
         """
-        runner_list = self._client.get_runner_github_info(self._path, self._prefix)
+        runner_list = self._client.list_runners(self._path, self._prefix)
 
         if states is None:
             return tuple(runner_list)

--- a/github-runner-manager/src/github_runner_manager/platform/github_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/github_provider.py
@@ -76,10 +76,22 @@ class GitHubRunnerPlatform(PlatformProvider):
         try:
             runner = self._client.get_runner(self._path, self._prefix, int(metadata.runner_id))
             online = runner.status == GitHubRunnerStatus.ONLINE
-            return PlatformRunnerHealth(online=online, busy=runner.busy, deletable=False)
+            return PlatformRunnerHealth(
+                instance_id=instance_id,
+                metadata=metadata,
+                online=online,
+                busy=runner.busy,
+                deletable=False,
+            )
 
         except GithubRunnerNotFoundError:
-            return PlatformRunnerHealth(online=False, busy=False, deletable=True)
+            return PlatformRunnerHealth(
+                instance_id=instance_id,
+                metadata=metadata,
+                online=False,
+                busy=False,
+                deletable=True,
+            )
 
     def get_runners(
         self, states: Iterable[PlatformRunnerState] | None = None

--- a/github-runner-manager/src/github_runner_manager/platform/github_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/github_provider.py
@@ -64,7 +64,7 @@ class GitHubRunnerPlatform(PlatformProvider):
         metadata: RunnerMetadata,
         instance_id: InstanceID,
     ) -> PlatformRunnerHealth:
-        """Get info on self-hosted runner.
+        """Get information on the health of a github runner.
 
         Args:
             metadata: Metadata for the runner.

--- a/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
@@ -82,7 +82,7 @@ class JobManagerPlatform(PlatformProvider):
             id=int(metadata.runner_id),
             metadata=metadata,
             # TODO unfortunately, we only have one label.
-            labels=[response.label],
+            labels=[SelfHostedRunnerLabel(response.label)],
             # status
             status=status,
             instance_id=instance_id,

--- a/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
@@ -70,11 +70,19 @@ class JobManagerPlatform(PlatformProvider):
                 raise PlatformApiError("API error") from exc
 
         # response.status one of: PENDING, IN_PROGRESS, COMPLETED, FAILED, CANCELLED
-        online = response.status in ["PENDING", "IN_PROGRESS", "COMPLETED"]
+        # TODO review this.
+        online = response.status not in ["PENDING", "FAILED"]
         deletable = response.deletable
-        busy = not deletable or response.status in ["PENDING", "IN_PROGRESS"]
+        # TODO review this.
+        busy = not deletable or response.status in ["IN_PROGRESS"]
 
-        return PlatformRunnerHealth(online=online, deletable=deletable, busy=busy)
+        return PlatformRunnerHealth(
+            instance_id=instance_id,
+            metadata=metadata,
+            online=online,
+            deletable=deletable,
+            busy=busy,
+        )
 
     def get_runners(
         self, states: Iterable[PlatformRunnerState] | None = None

--- a/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
@@ -70,11 +70,11 @@ class JobManagerPlatform(PlatformProvider):
                 raise PlatformApiError("API error") from exc
 
         # response.status one of: PENDING, IN_PROGRESS, COMPLETED, FAILED, CANCELLED
-        # TODO review this.
+        # TODO review this. I do not know what to use :(
         online = response.status not in ["PENDING", "FAILED"]
+        busy = response.status in ["IN_PROGRESS"]
         deletable = response.deletable
         # TODO review this.
-        busy = not deletable or response.status in ["IN_PROGRESS"]
 
         return PlatformRunnerHealth(
             instance_id=instance_id,

--- a/github-runner-manager/src/github_runner_manager/platform/multiplexer_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/multiplexer_provider.py
@@ -15,6 +15,7 @@ from github_runner_manager.platform.jobmanager_provider import JobManagerPlatfor
 from github_runner_manager.platform.platform_provider import (
     JobInfo,
     PlatformProvider,
+    PlatformRunnerHealth,
     PlatformRunnerState,
 )
 from github_runner_manager.types_.github import SelfHostedRunner
@@ -54,21 +55,21 @@ class MultiplexerPlatform(PlatformProvider):
         jobmanager_platform = JobManagerPlatform.build()
         return cls({"github": github_platform, "jobmanager": jobmanager_platform})
 
-    def get_runner(
+    def get_runner_health(
         self,
         metadata: RunnerMetadata,
         instance_id: InstanceID,
-    ) -> SelfHostedRunner:
-        """Get info on self-hosted runner.
+    ) -> PlatformRunnerHealth:
+        """Get health information on self-hosted runner.
 
         Args:
             metadata: Metadata for the runner.
             instance_id: Instance ID of the runner.
 
         Returns:
-            Platform Runner information.
+            Platform Runner Health information.
         """
-        return self._get_provider(metadata).get_runner(metadata, instance_id)
+        return self._get_provider(metadata).get_runner_health(metadata, instance_id)
 
     def get_runners(
         self, states: Iterable[PlatformRunnerState] | None = None

--- a/github-runner-manager/src/github_runner_manager/platform/multiplexer_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/multiplexer_provider.py
@@ -54,6 +54,22 @@ class MultiplexerPlatform(PlatformProvider):
         jobmanager_platform = JobManagerPlatform.build()
         return cls({"github": github_platform, "jobmanager": jobmanager_platform})
 
+    def get_runner(
+        self,
+        metadata: RunnerMetadata,
+        instance_id: InstanceID,
+    ) -> SelfHostedRunner:
+        """Get info on self-hosted runner.
+
+        Args:
+            metadata: Metadata for the runner.
+            instance_id: Instance ID of the runner.
+
+        Returns:
+            Platform Runner information.
+        """
+        return self._get_provider(metadata).get_runner(metadata, instance_id)
+
     def get_runners(
         self, states: Iterable[PlatformRunnerState] | None = None
     ) -> tuple[SelfHostedRunner, ...]:

--- a/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
@@ -105,14 +105,20 @@ class PlatformProvider(abc.ABC):
 
 @dataclass
 class PlatformRunnerHealth:
-    """TODO.
+    """Information about the health of a platform runner.
+
+    A runner can be online if it is connected to the platform. If the platform
+    does not provide that information, any runner that has connected to the platform
+    should be considered online. It is deletable if there is no risk in deleting the
+    compute instance, and busy if it is currently executing a job in the platform
+    manager.
 
     Attributes:
-        instance_id: TODO
-        metadata: TODO
-        online: TODO
-        busy: TODO
-        deletable: TODO
+        instance_id: InstanceID of the runner.
+        metadata: Metadata of the runner.
+        online: Whether the runner is online.
+        busy: Whether the runner is busy.
+        deletable: Whether the runner is deletable.
     """
 
     instance_id: InstanceID

--- a/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
@@ -25,20 +25,16 @@ class JobNotFoundError(PlatformError):
     """Represents an error when the job could not be found on the platform."""
 
 
-class RunnerNotFoundError(PlatformError):
-    """Represents an error when the runner could not be found on the platform."""
-
-
 class PlatformProvider(abc.ABC):
     """Base class for a Platform Provider."""
 
     @abc.abstractmethod
-    def get_runner(
+    def get_runner_health(
         self,
         metadata: RunnerMetadata,
         instance_id: InstanceID,
-    ) -> SelfHostedRunner:
-        """Get info on self-hosted runner.
+    ) -> "PlatformRunnerHealth":
+        """Get health information on self-hosted runner.
 
         Args:
             metadata: Metadata for the runner.
@@ -105,6 +101,21 @@ class PlatformProvider(abc.ABC):
             workflow_run_id: workflow run id of the job.
             runner: runner to get the job from.
         """
+
+
+@dataclass
+class PlatformRunnerHealth:
+    """TODO.
+
+    Attributes:
+        online: TODO
+        busy: TODO
+        deletable: TODO
+    """
+
+    online: bool
+    busy: bool
+    deletable: bool
 
 
 # Pending to review the coupling of this class with GitHub

--- a/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
@@ -108,11 +108,15 @@ class PlatformRunnerHealth:
     """TODO.
 
     Attributes:
+        instance_id: TODO
+        metadata: TODO
         online: TODO
         busy: TODO
         deletable: TODO
     """
 
+    instance_id: InstanceID
+    metadata: RunnerMetadata
     online: bool
     busy: bool
     deletable: bool

--- a/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
@@ -25,8 +25,25 @@ class JobNotFoundError(PlatformError):
     """Represents an error when the job could not be found on the platform."""
 
 
+class RunnerNotFoundError(PlatformError):
+    """Represents an error when the runner could not be found on the platform."""
+
+
 class PlatformProvider(abc.ABC):
     """Base class for a Platform Provider."""
+
+    @abc.abstractmethod
+    def get_runner(
+        self,
+        metadata: RunnerMetadata,
+        instance_id: InstanceID,
+    ) -> SelfHostedRunner:
+        """Get info on self-hosted runner.
+
+        Args:
+            metadata: Metadata for the runner.
+            instance_id: Instance ID of the runner.
+        """
 
     @abc.abstractmethod
     def get_runners(

--- a/github-runner-manager/src/github_runner_manager/reactive/consumer.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/consumer.py
@@ -237,6 +237,7 @@ def _spawn_runner(
         logger.error("Failed to spawn a runner. Will reject the message.")
         msg.reject(requeue=True)
         return
+    # TODO JAVI REDUCE NUMBER OF CALLS TO ~5.
     for _ in range(10):
         if platform_provider.check_job_been_picked_up(metadata=metadata, job_url=job_url):
             msg.ack()

--- a/github-runner-manager/src/github_runner_manager/reactive/consumer.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/consumer.py
@@ -238,8 +238,6 @@ def _spawn_runner(
         msg.reject(requeue=True)
         return
 
-    # A smaller value can be advantageous, as more runners can be spawned if
-    # there are many jobs.
     for _ in range(5):
         if platform_provider.check_job_been_picked_up(metadata=metadata, job_url=job_url):
             msg.ack()

--- a/github-runner-manager/src/github_runner_manager/reactive/consumer.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/consumer.py
@@ -238,7 +238,8 @@ def _spawn_runner(
         msg.reject(requeue=True)
         return
 
-    # TODO EXPLAIN THE 5. WE WANT A MESSAGE BACK AS QUICK AS POSSIBLE SO A RUNNER CAN BE SPAWNED
+    # A smaller value can be advantageous, as more runners can be spawned if
+    # there are many jobs.
     for _ in range(5):
         if platform_provider.check_job_been_picked_up(metadata=metadata, job_url=job_url):
             msg.ack()

--- a/github-runner-manager/src/github_runner_manager/reactive/consumer.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/consumer.py
@@ -237,8 +237,9 @@ def _spawn_runner(
         logger.error("Failed to spawn a runner. Will reject the message.")
         msg.reject(requeue=True)
         return
-    # TODO JAVI REDUCE NUMBER OF CALLS TO ~5.
-    for _ in range(10):
+
+    # TODO EXPLAIN THE 5. WE WANT A MESSAGE BACK AS QUICK AS POSSIBLE SO A RUNNER CAN BE SPAWNED
+    for _ in range(5):
         if platform_provider.check_job_been_picked_up(metadata=metadata, job_url=job_url):
             msg.ack()
             break

--- a/github-runner-manager/src/github_runner_manager/reactive/consumer.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/consumer.py
@@ -238,11 +238,13 @@ def _spawn_runner(
         msg.reject(requeue=True)
         return
 
-    for _ in range(5):
+    for iteration in range(5):
+        # Do not sleep on the first iteration — the job might already be taken.
+        if iteration != 0:
+            sleep(60)
         if platform_provider.check_job_been_picked_up(metadata=metadata, job_url=job_url):
             msg.ack()
             break
-        sleep(30)
     else:
         msg.reject(requeue=True)
 

--- a/github-runner-manager/src/github_runner_manager/types_/github.py
+++ b/github-runner-manager/src/github_runner_manager/types_/github.py
@@ -68,7 +68,8 @@ class SelfHostedRunner(BaseModel):
         status: The Github runner status.
         instance_id: InstanceID of the runner.
         metadata: Runner metadata.
-        deletable: TODO
+        deletable: Deletable runner. In GitHub, this is equivalent as the runner not
+            existing in GitHub, as that runner cannot get jobs.
     """
 
     busy: bool

--- a/github-runner-manager/src/github_runner_manager/types_/github.py
+++ b/github-runner-manager/src/github_runner_manager/types_/github.py
@@ -84,7 +84,7 @@ class SelfHostedRunner(BaseModel):
         """Build a SelfHostedRunner from the GitHub runner information and the InstanceID.
 
         Args:
-            github_dict: GitHub dictionary from the list_self_hosted_runners endpoint.
+            github_dict: GitHub dictionary from the list_runners endpoint.
             instance_id: InstanceID for the runner.
 
         Returns:

--- a/github-runner-manager/src/github_runner_manager/types_/github.py
+++ b/github-runner-manager/src/github_runner_manager/types_/github.py
@@ -68,6 +68,7 @@ class SelfHostedRunner(BaseModel):
         status: The Github runner status.
         instance_id: InstanceID of the runner.
         metadata: Runner metadata.
+        deletable: TODO
     """
 
     busy: bool
@@ -76,6 +77,7 @@ class SelfHostedRunner(BaseModel):
     status: GitHubRunnerStatus
     instance_id: InstanceID
     metadata: RunnerMetadata
+    deletable: bool = False
 
     @classmethod
     def build_from_github(cls, github_dict: dict, instance_id: InstanceID) -> "SelfHostedRunner":

--- a/github-runner-manager/tests/unit/manager/test_runner_manager.py
+++ b/github-runner-manager/tests/unit/manager/test_runner_manager.py
@@ -37,7 +37,7 @@ from github_runner_manager.types_.github import GitHubRunnerStatus, SelfHostedRu
             health,
             False,
             True,
-            id="Non reactive Github runners with any cloud state should be DELETED.",
+            id="Non reactive GitHub runners with any cloud state should be DELETED.",
         )
         for cloud_state in CloudRunnerState
         for health in HealthState

--- a/github-runner-manager/tests/unit/manager/test_runner_manager.py
+++ b/github-runner-manager/tests/unit/manager/test_runner_manager.py
@@ -236,9 +236,11 @@ def test_create_runner(
     runner_healthy: PlatformRunnerHealth,
 ):
     """
-    arrange: TODO.
-    act: TODO.
-    assert: TODO.
+    arrange: Given a specific pattern for creation waiting times and a list of.
+        PlatformRunnerHealth objects being the last one a healthy runner.
+    act: call runner_manager.create_runners.
+    assert: The runner manager will create the runner and make requests to check the health
+        until it gets a healthy state.
     """
     monkeypatch.setattr(
         runner_manager_module, "RUNNER_CREATION_WAITING_TIMES", creation_waiting_times
@@ -264,8 +266,8 @@ def test_create_runner(
     )
 
     (instance_id,) = runner_manager.create_runners(1, RunnerMetadata(), True)
-    assert instance_id
 
+    assert instance_id
     cloud_runner_manager.create_runner.assert_called_once()
     # The method to get the runner health was called three times
     # until the runner was online.
@@ -275,11 +277,13 @@ def test_create_runner(
 
 def test_create_runner_failed_waiting(monkeypatch: pytest.MonkeyPatch):
     """
-    arrange: TODO.
-    act: TODO.
-    assert: TODO.
+    arrange: Given a specific pattern for creation waiting times and a list of.
+        PlatformRunnerHealth objects where none is healthy
+    act: call runner_manager.create_runners.
+    assert: The runner manager will create the runner, it will check for the health state,
+       but the runner will not get into healthy state and the platform api for deleting
+       the runner will be called.
     """
-    # Wait and retry for three times.
     runner_creation_waiting_times = (0, 0)
     monkeypatch.setattr(
         runner_manager_module, "RUNNER_CREATION_WAITING_TIMES", runner_creation_waiting_times

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -326,10 +326,14 @@ class MockCloudRunnerManager(CloudRunnerManager):
             instance_id: Instance ID for the runner to create.
             metadata: Metadata for the runner.
             runner_context: Context for the runner.
+
+        Returns:
+            The CloudRunnerInstance for the runner
         """
         name = f"{self.name_prefix}-{instance_id}"
         runner = MockRunner(name)
         self.state.runners[instance_id] = runner
+        return runner.to_cloud_runner()
 
     def get_runners(
         self, states: Sequence[CloudRunnerState] | None = None
@@ -451,7 +455,9 @@ class MockGitHubRunnerPlatform(PlatformProvider):
                 busy=runner.github_state == PlatformRunnerState.BUSY,
                 deletable=False,
             )
-        return PlatformRunnerHealth(online=False, busy=False, deletable=True)
+        return PlatformRunnerHealth(
+            instance_id=instance_id, metadata=metadata, online=False, busy=False, deletable=True
+        )
 
     def get_runner_context(
         self, metadata: RunnerMetadata, instance_id: str, labels: list[str]

--- a/github-runner-manager/tests/unit/mock_runner_managers.py
+++ b/github-runner-manager/tests/unit/mock_runner_managers.py
@@ -445,6 +445,8 @@ class MockGitHubRunnerPlatform(PlatformProvider):
         if instance_id in self.state.runners:
             runner = self.state.runners[instance_id]
             return PlatformRunnerHealth(
+                instance_id=instance_id,
+                metadata=metadata,
                 online=runner.github_state != PlatformRunnerState.OFFLINE,
                 busy=runner.github_state == PlatformRunnerState.BUSY,
                 deletable=False,

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
@@ -92,7 +92,6 @@ def test_create_runner_with_aproxy(
     runner_context = RunnerContext(shell_run_script=agent_command)
     instance_id = InstanceID.build(prefix=prefix)
     metadata = RunnerMetadata()
-    monkeypatch.setattr(runner_manager, "_wait_runner_startup", MagicMock(return_value=None))
     monkeypatch.setattr(runner_manager, "_wait_runner_running", MagicMock(return_value=None))
 
     openstack_cloud = MagicMock(spec=OpenstackCloud)
@@ -124,7 +123,6 @@ def test_create_runner_without_aproxy(
     runner_context = RunnerContext(shell_run_script=agent_command)
     instance_id = InstanceID.build(prefix=prefix)
     metadata = RunnerMetadata()
-    monkeypatch.setattr(runner_manager, "_wait_runner_startup", MagicMock(return_value=None))
     monkeypatch.setattr(runner_manager, "_wait_runner_running", MagicMock(return_value=None))
 
     openstack_cloud = MagicMock(spec=OpenstackCloud)

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
@@ -92,7 +92,6 @@ def test_create_runner_with_aproxy(
     runner_context = RunnerContext(shell_run_script=agent_command)
     instance_id = InstanceID.build(prefix=prefix)
     metadata = RunnerMetadata()
-    monkeypatch.setattr(runner_manager, "_wait_runner_running", MagicMock(return_value=None))
 
     openstack_cloud = MagicMock(spec=OpenstackCloud)
     monkeypatch.setattr(runner_manager, "_openstack_cloud", openstack_cloud)
@@ -123,7 +122,6 @@ def test_create_runner_without_aproxy(
     runner_context = RunnerContext(shell_run_script=agent_command)
     instance_id = InstanceID.build(prefix=prefix)
     metadata = RunnerMetadata()
-    monkeypatch.setattr(runner_manager, "_wait_runner_running", MagicMock(return_value=None))
 
     openstack_cloud = MagicMock(spec=OpenstackCloud)
     monkeypatch.setattr(runner_manager, "_openstack_cloud", openstack_cloud)

--- a/github-runner-manager/tests/unit/platform/test_github_provider.py
+++ b/github-runner-manager/tests/unit/platform/test_github_provider.py
@@ -23,6 +23,8 @@ def _params_test_get_runner_health():
     runner_id = 3
     metadata = RunnerMetadata(platform_name="github", runner_id=str(runner_id))
     instance_id = InstanceID.build(prefix=prefix)
+    # The parameterized arguments are:
+    # "instance_id,metadata,self_hosted_runner,expected_online,expected_busy,expected_deletable",
     return [
         pytest.param(
             instance_id,

--- a/github-runner-manager/tests/unit/platform/test_github_provider.py
+++ b/github-runner-manager/tests/unit/platform/test_github_provider.py
@@ -1,0 +1,117 @@
+#  Copyright 2025 Canonical Ltd.
+#  See LICENSE file for licensing details.
+
+
+"""Test for the github provider module."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from github_runner_manager.github_client import GithubClient
+from github_runner_manager.manager.models import InstanceID, RunnerMetadata
+from github_runner_manager.platform.github_provider import (
+    GithubRunnerNotFoundError,
+    GitHubRunnerPlatform,
+)
+from github_runner_manager.types_.github import GitHubRunnerStatus, SelfHostedRunner
+
+
+def _params_test_get_runner_health():
+    """Parameterized data for test_get_runner_health."""
+    prefix = "unit-0"
+    runner_id = 3
+    metadata = RunnerMetadata(platform_name="github", runner_id=str(runner_id))
+    instance_id = InstanceID.build(prefix=prefix)
+    return [
+        pytest.param(
+            instance_id,
+            metadata,
+            SelfHostedRunner(
+                busy=False,
+                id=1,
+                labels=[],
+                status=GitHubRunnerStatus.OFFLINE,
+                instance_id=instance_id,
+                metadata=metadata,
+            ),
+            False,
+            False,
+            False,
+            id="Offline runner",
+        ),
+        pytest.param(
+            instance_id,
+            metadata,
+            SelfHostedRunner(
+                busy=False,
+                id=1,
+                labels=[],
+                status=GitHubRunnerStatus.ONLINE,
+                instance_id=instance_id,
+                metadata=metadata,
+            ),
+            True,
+            False,
+            False,
+            id="Online runner",
+        ),
+        pytest.param(
+            instance_id,
+            metadata,
+            SelfHostedRunner(
+                busy=True,
+                id=1,
+                labels=[],
+                status=GitHubRunnerStatus.OFFLINE,
+                instance_id=instance_id,
+                metadata=metadata,
+            ),
+            False,
+            True,
+            False,
+            id="Offline busy runner",
+        ),
+        pytest.param(
+            instance_id,
+            metadata,
+            GithubRunnerNotFoundError("not found"),
+            False,
+            False,
+            True,
+            id="Runner not in GitHub",
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "instance_id,metadata,self_hosted_runner,expected_online,expected_busy,expected_deletable",
+    _params_test_get_runner_health(),
+)
+def test_get_runner_health(
+    monkeypatch: pytest.MonkeyPatch,
+    instance_id: InstanceID,
+    metadata: RunnerMetadata,
+    self_hosted_runner: SelfHostedRunner,
+    expected_online: bool,
+    expected_busy: bool,
+    expected_deletable: bool,
+):
+    """
+    arrange: Given a GitHub self-hosted runner in GitHub (possibly missing).
+    act: Call GitRunnerPlatform.get_runner_health.
+    assert: The expected online, busy and deletable fields are set in the health depending
+        on the GitHub runner state.
+    """
+    prefix = "unit-0"
+    github_client_mock = MagicMock(spec=GithubClient)
+    github_client_mock.get_runner.side_effect = (self_hosted_runner,)
+
+    platform = GitHubRunnerPlatform(prefix=prefix, path="org", github_client=github_client_mock)
+
+    runner_health = platform.get_runner_health(instance_id=instance_id, metadata=metadata)
+
+    assert runner_health
+    assert runner_health.online is expected_online
+    assert runner_health.busy is expected_busy
+    assert runner_health.deletable is expected_deletable

--- a/github-runner-manager/tests/unit/platform/test_jobmanager_provider.py
+++ b/github-runner-manager/tests/unit/platform/test_jobmanager_provider.py
@@ -129,9 +129,9 @@ def test_check_job_been_picked_fails(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.parametrize(
     "job_status,job_deletable,expected_online,expected_busy,expected_deletable",
     [
-        pytest.param("PENDING", False, False, False, False, id="pending runner"),
+        pytest.param("PENDING", False, False, True, False, id="pending runner"),
         pytest.param("IN_PROGRESS", False, True, True, False, id="in progress runner"),
-        pytest.param("COMPLETED", False, True, False, False, id="completed not deletable runner"),
+        pytest.param("COMPLETED", False, True, True, False, id="completed not deletabule runner"),
         pytest.param("COMPLETED", True, True, False, True, id="completed and deletable runner"),
     ],
 )

--- a/github-runner-manager/tests/unit/platform/test_jobmanager_provider.py
+++ b/github-runner-manager/tests/unit/platform/test_jobmanager_provider.py
@@ -2,7 +2,7 @@
 #  See LICENSE file for licensing details.
 
 
-"""Test for the github provider module."""
+"""Test for the jobmanager provider module."""
 
 from unittest.mock import MagicMock
 

--- a/github-runner-manager/tests/unit/platform/test_jobmanager_provider.py
+++ b/github-runner-manager/tests/unit/platform/test_jobmanager_provider.py
@@ -8,6 +8,9 @@ from unittest.mock import MagicMock
 
 import pytest
 from jobmanager_client.models.job import Job
+from jobmanager_client.models.v1_jobs_job_id_health_get200_response import (
+    V1JobsJobIdHealthGet200Response,
+)
 from jobmanager_client.models.v1_jobs_job_id_token_post200_response import (
     V1JobsJobIdTokenPost200Response,
 )
@@ -121,3 +124,49 @@ def test_check_job_been_picked_fails(monkeypatch: pytest.MonkeyPatch):
 
     with pytest.raises(PlatformApiError):
         platform.check_job_been_picked_up(metadata, job_url)
+
+
+@pytest.mark.parametrize(
+    "job_status,job_deletable,expected_online,expected_busy,expected_deletable",
+    [
+        pytest.param("PENDING", False, False, False, False, id="pending runner"),
+        pytest.param("IN_PROGRESS", False, True, True, False, id="in progress runner"),
+        pytest.param("COMPLETED", False, True, False, False, id="completed not deletable runner"),
+        pytest.param("COMPLETED", True, True, False, True, id="completed and deletable runner"),
+    ],
+)
+def test_get_runner_health(
+    monkeypatch: pytest.MonkeyPatch,
+    job_status: str,
+    job_deletable: bool,
+    expected_online: bool,
+    expected_busy: bool,
+    expected_deletable: bool,
+):
+    """
+    arrange: Given job health information from the jobmanager.
+    act: Call JobManagerPlatform.get_runner_health.
+    assert: Assert the correct health state is reported.
+    """
+    call_api_mock = MagicMock()
+    monkeypatch.setattr("jobmanager_client.ApiClient.call_api", call_api_mock)
+
+    api_return_value = V1JobsJobIdHealthGet200Response(
+        label="label",
+        status=job_status,
+        deletable=job_deletable,
+    )
+    call_api_mock.side_effect = [api_return_value]
+
+    platform = JobManagerPlatform()
+    instance_id = InstanceID.build(prefix="unit-0")
+    metadata = RunnerMetadata(
+        platform_name="jobmanager", runner_id="3", url="http://jobmanager.example.com"
+    )
+
+    runner_health = platform.get_runner_health(metadata=metadata, instance_id=instance_id)
+
+    assert runner_health
+    assert runner_health.online is expected_online
+    assert runner_health.busy is expected_busy
+    assert runner_health.deletable is expected_deletable

--- a/github-runner-manager/tests/unit/test_github_client.py
+++ b/github-runner-manager/tests/unit/test_github_client.py
@@ -270,10 +270,10 @@ def test_github_api_http_error(github_client: GithubClient, job_stats_raw: JobSt
         )
 
 
-def test_get_runner_github_info(github_client: GithubClient, monkeypatch: pytest.MonkeyPatch):
+def test_list_runners(github_client: GithubClient, monkeypatch: pytest.MonkeyPatch):
     """
     arrange: A mocked Github Client that returns two runners, one for the requested prefix.
-    act: Call get_runner_github_info with the prefix.
+    act: Call list_runners with the prefix.
     assert: A correct runners is returned, the one matching the prefix.
     """
     response = {
@@ -316,7 +316,7 @@ def test_get_runner_github_info(github_client: GithubClient, monkeypatch: pytest
     monkeypatch.setattr(github_runner_manager.github_client, "pages", pages)
 
     github_repo = GitHubRepo(owner=secrets.token_hex(16), repo=secrets.token_hex(16))
-    runners = github_client.get_runner_github_info(path=github_repo, prefix="current-unit-0")
+    runners = github_client.list_runners(path=github_repo, prefix="current-unit-0")
 
     assert len(runners) == 1
     runner0 = runners[0]
@@ -545,7 +545,7 @@ def test_get_runner_context_org(github_client: GithubClient, monkeypatch: pytest
     )
 
 
-def test_get_runner_info(github_client: GithubClient, monkeypatch: pytest.MonkeyPatch):
+def test_get_runner(github_client: GithubClient, monkeypatch: pytest.MonkeyPatch):
     raw_runner = {
         "id": 588,
         "name": "test-r1601frq-0-n-99e88ff9d9ce",

--- a/github-runner-manager/tests/unit/test_github_client.py
+++ b/github-runner-manager/tests/unit/test_github_client.py
@@ -543,3 +543,21 @@ def test_get_runner_context_org(github_client: GithubClient, monkeypatch: pytest
         instance_id=instance_id,
         metadata=RunnerMetadata(platform_name="github", runner_id=18),
     )
+
+
+def test_get_runner_info(github_client: GithubClient, monkeypatch: pytest.MonkeyPatch):
+    raw_runner = {
+        "id": 588,
+        "name": "test-r1601frq-0-n-99e88ff9d9ce",
+        "os": "linux",
+        "status": "offline",
+        "busy": False,
+        "labels": [
+            {"id": 0, "name": "openstack_test", "type": "read-only"},
+            {"id": 0, "name": "linux", "type": "read-only"},
+            {"id": 0, "name": "self-hosted", "type": "read-only"},
+            {"id": 0, "name": "test-89be82ae89d6", "type": "read-only"},
+        ],
+    }
+    assert raw_runner
+    # TODO JAVI PENDING TO WRITE THESE TESTS

--- a/github-runner-manager/tests/unit/test_runner_scaler.py
+++ b/github-runner-manager/tests/unit/test_runner_scaler.py
@@ -29,6 +29,7 @@ from github_runner_manager.configuration.github import (
     GitHubRepo,
 )
 from github_runner_manager.errors import CloudError, ReconcileError
+from github_runner_manager.manager import runner_manager as runner_manager_module
 from github_runner_manager.manager.cloud_runner_manager import CloudRunnerState
 from github_runner_manager.manager.models import InstanceID
 from github_runner_manager.manager.runner_manager import FlushMode, RunnerManager
@@ -116,6 +117,8 @@ def runner_manager_fixture(
         cloud_runner_manager=mock_cloud,
         labels=["label1", "label2", "arm64", "noble", "flavorlabel"],
     )
+    # We do not want to wait in the unit tests for machines to be ready.
+    monkeypatch.setattr(runner_manager_module, "RUNNER_CREATION_WAITING_TIMES", (0,))
     return runner_manager
 
 

--- a/tests/integration/helpers/charm_metrics.py
+++ b/tests/integration/helpers/charm_metrics.py
@@ -73,14 +73,10 @@ async def wait_for_workflow_to_start(
                 return False
             try:
                 job: WorkflowJob = jobs[0]
-                logs = requests.get(job.logs_url()).content.decode("utf-8")
+                if runner_name == job.runner_name:
+                    return True
             except GithubException as exc:
                 logger.warning("Github error, %s", exc)
-                if exc.status == 410:
-                    logger.warning("Transient github error, %s", exc)
-                    return False
-            if runner_name in logs:
-                return True
         return False
 
     try:
@@ -136,12 +132,12 @@ async def cancel_workflow_run(
             continue
         try:
             job: WorkflowJob = jobs[0]
-            logs = requests.get(job.logs_url()).content.decode("utf-8")
         except GithubException as exc:
             if exc.status == 410:
                 logger.warning("Transient github error, %s", exc)
                 continue
-        if runner_name in logs:
+            logger.warning("Github error, %s", exc)
+        if runner_name == job.runner_name:
             run.cancel()
 
 

--- a/tests/integration/helpers/charm_metrics.py
+++ b/tests/integration/helpers/charm_metrics.py
@@ -8,7 +8,6 @@ import json
 import logging
 from time import sleep
 
-import requests
 from github.Branch import Branch
 from github.GithubException import GithubException
 from github.Repository import Repository

--- a/tests/integration/test_jobmanager.py
+++ b/tests/integration/test_jobmanager.py
@@ -274,7 +274,7 @@ async def test_jobmanager(
 
     httpserver.check_assertions()
 
-    # TODO CHECK NO ELEMENTS IN THE QUEUE AT THIS POINT.
+    assert_queue_is_empty(mongodb_uri, app.name)
 
     # The reconcile loop is still not adapted and will badly kill the instance as the ssh
     # health check will mark the instance as unhealthy.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

This PR starts with the removal of the ssh health checks, specifically, on creating a new server, the machine is not accessed using ssh. Instead, the platform provider is queried to check if the server is online (of it is deletable).

For that:
- A new method was added in the Platform providers called get_runner_health. This method returns the information about the health of a runner. Probably a method similar to this one (but affecting more than one runner) should be used when removing the ssh health checks in the main reconcile.
- The RunnerManager calls the cloud manager to create the openstack machine and then waits until the platform provider replies that the runner is healthy. The waiting times (and number of retries) are in the variable RUNNER_CREATION_WAITING_TIMES.

Because of this change, up to 5 new requests can be made to the GitHub API. To compensate, I have removed 5 calls when checking if the job has been picked up. This has advantages and disadvantages. As the advantage, reactive runner will be spawned faster when there is a lot of pressure (the process will die sooner and the message requeued faster).


A few things pending (and out of scope for this PR):
- The PlatformProvider interface still has a few rough edges. A small cleanup will be done in following PRs. For example:
  - It is not clear the use of the SelfHostedRunner class (probably it is enough with the health check status).
  - The exceptions raised in the API are not totally clear, and places in different files.
- Actually, no waiting should be done on runner creation, but that is outside of scope for this PR. For that:
  - Runners can be deleted in the reconcile loop if they are offline after a long time since creation.
  - The waiting should only exist in the case of reactive runners (and a way without waiting should be thought).
- Currently, runners are flushed in reactive mode when there are no messages. It could be interesting to rethink the idea, and flush runners periodically (even for non-reactive).

 
- ### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->