### PR TITLE
Feat/isd 3149/adding how to landing page

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 ### 2025-04-22
 
-- Add how-to langing page.
+- Add how-to landing page.
 
 ### 2025-04-15
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
-### 20250-04-15
+### 2025-04-22
+
+- Add how-to langing page.
+
+### 2025-04-15
 
 - Fix a race condition where keypairs were being deleted even though the server was being built, potentially killing active github action runs.
 

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -4,11 +4,11 @@ The following guides cover key processes and common tasks for managing
 and using the Github Runner charm.
 
 ## Initial setup
-* [Change GitHub personal access token]
 * [Change repository or organization]
+* [Change GitHub personal access token]
 
 ## Basic operations
-* [Add custom labels]:
+* [Add custom labels]
 * [Debug with SSH]
 * [Integrate with COS]
 * [Spawn OpenStack runner]
@@ -17,19 +17,17 @@ and using the Github Runner charm.
 ## Security
 * [Comply with security requirements]
 
-## Upgrade and redeployment 
-
 ## Development
 * [Contribute]
 
 <!--Links-->
 
-[Add custom labels]: (how-to/add-custom-labels.md)
 [Change repository or organization]: (how-to/change-path.md)
 [Change GitHub personal access token]: (how-to/change-token.md)
-[Comply with security requirements]: (how-to/comply-security.md)
-[Contribute]: (how-to/contribute.md)
+[Add custom labels]: (how-to/add-custom-labels.md)
 [Debug with SSH]: (how-to/debug-with-ssh.md)
 [Integrate with COS]: (how-to/integrate-with-cos.md)
 [Spawn OpenStack runner]: (how-to/openstack-runner.md)
 [Set up reactive spawning]: (how-to/reactive.md)
+[Comply with security requirements]: (how-to/comply-security.md)
+[Contribute]: (how-to/contribute.md)

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,35 @@
+# How-to guides
+
+The following guides cover key processes and common tasks for managing
+and using the Github Runner charm.
+
+## Initial setup
+* [Change GitHub personal access token]
+* [Change repository or organization]
+
+## Basic operations
+* [Add custom labels]:
+* [Debug with SSH]
+* [Integrate with COS]
+* [Spawn OpenStack runner]
+* [Set up reactive spawning]
+
+## Security
+* [Comply with security requirements]
+
+## Upgrade and redeployment 
+
+## Development
+* [Contribute]
+
+<!--Links-->
+
+[Add custom labels]: (how-to/add-custom-labels.md)
+[Change repository or organization]: (how-to/change-path.md)
+[Change GitHub personal access token]: (how-to/change-token.md)
+[Comply with security requirements]: (how-to/comply-security.md)
+[Contribute]: (how-to/contribute.md)
+[Debug with SSH]: (how-to/debug-with-ssh.md)
+[Integrate with COS]: (how-to/integrate-with-cos.md)
+[Spawn OpenStack runner]: (how-to/openstack-runner.md)
+[Set up reactive spawning]: (how-to/reactive.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,15 +46,15 @@ Thinking about using the GitHub runner charm for your next project? [Get in touc
 # Contents
 
 1. [How to](how-to)
-  1. [Add custom labels](how-to/add-custom-labels.md)
   1. [Change repository or organization](how-to/change-path.md)
   1. [Change GitHub personal access token](how-to/change-token.md)
-  1. [Comply with security requirements](how-to/comply-security.md)
-  1. [Contribute](how-to/contribute.md)
+  1. [Add custom labels](how-to/add-custom-labels.md)
   1. [Debug with SSH](how-to/debug-with-ssh.md)
   1. [Integrate with COS](how-to/integrate-with-cos.md)
   1. [Spawn OpenStack runner](how-to/openstack-runner.md)
   1. [Set up reactive spawning](how-to/reactive.md)
+  1. [Comply with security requirements](how-to/comply-security.md)
+  1. [Contribute](how-to/contribute.md)
 1. [Reference](reference)
   1. [Actions](reference/actions.md)
   1. [Configurations](reference/configurations.md)


### PR DESCRIPTION
Applicable ticket: ISD-3149

### Overview

This PR is for adding a landing page for how-to guides of Github-runner charm

### Rationale

The aim is to collect all the how-to guides in one single webpage for a better structure, where all the guides will be visible and structured under one single page.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [X] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->
