### PR TITLE
Catch validation exceptions in jobmanager

### DIFF
--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -334,10 +334,19 @@ class RunnerManager:
                         continue
                     logger.info("Deleting busy runner: %s", cloud_runner.instance_id)
                 except PlatformApiError as exc:
+                    if not delete_busy_runners:
+                        logger.warning(
+                            "Failed to delete platform runner %s. %s. Skipping.",
+                            cloud_runner.instance_id,
+                            exc,
+                        )
+                        continue
                     logger.warning(
-                        "Failed to delete platform runner %s. %s", cloud_runner.instance_id, exc
+                        "Deleting runner: %s after platform failure %s.",
+                        cloud_runner.instance_id,
+                        exc,
                     )
-                    continue
+
             logging.info("Delete runner in cloud: %s", cloud_runner.instance_id)
             runner_metric = self._cloud.delete_runner(cloud_runner.instance_id)
             if not runner_metric:

--- a/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/jobmanager_provider.py
@@ -10,6 +10,7 @@ import jobmanager_client
 from jobmanager_client.models.v1_jobs_job_id_token_post_request import V1JobsJobIdTokenPostRequest
 from jobmanager_client.rest import ApiException, NotFoundException
 from pydantic import HttpUrl
+from pydantic.error_wrappers import ValidationError
 from urllib3.exceptions import RequestError
 
 from github_runner_manager.manager.models import (
@@ -78,7 +79,7 @@ class JobManagerPlatform(PlatformProvider):
                     deletable=False,
                     busy=False,
                 )
-            except (ApiException, RequestError) as exc:
+            except (ApiException, RequestError, ValidationError) as exc:
                 logger.exception(
                     "Error calling jobmanager api for runner %s. %s", runner_identity, exc
                 )
@@ -195,7 +196,7 @@ class JobManagerPlatform(PlatformProvider):
                         ),
                     )
                 raise PlatformApiError("Empty token from jobmanager API")
-            except (ApiException, RequestError) as exc:
+            except (ApiException, RequestError, ValidationError) as exc:
                 logger.exception("Error calling jobmanager api.")
                 raise PlatformApiError("API error") from exc
 
@@ -220,7 +221,7 @@ class JobManagerPlatform(PlatformProvider):
                 job = api_instance.v1_jobs_job_id_get(int(metadata.runner_id))
                 if job.status != JobStatus.PENDING:
                     return True
-            except (ApiException, RequestError) as exc:
+            except (ApiException, RequestError, ValidationError) as exc:
                 logger.exception("Error calling jobmanager api to get job information.")
                 raise PlatformApiError("API error") from exc
         return False


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

The jobmanager client can raise ValidationErrors. Catch them and tranform them to PlatformApiExceptions. 

Besides that, in case of busy runners, remove them whatever the failure in the platform. 

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->