### PR TITLE
Some major improvements and fixes

### DIFF
--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -412,7 +412,7 @@ class RunnerManager:
             A tuple of instance ID's of runners spawned.
         """
         instance_id_list = []
-        with Pool(processes=min(num, 20)) as pool:
+        with Pool(processes=min(num, 30)) as pool:
             jobs = pool.imap_unordered(
                 func=RunnerManager._create_runner, iterable=create_runner_args_sequence
             )

--- a/github-runner-manager/src/github_runner_manager/platform/multiplexer_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/multiplexer_provider.py
@@ -98,7 +98,9 @@ class MultiplexerPlatform(PlatformProvider):
         identities_by_provider: dict[str, RunnerIdentity] = defaultdict(list)
         for identity in requested_runners:
             identities_by_provider[identity.metadata.platform_name].append(identity)
-        for platform_name, platform_identities in identities_by_provider.items():
+        # Call all of them, whether there is data or not
+        for platform_name in self._providers:
+            platform_identities = identities_by_provider.get(platform_name, [])
             provider_health_response = self._providers[platform_name].get_runners_health(
                 platform_identities
             )

--- a/github-runner-manager/src/github_runner_manager/repo_policy_compliance_client.py
+++ b/github-runner-manager/src/github_runner_manager/repo_policy_compliance_client.py
@@ -9,6 +9,8 @@ from urllib.parse import urljoin
 import requests
 import urllib3
 
+from github_runner_manager.errors import RunnerCreateError
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,8 +38,8 @@ class RepoPolicyComplianceClient:  # pylint: disable=too-few-public-methods
         """Get a single-use token for repo policy compliance check.
 
         Raises:
-            HTTPError: If there was an error getting one-time token from repo-policy-compliance \
-                service.
+            RunnerCreateError: If there was an error getting one-time token from \
+                repo-policy-compliance service.
 
         Returns:
             The one-time token to be used in a single request of repo policy compliance check.
@@ -47,9 +49,9 @@ class RepoPolicyComplianceClient:  # pylint: disable=too-few-public-methods
             response = self._session.get(url, headers={"Authorization": f"Bearer {self.token}"})
             response.raise_for_status()
             return response.content.decode("utf-8")
-        except requests.HTTPError:
+        except requests.RequestException as exc:
             logger.exception("Unable to get one time token from repo policy compliance service.")
-            raise
+            raise RunnerCreateError from exc
 
     def _create_session(self) -> requests.Session:
         """Create a new requests session.

--- a/github-runner-manager/tests/unit/platform/test_multiplexer_provider.py
+++ b/github-runner-manager/tests/unit/platform/test_multiplexer_provider.py
@@ -28,14 +28,12 @@ def test_get_runners_health(
     prefix = "unit-0"
 
     github_provider_mock = MagicMock(spec=PlatformProvider)
-    other_github_provider_mock = MagicMock(spec=PlatformProvider)
     jobmanager_provider_mock = MagicMock(spec=PlatformProvider)
 
     platform = MultiplexerPlatform(
         {
             "github": github_provider_mock,
             "jobmanager": jobmanager_provider_mock,
-            "other_github": other_github_provider_mock,
         }
     )
 
@@ -54,10 +52,6 @@ def test_get_runners_health(
     identity_jobmanager_2 = RunnerIdentity(
         instance_id=InstanceID.build(prefix=prefix),
         metadata=RunnerMetadata(platform_name="jobmanager", runner_id=str(2)),
-    )
-    identity_other_github_1 = RunnerIdentity(
-        instance_id=InstanceID.build(prefix=prefix),
-        metadata=RunnerMetadata(platform_name="other_github", runner_id=str(1)),
     )
 
     jobmanager_provider_mock.get_runners_health.return_value = RunnersHealthResponse(
@@ -84,11 +78,6 @@ def test_get_runners_health(
         non_requested_runners=[identity_github_2],
     )
 
-    other_github_provider_mock.get_runners_health.return_value = RunnersHealthResponse(
-        requested_runners=[],
-        non_requested_runners=[identity_other_github_1],
-    )
-
     requested_runners = [identity_github_1, identity_jobmanager_1, identity_jobmanager_2]
     runners_health_response = platform.get_runners_health(requested_runners)
 
@@ -96,10 +85,7 @@ def test_get_runners_health(
         [health_identity_jobmanager_1, health_identity_github_1]
     )
     assert runners_health_response.failed_requested_runners == [identity_jobmanager_2]
-    assert runners_health_response.non_requested_runners == [
-        identity_github_2,
-        identity_other_github_1,
-    ]
+    assert runners_health_response.non_requested_runners == [identity_github_2]
 
 
 def test_get_runners_health_returns_non_requested_runners_always(

--- a/src/charm.py
+++ b/src/charm.py
@@ -72,7 +72,7 @@ from manager_client import GitHubRunnerManagerClient
 # The reconcile loop can get stuck in a charm upgrade. Put a timeout so
 # we can get out of that issue.
 # https://bugs.launchpad.net/juju/+bug/2055184 causing a stuck reconcile event.
-RECONCILIATION_INTERVAL_TIMEOUT = 3000
+RECONCILIATION_INTERVAL_TIMEOUT_SECONDS = 3000
 RECONCILE_RUNNERS_EVENT = "reconcile-runners"
 
 # This is currently hardcoded and may be moved to a config option in the future.
@@ -313,7 +313,7 @@ class GithubRunnerCharm(CharmBase):
         self._event_timer.ensure_event_timer(
             event_name="reconcile-runners",
             interval=int(self.config[RECONCILE_INTERVAL_CONFIG_NAME]),
-            timeout=RECONCILIATION_INTERVAL_TIMEOUT,
+            timeout=RECONCILIATION_INTERVAL_TIMEOUT_SECONDS,
         )
 
     def _ensure_reconcile_timer_is_active(self) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -69,10 +69,10 @@ from event_timer import EventTimer, TimerStatusError
 from factories import create_runner_scaler
 from manager_client import GitHubRunnerManagerClient
 
-# We assume a stuck reconcile event when it takes longer
-# than 10 times a normal interval. Currently, we are only aware of
+# The reconcile loop can get stuck in a charm upgrade. Put a timeout so
+# we can get out of that issue.
 # https://bugs.launchpad.net/juju/+bug/2055184 causing a stuck reconcile event.
-RECONCILIATION_INTERVAL_TIMEOUT_FACTOR = 10
+RECONCILIATION_INTERVAL_TIMEOUT = 3000
 RECONCILE_RUNNERS_EVENT = "reconcile-runners"
 
 # This is currently hardcoded and may be moved to a config option in the future.
@@ -313,8 +313,7 @@ class GithubRunnerCharm(CharmBase):
         self._event_timer.ensure_event_timer(
             event_name="reconcile-runners",
             interval=int(self.config[RECONCILE_INTERVAL_CONFIG_NAME]),
-            timeout=RECONCILIATION_INTERVAL_TIMEOUT_FACTOR
-            * int(self.config[RECONCILE_INTERVAL_CONFIG_NAME]),
+            timeout=RECONCILIATION_INTERVAL_TIMEOUT,
         )
 
     def _ensure_reconcile_timer_is_active(self) -> None:

--- a/tests/integration/test_reactive.py
+++ b/tests/integration/test_reactive.py
@@ -3,6 +3,7 @@
 
 """Testing reactive mode. This is only supported for the OpenStack cloud."""
 import json
+from asyncio import sleep
 from typing import AsyncIterator
 
 import pytest
@@ -99,6 +100,9 @@ async def test_reactive_mode_spawns_runner(
 
     # This reconcile call is to check that we are not killing machines that are under
     # construction in a subsequent reconciliation.
+
+    # There may be a race condition between getting the token and spawning the machine.
+    await sleep(10)
     await reconcile(app, app.model)
 
     try:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Increase the number of processes to spawn machines, so we can put more machines per unit.

Hardcode the timeout for the reconcile, so we can reduce the reconcile interval without impacting this timeout.

Always call all providers in get_runners_health, so cleaning on non requested runners be done.

Change repo policy compliance exception to RunnerCreatedRunner so it does not break the reconcile loop.
### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->