### PR TITLE
feat: Change repo panel to display workflow count

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2025-05-09
+
+- Change the repository panel to show the number of jobs per workflow per repository.
 
 ### 2025-05-06
 

--- a/docs/reference/cos.md
+++ b/docs/reference/cos.md
@@ -26,7 +26,7 @@ The "GitHub Self-Hosted Runner Metrics" metrics dashboard presents the following
  regular expression on the `Repository` variable. The following metrics are displayed:
   - Proportion charts: Share of jobs by completion status, job conclusion, application, repo policy check failure http codes and github events over time.
   - Job duration observation
-  - Number of jobs per repository
+  - Number of jobs per workflow per repository
 
 The "GitHub Self-Hosted Runner Metrics (Long-Term)" metrics dashboard displays the following rows:
 

--- a/src/grafana_dashboards/metrics.json
+++ b/src/grafana_dashboards/metrics.json
@@ -1920,7 +1920,7 @@
         "type": "loki",
         "uid": "${lokids}"
       },
-      "description": "Visualises the number of jobs per repository.",
+      "description": "Visualises the number of jobs per workflow per repository.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1931,7 +1931,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1972,7 +1973,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "code",
-          "expr": "sum by(repo)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",flavor=\"flavor\" | event=\"runner_start\" | json repo=\"repo\" | flavor=~\"$flavor\" | repo=~\"$repository\"[$__range]))",
+          "expr": "sum by(repo,workflow)(count_over_time({filename=\"/var/log/github-runner-metrics.log\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} | json event=\"event\",flavor=\"flavor\" | event=\"runner_start\" | json repo=\"repo\",workflow=\"workflow\" | flavor=~\"$flavor\" | repo=~\"$repository\"[$__range]))",
           "legendFormat": "",
           "queryType": "instant",
           "refId": "A"


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Change panel to look like
![Screenshot from 2025-05-09 13-43-38](https://github.com/user-attachments/assets/79c2e67c-8fc5-4e16-b862-c33545255447)


### Rationale

It makes it easier to find respective workflows (e.g. with huge count).


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->