### PR TITLE
fix: promote workflow

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -28,4 +28,5 @@ jobs:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
       doc-automation-disabled: false
+      base-channel: '22.04'
     secrets: inherit


### PR DESCRIPTION
Applicable spec: <link>

### Overview

pass base-channel to promote-workflow

### Rationale

The workflow is broken as it uses the first base-channel found by `charmcraft status`, which is `20.04`: https://github.com/canonical/github-runner-operator/actions/runs/15435575288/job/43441256804


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->