### PR TITLE
[ISD-3689] Fix: metric log owner on upgrade

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,33 +14,33 @@ concurrency:
 jobs:
   # test option values defined at test/conftest.py are passed on via repository secret
   # INTEGRATION_TEST_ARGS to operator-workflows automatically.
-  integration-tests:
-    name: Integration test with juju 3.1
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-    secrets: inherit
-    with:
-      juju-channel: 3.1/stable
-      pre-run-script: scripts/setup-integration-tests.sh
-      provider: lxd
-      test-tox-env: integration-juju3.1
-      modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'
-      extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
-      self-hosted-runner: true
-      self-hosted-runner-label: stg-private-endpoint
-      test-timeout: 90
-  openstack-interface-tests-private-endpoint:
-    name: openstack interface test using private-endpoint
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-    secrets: inherit
-    with:
-      juju-channel: 3.6/stable
-      pre-run-script: scripts/setup-integration-tests.sh
-      provider: lxd
-      test-tox-env: integration-juju3.6
-      modules: '["test_runner_manager_openstack"]'
-      extra-arguments: '--log-format="%(asctime)s %(levelname)s %(message)s"'
-      self-hosted-runner: true
-      self-hosted-runner-label: stg-private-endpoint
+  # integration-tests:
+  #   name: Integration test with juju 3.1
+  #   uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+  #   secrets: inherit
+  #   with:
+  #     juju-channel: 3.1/stable
+  #     pre-run-script: scripts/setup-integration-tests.sh
+  #     provider: lxd
+  #     test-tox-env: integration-juju3.1
+  #     modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'
+  #     extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
+  #     self-hosted-runner: true
+  #     self-hosted-runner-label: stg-private-endpoint
+  #     test-timeout: 90
+  # openstack-interface-tests-private-endpoint:
+  #   name: openstack interface test using private-endpoint
+  #   uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+  #   secrets: inherit
+  #   with:
+  #     juju-channel: 3.6/stable
+  #     pre-run-script: scripts/setup-integration-tests.sh
+  #     provider: lxd
+  #     test-tox-env: integration-juju3.6
+  #     modules: '["test_runner_manager_openstack"]'
+  #     extra-arguments: '--log-format="%(asctime)s %(levelname)s %(message)s"'
+  #     self-hosted-runner: true
+  #     self-hosted-runner-label: stg-private-endpoint
   openstack-integration-tests-private-endpoint:
     name: Integration test using private-endpoint
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
@@ -50,14 +50,17 @@ jobs:
       pre-run-script: scripts/setup-integration-tests.sh
       provider: lxd
       test-tox-env: integration-juju3.6
-      modules: '["test_charm_metrics_failure", "test_charm_metrics_success", "test_charm_fork_repo", "test_charm_fork_path_change", "test_charm_no_runner", "test_charm_runner", "test_reactive", "test_jobmanager"]'
+      modules: '["test_charm_no_runner"]'
+      # modules: '["test_charm_metrics_failure", "test_charm_metrics_success", "test_charm_fork_repo", "test_charm_fork_path_change", "test_charm_no_runner", "test_charm_runner", "test_reactive", "test_jobmanager"]'
       extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
       self-hosted-runner: true
       self-hosted-runner-label: stg-private-endpoint
-  allure-report:
-    if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
-    needs:
-      - integration-tests
-      - openstack-interface-tests-private-endpoint
-      - openstack-integration-tests-private-endpoint
-    uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main
+      tmate-debug: true
+      tmate-timeout: 3000
+  # allure-report:
+  #   if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
+  #   needs:
+  #     - integration-tests
+  #     - openstack-interface-tests-private-endpoint
+  #     - openstack-integration-tests-private-endpoint
+  #   uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,33 +14,33 @@ concurrency:
 jobs:
   # test option values defined at test/conftest.py are passed on via repository secret
   # INTEGRATION_TEST_ARGS to operator-workflows automatically.
-  # integration-tests:
-  #   name: Integration test with juju 3.1
-  #   uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-  #   secrets: inherit
-  #   with:
-  #     juju-channel: 3.1/stable
-  #     pre-run-script: scripts/setup-integration-tests.sh
-  #     provider: lxd
-  #     test-tox-env: integration-juju3.1
-  #     modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'
-  #     extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
-  #     self-hosted-runner: true
-  #     self-hosted-runner-label: stg-private-endpoint
-  #     test-timeout: 90
-  # openstack-interface-tests-private-endpoint:
-  #   name: openstack interface test using private-endpoint
-  #   uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-  #   secrets: inherit
-  #   with:
-  #     juju-channel: 3.6/stable
-  #     pre-run-script: scripts/setup-integration-tests.sh
-  #     provider: lxd
-  #     test-tox-env: integration-juju3.6
-  #     modules: '["test_runner_manager_openstack"]'
-  #     extra-arguments: '--log-format="%(asctime)s %(levelname)s %(message)s"'
-  #     self-hosted-runner: true
-  #     self-hosted-runner-label: stg-private-endpoint
+  integration-tests:
+    name: Integration test with juju 3.1
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      juju-channel: 3.1/stable
+      pre-run-script: scripts/setup-integration-tests.sh
+      provider: lxd
+      test-tox-env: integration-juju3.1
+      modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'
+      extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
+      self-hosted-runner: true
+      self-hosted-runner-label: stg-private-endpoint
+      test-timeout: 90
+  openstack-interface-tests-private-endpoint:
+    name: openstack interface test using private-endpoint
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      juju-channel: 3.6/stable
+      pre-run-script: scripts/setup-integration-tests.sh
+      provider: lxd
+      test-tox-env: integration-juju3.6
+      modules: '["test_runner_manager_openstack"]'
+      extra-arguments: '--log-format="%(asctime)s %(levelname)s %(message)s"'
+      self-hosted-runner: true
+      self-hosted-runner-label: stg-private-endpoint
   openstack-integration-tests-private-endpoint:
     name: Integration test using private-endpoint
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
@@ -55,12 +55,10 @@ jobs:
       extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
       self-hosted-runner: true
       self-hosted-runner-label: stg-private-endpoint
-      tmate-debug: true
-      tmate-timeout: 3000
-  # allure-report:
-  #   if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
-  #   needs:
-  #     - integration-tests
-  #     - openstack-interface-tests-private-endpoint
-  #     - openstack-integration-tests-private-endpoint
-  #   uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main
+  allure-report:
+    if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
+    needs:
+      - integration-tests
+      - openstack-interface-tests-private-endpoint
+      - openstack-integration-tests-private-endpoint
+    uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,33 +14,33 @@ concurrency:
 jobs:
   # test option values defined at test/conftest.py are passed on via repository secret
   # INTEGRATION_TEST_ARGS to operator-workflows automatically.
-  integration-tests:
-    name: Integration test with juju 3.1
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-    secrets: inherit
-    with:
-      juju-channel: 3.1/stable
-      pre-run-script: scripts/setup-integration-tests.sh
-      provider: lxd
-      test-tox-env: integration-juju3.1
-      modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'
-      extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
-      self-hosted-runner: true
-      self-hosted-runner-label: stg-private-endpoint
-      test-timeout: 90
-  openstack-interface-tests-private-endpoint:
-    name: openstack interface test using private-endpoint
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-    secrets: inherit
-    with:
-      juju-channel: 3.6/stable
-      pre-run-script: scripts/setup-integration-tests.sh
-      provider: lxd
-      test-tox-env: integration-juju3.6
-      modules: '["test_runner_manager_openstack"]'
-      extra-arguments: '--log-format="%(asctime)s %(levelname)s %(message)s"'
-      self-hosted-runner: true
-      self-hosted-runner-label: stg-private-endpoint
+  # integration-tests:
+  #   name: Integration test with juju 3.1
+  #   uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+  #   secrets: inherit
+  #   with:
+  #     juju-channel: 3.1/stable
+  #     pre-run-script: scripts/setup-integration-tests.sh
+  #     provider: lxd
+  #     test-tox-env: integration-juju3.1
+  #     modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'
+  #     extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
+  #     self-hosted-runner: true
+  #     self-hosted-runner-label: stg-private-endpoint
+  #     test-timeout: 90
+  # openstack-interface-tests-private-endpoint:
+  #   name: openstack interface test using private-endpoint
+  #   uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+  #   secrets: inherit
+  #   with:
+  #     juju-channel: 3.6/stable
+  #     pre-run-script: scripts/setup-integration-tests.sh
+  #     provider: lxd
+  #     test-tox-env: integration-juju3.6
+  #     modules: '["test_runner_manager_openstack"]'
+  #     extra-arguments: '--log-format="%(asctime)s %(levelname)s %(message)s"'
+  #     self-hosted-runner: true
+  #     self-hosted-runner-label: stg-private-endpoint
   openstack-integration-tests-private-endpoint:
     name: Integration test using private-endpoint
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
@@ -50,14 +50,17 @@ jobs:
       pre-run-script: scripts/setup-integration-tests.sh
       provider: lxd
       test-tox-env: integration-juju3.6
-      modules: '["test_charm_metrics_failure", "test_charm_metrics_success", "test_charm_fork_repo", "test_charm_fork_path_change", "test_charm_no_runner", "test_charm_runner", "test_reactive", "test_jobmanager"]'
+      modules: '["test_reactive"]'
+      # modules: '["test_charm_metrics_failure", "test_charm_metrics_success", "test_charm_fork_repo", "test_charm_fork_path_change", "test_charm_no_runner", "test_charm_runner", "test_reactive", "test_jobmanager"]'
       extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
       self-hosted-runner: true
       self-hosted-runner-label: stg-private-endpoint
-  allure-report:
-    if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
-    needs:
-      - integration-tests
-      - openstack-interface-tests-private-endpoint
-      - openstack-integration-tests-private-endpoint
-    uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main
+      tmate-debug: true
+      tmate-timeout: 3000
+  # allure-report:
+  #   if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
+  #   needs:
+  #     - integration-tests
+  #     - openstack-interface-tests-private-endpoint
+  #     - openstack-integration-tests-private-endpoint
+  #   uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -50,8 +50,7 @@ jobs:
       pre-run-script: scripts/setup-integration-tests.sh
       provider: lxd
       test-tox-env: integration-juju3.6
-      modules: '["test_reactive"]'
-      # modules: '["test_charm_metrics_failure", "test_charm_metrics_success", "test_charm_fork_repo", "test_charm_fork_path_change", "test_charm_no_runner", "test_charm_runner", "test_reactive", "test_jobmanager"]'
+      modules: '["test_charm_metrics_failure", "test_charm_metrics_success", "test_charm_fork_repo", "test_charm_fork_path_change", "test_charm_no_runner", "test_charm_runner", "test_reactive", "test_jobmanager"]'
       extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
       self-hosted-runner: true
       self-hosted-runner-label: stg-private-endpoint

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,33 +14,33 @@ concurrency:
 jobs:
   # test option values defined at test/conftest.py are passed on via repository secret
   # INTEGRATION_TEST_ARGS to operator-workflows automatically.
-  # integration-tests:
-  #   name: Integration test with juju 3.1
-  #   uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-  #   secrets: inherit
-  #   with:
-  #     juju-channel: 3.1/stable
-  #     pre-run-script: scripts/setup-integration-tests.sh
-  #     provider: lxd
-  #     test-tox-env: integration-juju3.1
-  #     modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'
-  #     extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
-  #     self-hosted-runner: true
-  #     self-hosted-runner-label: stg-private-endpoint
-  #     test-timeout: 90
-  # openstack-interface-tests-private-endpoint:
-  #   name: openstack interface test using private-endpoint
-  #   uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-  #   secrets: inherit
-  #   with:
-  #     juju-channel: 3.6/stable
-  #     pre-run-script: scripts/setup-integration-tests.sh
-  #     provider: lxd
-  #     test-tox-env: integration-juju3.6
-  #     modules: '["test_runner_manager_openstack"]'
-  #     extra-arguments: '--log-format="%(asctime)s %(levelname)s %(message)s"'
-  #     self-hosted-runner: true
-  #     self-hosted-runner-label: stg-private-endpoint
+  integration-tests:
+    name: Integration test with juju 3.1
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      juju-channel: 3.1/stable
+      pre-run-script: scripts/setup-integration-tests.sh
+      provider: lxd
+      test-tox-env: integration-juju3.1
+      modules: '["test_charm_scheduled_events", "test_debug_ssh", "test_charm_upgrade"]'
+      extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
+      self-hosted-runner: true
+      self-hosted-runner-label: stg-private-endpoint
+      test-timeout: 90
+  openstack-interface-tests-private-endpoint:
+    name: openstack interface test using private-endpoint
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      juju-channel: 3.6/stable
+      pre-run-script: scripts/setup-integration-tests.sh
+      provider: lxd
+      test-tox-env: integration-juju3.6
+      modules: '["test_runner_manager_openstack"]'
+      extra-arguments: '--log-format="%(asctime)s %(levelname)s %(message)s"'
+      self-hosted-runner: true
+      self-hosted-runner-label: stg-private-endpoint
   openstack-integration-tests-private-endpoint:
     name: Integration test using private-endpoint
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
@@ -50,17 +50,14 @@ jobs:
       pre-run-script: scripts/setup-integration-tests.sh
       provider: lxd
       test-tox-env: integration-juju3.6
-      modules: '["test_charm_no_runner"]'
-      # modules: '["test_charm_metrics_failure", "test_charm_metrics_success", "test_charm_fork_repo", "test_charm_fork_path_change", "test_charm_no_runner", "test_charm_runner", "test_reactive", "test_jobmanager"]'
+      modules: '["test_charm_metrics_failure", "test_charm_metrics_success", "test_charm_fork_repo", "test_charm_fork_path_change", "test_charm_no_runner", "test_charm_runner", "test_reactive", "test_jobmanager"]'
       extra-arguments: '-m openstack --log-format="%(asctime)s %(levelname)s %(message)s"'
       self-hosted-runner: true
       self-hosted-runner-label: stg-private-endpoint
-      tmate-debug: true
-      tmate-timeout: 3000
-  # allure-report:
-  #   if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
-  #   needs:
-  #     - integration-tests
-  #     - openstack-interface-tests-private-endpoint
-  #     - openstack-integration-tests-private-endpoint
-  #   uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main
+  allure-report:
+    if: ${{ (success() || failure()) && github.event_name == 'schedule' }}
+    needs:
+      - integration-tests
+      - openstack-interface-tests-private-endpoint
+      - openstack-integration-tests-private-endpoint
+    uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2025-06-10
+
+- Fix issue with upgraded charm unit unable to issue metrics due to metric log ownership issues.
+
 ### 2025-06-04
 
 - Reduce the reconcile-interval configuration from 10 minutes to 5 minutes. This is the interval 

--- a/github-runner-manager/src/github_runner_manager/reconcile_service.py
+++ b/github-runner-manager/src/github_runner_manager/reconcile_service.py
@@ -18,8 +18,7 @@ from github_runner_manager.manager.runner_scaler import RunnerScaler
 
 logger = logging.getLogger(__name__)
 
-RECONCILE_ID_FILE = Path("/var/log/reconcile.id")
-
+RECONCILE_ID_FILE = Path("~").expanduser() / "reconcile.id"
 RECONCILE_SERVICE_START_MSG = "Starting the reconcile service..."
 RECONCILE_START_MSG = "Start reconciliation"
 RECONCILE_END_MSG = "End reconciliation"

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,12 +17,14 @@ import functools
 import json
 import logging
 import pathlib
+import shutil
 from typing import Any, Callable, Sequence, TypeVar
 
 import ops
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from github_runner_manager import constants
+from github_runner_manager.metrics.events import METRICS_LOG_PATH
 from github_runner_manager.platform.platform_provider import TokenError
 from github_runner_manager.utilities import set_env_var
 from ops.charm import (
@@ -525,6 +527,15 @@ def _setup_runner_manager_user() -> None:
     execute_command(["/usr/bin/chmod", "700", f"/home/{constants.RUNNER_MANAGER_USER}/.ssh"])
     # Give the user access to write to /var/log
     execute_command(["/usr/sbin/usermod", "-a", "-G", "syslog", constants.RUNNER_MANAGER_USER])
+
+    # For charm upgrade, previous revision root owns the metric logs, this is changed to runner
+    # manager.
+    if METRICS_LOG_PATH.exists():
+        shutil.chown(
+            METRICS_LOG_PATH,
+            user=constants.RUNNER_MANAGER_USER,
+            group=constants.RUNNER_MANAGER_GROUP,
+        )
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -527,7 +527,7 @@ def _setup_runner_manager_user() -> None:
     execute_command(["/usr/bin/chmod", "700", f"/home/{constants.RUNNER_MANAGER_USER}/.ssh"])
     # Give the user access to write to /var/log
     execute_command(["/usr/sbin/usermod", "-a", "-G", "syslog", constants.RUNNER_MANAGER_USER])
-    execute_command(["/usr/sbin/chmod", "g+w", "/var/log"])
+    execute_command(["/usr/bin/chmod", "g+w", "/var/log"])
 
     # For charm upgrade, previous revision root owns the metric logs, this is changed to runner
     # manager.

--- a/src/charm.py
+++ b/src/charm.py
@@ -527,6 +527,7 @@ def _setup_runner_manager_user() -> None:
     execute_command(["/usr/bin/chmod", "700", f"/home/{constants.RUNNER_MANAGER_USER}/.ssh"])
     # Give the user access to write to /var/log
     execute_command(["/usr/sbin/usermod", "-a", "-G", "syslog", constants.RUNNER_MANAGER_USER])
+    execute_command(["/usr/sbin/chmod", "g+w", "/var/log"])
 
     # For charm upgrade, previous revision root owns the metric logs, this is changed to runner
     # manager.

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -92,7 +92,7 @@ async def get_reconcile_id(unit: Unit) -> str:
     """
     _, stdout, _ = await run_in_unit(
         unit,
-        "cat /var/log/reconcile.id",
+        "cat /home/runner-manager/reconcile.id",
         assert_on_failure=True,
         assert_msg="Unable to get reconcile ID",
     )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Older revision the metric log is owned by root.
The current revision the metric log is owned by the runner manager.
This is causing upgrade application to unable to issue metrics.


### Rationale

Fix issue metrics for upgraded units.


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->