### PR TITLE
fix: revert copy truncate

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @cbartz @yhaliaw @javierdelapuente
+*       @cbartz @yhaliaw @javierdelapuente @yanksyoon

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 2025-06-16
+
+- Revert copytruncate logrotate method for reactive processes, as copytruncate keeps log files on disks and does not remove them, and each process is writing to a new file leading to a huge and increasing amount
+of zero sized files in the reactive log directory. This is a temporary fix until a better solution is implemented, as it has the downside that long lived reactive processes may write to deleted log files.
+
+
 ### 2025-06-12
 
 - Disable and remove any legacy service on upgrade. This fixes issue with the legacy service in upgraded units.

--- a/src/logrotate.py
+++ b/src/logrotate.py
@@ -52,7 +52,7 @@ class LogrotateConfig(BaseModel):
     log_path_glob_pattern: str
     rotate: int
     create: bool
-    copytruncate: bool = False
+    copytruncate: bool = True
     notifempty: bool = True
     frequency: LogrotateFrequency = LogrotateFrequency.WEEKLY
 
@@ -74,6 +74,7 @@ REACTIVE_LOGROTATE_CONFIG = LogrotateConfig(
     create=False,
     notifempty=False,
     frequency=LogrotateFrequency.DAILY,
+    copytruncate=False,
 )
 
 GITHUB_RUNNER_MANAGER_CONFIG = LogrotateConfig(

--- a/src/logrotate.py
+++ b/src/logrotate.py
@@ -43,6 +43,7 @@ class LogrotateConfig(BaseModel):
         log_path_glob_pattern: The glob pattern for the log path.
         rotate: The number of log files to keep.
         create: Whether to create the log file if it does not exist.
+        copytruncate: Whether to copy the log file and truncate it after rotation.
         notifempty: Whether to not rotate the log file if it is empty.
         frequency: The frequency of log rotation.
     """
@@ -51,6 +52,7 @@ class LogrotateConfig(BaseModel):
     log_path_glob_pattern: str
     rotate: int
     create: bool
+    copytruncate: bool = False
     notifempty: bool = True
     frequency: LogrotateFrequency = LogrotateFrequency.WEEKLY
 
@@ -134,7 +136,7 @@ def _write_config(logrotate_config: LogrotateConfig) -> None:
         f"""{logrotate_config.log_path_glob_pattern} {{
 {logrotate_config.frequency}
 rotate {logrotate_config.rotate}
-copytruncate
+{"copytruncate" if logrotate_config.copytruncate else "nocopytruncate"}
 missingok
 {"notifempty" if logrotate_config.notifempty else "ifempty"}
 {"create" if logrotate_config.create else "nocreate"}

--- a/tests/unit/test_logrotate.py
+++ b/tests/unit/test_logrotate.py
@@ -77,11 +77,13 @@ def test_setup_writes_logrotate_config(logrotate_dir: Path):
 
 @pytest.mark.parametrize("create", [True, False])
 @pytest.mark.parametrize("notifempty", [True, False])
+@pytest.mark.parametrize("copytruncate", [True, False])
 @pytest.mark.parametrize("frequency", [freq for freq in logrotate.LogrotateFrequency])
 @pytest.mark.usefixtures("logrotate_dir")
 def test__write_config(
     create: bool,
     notifempty: bool,
+    copytruncate: bool,
     frequency: logrotate.LogrotateFrequency,
     logrotate_dir: Path,
     tmp_path: Path,
@@ -103,6 +105,7 @@ def test__write_config(
         create=create,
         notifempty=notifempty,
         frequency=frequency,
+        copytruncate=copytruncate
     )
 
     logrotate._write_config(logrotate_config)
@@ -110,7 +113,7 @@ def test__write_config(
     expected_logrotate_config = f"""{log_path_glob_pattern} {{
 {frequency}
 rotate {rotate}
-copytruncate
+{"copytruncate" if copytruncate else "nocopytruncate"}
 missingok
 {"notifempty" if notifempty else "ifempty"}
 {"create" if create else "nocreate"}

--- a/tests/unit/test_logrotate.py
+++ b/tests/unit/test_logrotate.py
@@ -105,7 +105,7 @@ def test__write_config(
         create=create,
         notifempty=notifempty,
         frequency=frequency,
-        copytruncate=copytruncate
+        copytruncate=copytruncate,
     )
 
     logrotate._write_config(logrotate_config)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Revert copytruncate logrotate config for reactive processes.

### Rationale

copytruncate does not remove the files on the disk leading to a lot of zero sized files on the disk which leads to issue with the grafana agent.

### Juju Events Changes

n/a

### Module Changes

n/a

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->