### PR TITLE
[ISD-3751] Fix: rejecting without retry for reactive job not found.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,11 +2,13 @@
 
 This changelog documents user-relevant changes to the GitHub runner charm.
 
+## 2025-06-24
+
+- Fix a bug where deleted GitHub Actions Job would cause an endless loop of retries.
 
 ### 2025-06-17
 
-- Fix bug where SSH connection error always appears in the logs.
-
+- Fix a bug where SSH connection error always appears in the logs.
 
 ### 2025-06-16
 

--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -341,7 +341,7 @@ class GithubClient:
         Args:
             path: GitHub repository path in the format '<owner>/<repo>'.
             job_id: The job id.
-        
+
         Raises:
             JobNotFoundError: Cannot find job on GitHub.
 

--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -341,15 +341,23 @@ class GithubClient:
         Args:
             path: GitHub repository path in the format '<owner>/<repo>'.
             job_id: The job id.
+        
+        Raises:
+            JobNotFoundError: Cannot find job on GitHub.
 
         Returns:
             The JSON response from the API.
         """
-        job_raw = self._client.actions.get_job_for_workflow_run(
-            owner=path.owner,
-            repo=path.repo,
-            job_id=job_id,
-        )
+        try:
+            job_raw = self._client.actions.get_job_for_workflow_run(
+                owner=path.owner,
+                repo=path.repo,
+                job_id=job_id,
+            )
+        except HTTPError as exc:
+            if exc.code == 404:
+                raise JobNotFoundError(f"Could not find job for job id {job_id}.") from exc
+            raise
         return self._to_job_info(job_raw)
 
     @staticmethod

--- a/github-runner-manager/src/github_runner_manager/reactive/consumer.py
+++ b/github-runner-manager/src/github_runner_manager/reactive/consumer.py
@@ -90,7 +90,8 @@ def get_queue_size(queue_config: QueueConfig) -> int:
         raise QueueError("Error when communicating with the queue") from exc
 
 
-def consume(
+# Ignore `consume` too complex as it is pending re-design.
+def consume(  # noqa: C901
     queue_config: QueueConfig,
     runner_manager: RunnerManager,
     platform_provider: PlatformProvider,

--- a/tests/integration/test_reactive.py
+++ b/tests/integration/test_reactive.py
@@ -163,7 +163,7 @@ async def test_reactive_mode_with_not_found_job(
 
     # There may be a race condition between getting the token and spawning the machine.
     await sleep(10)
-    await wait_for_reconcile(app, app.model)
+    await wait_for_reconcile(app)
 
     assert_queue_is_empty(mongodb_uri, app.name)
 

--- a/tests/integration/test_reactive.py
+++ b/tests/integration/test_reactive.py
@@ -10,6 +10,7 @@ import pytest
 import pytest_asyncio
 from github import Branch, Repository
 from github_runner_manager.manager.cloud_runner_manager import PostJobStatus
+from github_runner_manager.reactive.consumer import JobDetails
 from juju.application import Application
 from pytest_operator.plugin import OpsTest
 
@@ -134,6 +135,36 @@ async def test_reactive_mode_spawns_runner(
         assert False, "runner_installed event has not been logged"
 
     await _assert_metrics_are_logged(app, github_repository)
+
+
+@pytest.mark.abort_on_fail
+async def test_reactive_mode_with_not_found_job(
+    ops_test: OpsTest,
+    app: Application,
+):
+    """
+    arrange: Place a message in the queue with a non-existent job url.
+    act: Call reconcile.
+    assert: The message is removed from the queue.
+    """
+    mongodb_uri = await get_mongodb_uri(ops_test, app)
+
+    labels = {app.name, "x64"}  # The architecture label should be ignored in the
+    # label validation in the reactive consumer.
+    job = JobDetails(
+        labels=labels,
+        url="https://github.com/canonical/github-runner-operator/actions/runs/mock-run/job/mock-job",
+    )
+    add_to_queue(
+        json.dumps(json.loads(job.json()) | {"ignored_noise": "foobar"}),
+        mongodb_uri,
+        app.name,
+    )
+
+    await sleep(10)
+    await wait_for_reconcile(app, app.model)
+
+    assert_queue_is_empty(mongodb_uri, app.name)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_reactive.py
+++ b/tests/integration/test_reactive.py
@@ -161,6 +161,7 @@ async def test_reactive_mode_with_not_found_job(
         app.name,
     )
 
+    # There may be a race condition between getting the token and spawning the machine.
     await sleep(10)
     await wait_for_reconcile(app, app.model)
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
For reactive message, if a GitHub Actions Jobs is not found with GitHub API (status code 404), then reject the reactive message without retries.

### Rationale

<!-- The reason the change is needed -->
For status code 404 on a get GitHub Actions Jobs, the response would not change. Likely the job is deleted, e.g., repo deleted, workflow deleted, etc.

If the reactive message is re-queue, we would end in a endless loop of re-queuing.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->