### PR TITLE
Hotfix: Add timeout for HTTP requests

### DIFF
--- a/src/manager_client.py
+++ b/src/manager_client.py
@@ -122,7 +122,7 @@ class GitHubRunnerManagerClient:
             The information on the runners.
         """
         self.wait_till_ready()
-        response = self._request(_HTTPMethod.GET, "/runner/check")
+        response = self._request(_HTTPMethod.GET, "/runner/check", timeout=600)
         runner_info = json.loads(response.text)
         runner_info["runners"] = tuple(runner_info["runners"])
         runner_info["busy_runners"] = tuple(runner_info["busy_runners"])
@@ -138,7 +138,7 @@ class GitHubRunnerManagerClient:
         """
         self.wait_till_ready()
         params = {"flush-busy": str(busy)}
-        self._request(_HTTPMethod.POST, "/runner/flush", params=params)
+        self._request(_HTTPMethod.POST, "/runner/flush", params=params, timeout=600)
 
     def health_check(self) -> None:
         """Request a health check on the runner manager service.
@@ -151,7 +151,7 @@ class GitHubRunnerManagerClient:
                 API requests.
         """
         try:
-            response = self._request(_HTTPMethod.GET, "/health")
+            response = self._request(_HTTPMethod.GET, "/health", timeout=60)
         except requests.HTTPError as err:
             raise RunnerManagerServiceNotReadyError(NOT_READY_ERROR_MESSAGE) from err
         except requests.ConnectionError as err:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Add timeout to HTTP requests from the charm to github-runner-manager service.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->