### PR TITLE
chore: print application version on startup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,5 +28,6 @@ Applicable spec: <link>
 - [ ] The documentation for charmhub is updated.
 - [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
 - [ ] The changelog is updated with changes that affects the users of the charm.
+- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.
 
 <!-- Explanation for any unchecked items above -->

--- a/github-runner-manager/pyproject.toml
+++ b/github-runner-manager/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/github-runner-manager/src/github_runner_manager/cli.py
+++ b/github-runner-manager/src/github_runner_manager/cli.py
@@ -3,6 +3,7 @@
 
 """The CLI entrypoint for github-runner-manager application."""
 
+import importlib.metadata
 import logging
 import sys
 from functools import partial
@@ -16,6 +17,8 @@ from github_runner_manager.configuration import ApplicationConfiguration
 from github_runner_manager.http_server import FlaskArgs, start_http_server
 from github_runner_manager.reconcile_service import start_reconcile_service
 from github_runner_manager.thread_manager import ThreadManager
+
+version = importlib.metadata.version("github-runner-manager")
 
 
 @click.command()
@@ -75,6 +78,7 @@ def main(
         stream=sys.stderr,
         format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
     )
+    logging.info("Starting GitHub runner manager service version: %s", version)
 
     lock = Lock()
     config_str = config_file.read()


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Print installed runner manager version on startup
<!-- A high level overview of the change -->

### Rationale

- To debug the runner manager version running without checking the source code.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->
No user facing changes.