### PR TITLE
[ISD-3842] Fix: increase timeout for flush runner

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 This changelog documents user-relevant changes to the GitHub runner charm.
 
+## 2025-07-28
+
+- Fix an issue where the charm can error out due to timeout during flush runners.
+
 ## 2025-07-24
 
 - Fix an issue with infinite retry of a reactive job message.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Increase the timeout for flush runner request from charm to github-runner-manager.

### Rationale

<!-- The reason the change is needed -->
The flush runner request from charm to the github-runner-manager can take a long time to it will wait for current reconcile to complete. While this should be rare, it can be possible for flush-runner to take more than 10 mins due to waiting for reconcile to complete.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.

<!-- Explanation for any unchecked items above -->