### PR TITLE
chore: rename cleanup function

### DIFF
--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_cloud.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_cloud.py
@@ -532,7 +532,7 @@ class OpenstackCloud:
             )
 
     @_catch_openstack_errors
-    def cleanup(self) -> None:
+    def delete_expired_keys(self) -> None:
         """Cleanup unused key files and openstack keypairs."""
         with self._get_openstack_connection() as conn:
             instances = self._get_openstack_instances(conn)

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -5,7 +5,6 @@
 
 import logging
 import secrets
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
 

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -47,25 +47,6 @@ RUNNER_STARTUP_PROCESS = "/home/ubuntu/actions-runner/run.sh"
 OUTDATED_METRICS_STORAGE_IN_SECONDS = CREATE_SERVER_TIMEOUT + 30  # add a bit on top of the timeout
 
 
-class _GithubRunnerRemoveError(Exception):
-    """Represents an error while SSH into a runner and running the remove script."""
-
-
-@dataclass
-class _RunnerHealth:
-    """Runners with health state.
-
-    Attributes:
-        healthy: The list of healthy runners.
-        unhealthy:  The list of unhealthy runners.
-        unknown: The list of runners whose health state could not be determined.
-    """
-
-    healthy: tuple[OpenstackInstance, ...]
-    unhealthy: tuple[OpenstackInstance, ...]
-    unknown: tuple[OpenstackInstance, ...]
-
-
 class OpenStackRunnerManager(CloudRunnerManager):
     """Manage self-hosted runner on OpenStack cloud.
 
@@ -158,7 +139,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
 
     def cleanup(self) -> None:
         """Cleanup runner and resource on the cloud."""
-        self._openstack_cloud.cleanup()
+        self._openstack_cloud.delete_expired_keys()
 
     def _build_cloud_runner_instance(self, instance: OpenstackInstance) -> CloudRunnerInstance:
         """Build a new cloud runner instance from an openstack instance."""

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_cloud.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_cloud.py
@@ -237,7 +237,7 @@ def test_keypair_cleanup_freshly_created_keypairs(
     openstack_connect_mock.return_value = openstack_connection_mock
 
     # act #
-    openstack_cloud.cleanup()
+    openstack_cloud.delete_expired_keys()
 
     # assert #
     # Check if only the old keypairs are deleted

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_cloud.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_cloud.py
@@ -85,7 +85,7 @@ def mock_openstack_conn_fixture(monkeypatch: pytest.MonkeyPatch):
         ),
         pytest.param("get_instance", {"instance_id": FAKE_ARG}, id="get_instance"),
         pytest.param("get_instances", {}, id="get_instances"),
-        pytest.param("cleanup", {}, id="cleanup"),
+        pytest.param("delete_expired_keys", {}, id="delete_expired_keys"),
     ],
 )
 def test_raises_openstack_error(


### PR DESCRIPTION
Applicable spec: N/A

### Overview

- Rename cleanup function to delete_expired_keys
- Delete unused dataclasses
<!-- A high level overview of the change -->

### Rationale

- chore
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

No user facing changes
<!-- Explanation for any unchecked items above -->