### PR TITLE
chore: rename get vms

### DIFF
--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -186,7 +186,7 @@ class RunnerManager:
         """
         logger.debug("runner_manager::get_runners")
         vms = self._cloud.get_vms()
-        logger.info("clouds runners response %s", vms)
+        logger.info("list vms response: %s", vms)
         runners_health_response = self._platform.get_runners_health(vms)
         logger.info("runner health response %s", runners_health_response)
         runners_health = runners_health_response.requested_runners

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -185,18 +185,18 @@ class RunnerManager:
             Information on the runners.
         """
         logger.debug("runner_manager::get_runners")
-        cloud_runners = self._cloud.get_runners()
-        runners_health_response = self._platform.get_runners_health(cloud_runners)
-        logger.info("clouds runners response %s", cloud_runners)
+        vms = self._cloud.get_vms()
+        logger.info("clouds runners response %s", vms)
+        runners_health_response = self._platform.get_runners_health(vms)
         logger.info("runner health response %s", runners_health_response)
         runners_health = runners_health_response.requested_runners
         health_runners_map = {runner.identity.instance_id: runner for runner in runners_health}
         return tuple(
             RunnerInstance.from_cloud_and_platform_health(
-                cloud_instance=cloud_runner,
-                platform_health_state=health_runners_map.get(cloud_runner.instance_id, None),
+                cloud_instance=vm,
+                platform_health_state=health_runners_map.get(vm.instance_id, None),
             )
-            for cloud_runner in cloud_runners
+            for vm in vms
         )
 
     def delete_runners(self, num: int) -> IssuedMetricEventsStats:

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -25,6 +25,7 @@ from github_runner_manager.platform.platform_provider import (
     PlatformProvider,
     PlatformRunnerHealth,
     PlatformRunnerState,
+    RunnersHealthResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -267,11 +268,9 @@ class RunnerManager:
             clean_idle,
             force_delete,
         )
-        cloud_runners = self._cloud.get_runners()
-        logger.info("cleanup cloud_runners %s", cloud_runners)
-        runners_health_response = self._platform.get_runners_health(
-            requested_runners=cloud_runners
-        )
+        vms = self._cloud.get_vms()
+        logger.info("All VMs listed for clean up analysis: %s", vms)
+        runners_health_response = self._platform.get_runners_health(requested_runners=vms)
         logger.info("cleanup health_response %s", runners_health_response)
 
         # Clean dangling resources in the cloud
@@ -280,13 +279,13 @@ class RunnerManager:
         # Always clean all runners in the platform that are not in the cloud
         self._clean_platform_runners(runners_health_response.non_requested_runners)
 
-        cloud_runners_to_delete = list(cloud_runners)
+        vms_to_delete = list(vms)
         health_runners_map = {
             health.identity.instance_id: health
             for health in runners_health_response.requested_runners
         }
 
-        cloud_runners_to_delete = list(
+        vms_to_delete = list(
             filter(
                 lambda cloud_runner: _filter_runner_to_delete(
                     cloud_runner,
@@ -294,25 +293,23 @@ class RunnerManager:
                     clean_idle=clean_idle,
                     force_delete=force_delete,
                 ),
-                cloud_runners_to_delete,
+                vms_to_delete,
             )
         )
 
         if maximum_runners_to_delete is not None:
-            cloud_runners_to_delete.sort(
-                key=partial(_runner_deletion_sort_key, health_runners_map)
-            )
-            cloud_runners_to_delete = cloud_runners_to_delete[:maximum_runners_to_delete]
+            vms_to_delete.sort(key=partial(_runner_deletion_sort_key, health_runners_map))
+            vms_to_delete = vms_to_delete[:maximum_runners_to_delete]
 
-        return self._delete_cloud_runners(
-            cloud_runners_to_delete,
+        return self._delete_vms(
+            vms_to_delete,
             runners_health_response.requested_runners,
             delete_busy_runners=force_delete,
         )
 
-    def _delete_cloud_runners(
+    def _delete_vms(
         self,
-        cloud_runners: Sequence[VM],
+        vms: Sequence[VM],
         runners_health: Sequence[PlatformRunnerHealth],
         delete_busy_runners: bool = False,
     ) -> Iterable[runner_metrics.RunnerMetrics]:
@@ -323,7 +320,7 @@ class RunnerManager:
 
         Runners without health information should not be deleted.
         """
-        if not cloud_runners:
+        if not vms:
             return []
 
         runner_identity_map = {
@@ -334,7 +331,7 @@ class RunnerManager:
             # The runner_id cannot be None due to the if condition. the type system
             # isn't able to catch that.
             cast(str, runner_identity_map[runner.instance_id].metadata.runner_id)
-            for runner in cloud_runners
+            for runner in vms
             if runner.instance_id in runner_identity_map
             and runner_identity_map[runner.instance_id].metadata.runner_id
         ]
@@ -348,16 +345,16 @@ class RunnerManager:
             set(platform_runner_ids_to_delete) - set(deleted_runner_ids),
         )
 
-        logger.info("Cloud runners: %s", cloud_runners)
+        logger.info("VMs: %s", vms)
         cloud_vm_ids_to_delete = [
-            runner.instance_id
-            for runner in cloud_runners
+            vm.instance_id
+            for vm in vms
             # We can delete all VMs if delete_busy_runners is True
             if delete_busy_runners
             # We can delete the VM if no runner is associated with it
-            or not runner.metadata.runner_id
+            or not vm.metadata.runner_id
             # We can delete the VM if it has been deleted from the Platform provider.
-            or runner.metadata.runner_id in deleted_runner_ids
+            or vm.metadata.runner_id in deleted_runner_ids
         ]
         logger.info("Extracting metrics from cloud VMs: %s", cloud_vm_ids_to_delete)
         extracted_metrics = self._cloud.extract_metrics(instance_ids=cloud_vm_ids_to_delete)

--- a/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/runner_manager.py
@@ -25,7 +25,6 @@ from github_runner_manager.platform.platform_provider import (
     PlatformProvider,
     PlatformRunnerHealth,
     PlatformRunnerState,
-    RunnersHealthResponse,
 )
 
 logger = logging.getLogger(__name__)

--- a/github-runner-manager/src/github_runner_manager/manager/vm_manager.py
+++ b/github-runner-manager/src/github_runner_manager/manager/vm_manager.py
@@ -245,7 +245,7 @@ class CloudRunnerManager(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_runners(self) -> Sequence[VM]:
+    def get_vms(self) -> Sequence[VM]:
         """Get cloud self-hosted runners."""
 
     @abc.abstractmethod

--- a/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
+++ b/github-runner-manager/src/github_runner_manager/openstack_cloud/openstack_runner_manager.py
@@ -121,7 +121,7 @@ class OpenStackRunnerManager(CloudRunnerManager):
         logger.info("Runner %s created successfully", instance.instance_id)
         return self._build_cloud_runner_instance(instance)
 
-    def get_runners(self) -> Sequence[VM]:
+    def get_vms(self) -> Sequence[VM]:
         """Get cloud self-hosted runners.
 
         Returns:

--- a/github-runner-manager/tests/unit/fake_runner_managers.py
+++ b/github-runner-manager/tests/unit/fake_runner_managers.py
@@ -130,7 +130,7 @@ class FakeCloudRunnerManager(CloudRunnerManager):
         self._cloud_runners[runner_identity.instance_id] = created_runner
         return created_runner
 
-    def get_runners(self) -> Sequence[VM]:
+    def get_vms(self) -> Sequence[VM]:
         """Get all the cloud runner instances managed by the manager.
 
         Returns:

--- a/tests/integration/jobmanager/helpers.py
+++ b/tests/integration/jobmanager/helpers.py
@@ -198,7 +198,7 @@ async def prepare_runner_tunnel_for_builder_agent(
     return True
 
 
-async def _execute_command_with_builder_agent(instance_helper, unit, command) -> None:
+async def execute_command_with_builder_agent(instance_helper, unit, command) -> None:
     """Execute a command in the builder-agent."""
     execute_command = (
         "'curl http://127.0.0.1:8080/execute -X POST "

--- a/tests/integration/jobmanager/helpers.py
+++ b/tests/integration/jobmanager/helpers.py
@@ -199,7 +199,13 @@ async def prepare_runner_tunnel_for_builder_agent(
 
 
 async def execute_command_with_builder_agent(instance_helper, unit, command) -> None:
-    """Execute a command in the builder-agent."""
+    """Execute a command in the builder-agent.
+
+    Args:
+        instance_helper: Helper class to manage interactions with OpenStack instances.
+        unit: The Juju unit to operate on.
+        command: The command to run.
+    """
     execute_command = (
         "'curl http://127.0.0.1:8080/execute -X POST "
         '--header "Content-Type: application/json" '

--- a/tests/integration/jobmanager/test_jobmanager_prespawned.py
+++ b/tests/integration/jobmanager/test_jobmanager_prespawned.py
@@ -20,8 +20,8 @@ from tests.integration.helpers.openstack import OpenStackInstanceHelper
 from tests.integration.jobmanager.helpers import (
     GetRunnerHealthEndpoint,
     _assert_runners,
-    _execute_command_with_builder_agent,
     add_builder_agent_health_endpoint_response,
+    execute_command_with_builder_agent,
     prepare_runner_tunnel_for_builder_agent,
     wait_for_runner_to_be_registered,
 )
@@ -121,7 +121,7 @@ async def test_jobmanager(
 
     # Ok, at this point, we want to tell the builder-agent to execute some command,
     # specifically a sleep so we can check that it goes over executing and finished statuses.
-    await _execute_command_with_builder_agent(instance_helper, unit, "sleep 30")
+    await execute_command_with_builder_agent(instance_helper, unit, "sleep 30")
 
     # 7. The builder-agent will run the job. While running the job it will send the status
     #         EXECUTING and after it is finished it will send the status FINISHED.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Rename cloud's `get_runners` method to `get_vms` to separate naming of "runner" to be GitHub or Job manager (platform) and cloud's resources as VMs.

<!-- A high level overview of the change -->

### Rationale

- Reduce confusion around naming.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

Trivial, no user facing changes.
<!-- Explanation for any unchecked items above -->