### PR TITLE
feat: add job metrics

### DIFF
--- a/github-runner-manager/src/github_runner_manager/metrics/labels.py
+++ b/github-runner-manager/src/github_runner_manager/metrics/labels.py
@@ -5,3 +5,7 @@
 
 FLAVOR = "flavor"
 CLOUD = "cloud"
+REPOSITORY = "repository"
+EVENT = "event"
+CONCLUSION = "conclusion"
+STATUS = "status"

--- a/tests/integration/test_prometheus_metrics.py
+++ b/tests/integration/test_prometheus_metrics.py
@@ -216,6 +216,9 @@ async def test_prometheus_metrics(
         "delete_runner_duration_seconds_bucket",
         "deleted_vms_total",
         "delete_vm_duration_seconds_bucket",
+        "job_duration_seconds_bucket",
+        "job_status_count",
+        "job_event_count",
     )
 
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Adds prometheus metrics for jobs
<!-- A high level overview of the change -->

### Rationale

- To see metrics per jobs/repositories
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

Non user-facing changes, adding metrics for prometheus.
<!-- Explanation for any unchecked items above -->