### PR TITLE
chore: add buckets to histogram metrics

### DIFF
--- a/github-runner-manager/src/github_runner_manager/metrics/runner.py
+++ b/github-runner-manager/src/github_runner_manager/metrics/runner.py
@@ -50,21 +50,25 @@ RUNNER_IDLE_DURATION_SECONDS = Histogram(
     name="runner_idle_duration_seconds",
     documentation="Time in seconds to runner waiting idle for the job to be picked up.",
     labelnames=[labels.FLAVOR],
+    buckets=[5, 10, 15, 30, 60, 60 * 2, 60 * 3, 60 * 5, 60 * 10, float("inf")],
 )
 RUNNER_QUEUE_DURATION_SECONDS = Histogram(
     name="runner_queue_duration_seconds",
     documentation="Time taken in seconds for the job to be started.",
     labelnames=[labels.FLAVOR],
+    buckets=[5, 30, 60, 60 * 5, 60 * 10, 60 * 20, 60 * 30, 60 * 60, 60 * 60 * 2, float("inf")],
 )
 EXTRACT_METRICS_DURATION_SECONDS = Histogram(
     name="extract_metrics_duration_seconds",
     documentation="Time taken in seconds for the metrics to be extracted.",
     labelnames=[labels.FLAVOR],
+    buckets=[5, 10, 15, 30, 60, 60 * 2, 60 * 3, 60 * 5, 60 * 10, float("inf")],
 )
 JOB_DURATION_SECONDS = Histogram(
     name="job_duration_seconds",
     documentation="Time taken in seconds for the job to be completed.",
     labelnames=[labels.FLAVOR],
+    buckets=[60, 60 * 5, 60 * 10, 60 * 20, 60 * 30, 60 * 60, 60 * 60 * 2, float("inf")],
 )
 JOB_REPOSITORY_COUNT = Gauge(
     name="job_repository_count",


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Adds buckets to histogram metrics
<!-- A high level overview of the change -->

### Rationale

- For metrics values that are not sub-seconds, the default bucket sizes are too fine-grained, making most of the metrics end up in +inf bucket.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

<!-- Explanation for any unchecked items above -->

No user facing changes, only metrics bucket sizes are updated.