### PR TITLE
test: microk8s wait ready timeout

### DIFF
--- a/tests/integration/setup-integration-tests.sh
+++ b/tests/integration/setup-integration-tests.sh
@@ -22,7 +22,7 @@ fi
 # Get preferred source IP address for metallb
 IPADDR=$( { ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc'; } )
 sudo microk8s enable "metallb:$IPADDR-$IPADDR" "hostpath-storage"
-microk8s status --wait-ready
+microk8s status --wait-ready --timeout=1200
 
 unset JUJU_CONTROLLER
 unset JUJU_MODEL


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Add timeout to microk8s setup script
<!-- A high level overview of the change -->

### Rationale

- Due to infra issues, this does not timeout and continues to hold the runner for 6+ hours
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

No user facing changes.
<!-- Explanation for any unchecked items above -->