### PR TITLE
fix: Remove -v in socat as in can incur in performance issues

### DIFF
--- a/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
@@ -53,7 +53,7 @@ StandardError=syslog
 RestartSec=1
 SyslogIdentifier=tmate-http-proxy
 
-ExecStart=socat -v TCP-LISTEN:{{ssh_debug_info.local_proxy_port}},fork,bind={{ssh_debug_info.local_proxy_host}} PROXY:{{runner_proxy_config.proxy_host}}:{{ssh_debug_info['host']}}:{{ssh_debug_info['port']}}{% if runner_proxy_config.proxy_port %},proxyport={{runner_proxy_config.proxy_port}}{% endif %}
+ExecStart=socat TCP-LISTEN:{{ssh_debug_info.local_proxy_port}},fork,bind={{ssh_debug_info.local_proxy_host}} PROXY:{{runner_proxy_config.proxy_host}}:{{ssh_debug_info['host']}}:{{ssh_debug_info['port']}}{% if runner_proxy_config.proxy_port %},proxyport={{runner_proxy_config.proxy_port}}{% endif %}
 Restart=always
 
 [Install]


### PR DESCRIPTION
Applicable spec: <link>

### Overview

`-v` in socat writes transferred data to stderr, and it has been reported that in can generate performance issues. 

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

<!-- Explanation for any unchecked items above -->