### PR TITLE
ci: apply dockerhub mirror e2e

### DIFF
--- a/.github/workflows/e2e_test_run.yaml
+++ b/.github/workflows/e2e_test_run.yaml
@@ -59,6 +59,10 @@ jobs:
         run: sudo snap install microk8s --classic
       - name: Setup Dockerhub mirror for microk8s
         run: |
+          if [[ -z "${DOCKERHUB_MIRROR}" ]]; then
+              echo "DOCKERHUB_MIRROR not set, skipping Docker Hub mirror setup"
+              exit 0
+          fi
           sudo tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml > /dev/null << EOF
           server = "$DOCKERHUB_MIRROR"
 
@@ -67,7 +71,12 @@ jobs:
           EOF
           cat /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml
       - name: Restart microk8s to apply mirror settings
-        run: microk8s stop && microk8s start
+        run: |
+          if [[ -z "${DOCKERHUB_MIRROR}" ]]; then
+              echo "DOCKERHUB_MIRROR not set, skipping microk8s restart"
+              exit 0
+          fi
+          microk8s stop && microk8s start
       - name: Wait for microk8s
         timeout-minutes: 10
         run: microk8s status --wait-ready


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Apply dockerhub mirror to microk8s - e2e tests are failing due to it. Working workflow link: https://github.com/canonical/github-runner-operator-tests/actions/runs/19757724850/job/56612415758

- Since dispatched workflows are only applied after they've been merged to main, this PR needs to be force merged.
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

<!-- Explanation for any unchecked items above -->