### PR TITLE
test: fix jubilant controller prefix issue

### DIFF
--- a/tests/integration/test_prometheus_metrics.py
+++ b/tests/integration/test_prometheus_metrics.py
@@ -42,8 +42,11 @@ def prometheus_app_fixture(k8s_juju: jubilant.Juju):
     """Deploy prometheus charm."""
     k8s_juju.deploy("prometheus-k8s", channel="1/stable")
     k8s_juju.wait(lambda status: jubilant.all_active(status, "prometheus-k8s"))
+    # k8s_juju.model and juju.model already has <controller>: prefixed. we must split them since
+    # juju.consume expects only the model name.
+    k8s_juju_model_name = k8s_juju.model.split(":", 1)[1]
     k8s_juju.offer(
-        f"{k8s_juju.model}.prometheus-k8s",
+        f"{k8s_juju_model_name}.prometheus-k8s",
         endpoint="receive-remote-write",
         controller=MICROK8S_CONTROLLER_NAME,
     )
@@ -56,8 +59,11 @@ def grafana_app_fixture(k8s_juju: jubilant.Juju, prometheus_app: AppStatus):
     k8s_juju.deploy("grafana-k8s", channel="1/stable")
     k8s_juju.integrate("grafana-k8s:grafana-source", f"{prometheus_app.charm_name}:grafana-source")
     k8s_juju.wait(lambda status: jubilant.all_active(status, "grafana-k8s", "prometheus-k8s"))
+    # k8s_juju.model and juju.model already has <controller>: prefixed. we must split them since
+    # juju.consume expects only the model name.
+    k8s_juju_model_name = k8s_juju.model.split(":", 1)[1]
     k8s_juju.offer(
-        f"{k8s_juju.model}.grafana-k8s",
+        f"{k8s_juju_model_name}.grafana-k8s",
         endpoint="grafana-dashboard",
         controller=MICROK8S_CONTROLLER_NAME,
     )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Update test syntax to lastest jubilant syntax, this test is failing due to backwards incompatible jubilant updates.
<!-- A high level overview of the change -->

### Rationale

- Remove test failure blocker.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

Testing syntax update only.
<!-- Explanation for any unchecked items above -->