### PR TITLE
fix: Fix deprecation warning message formatting

### DIFF
--- a/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
@@ -22,7 +22,7 @@ jq -n \
 {% endif %}
 
 {% if do_repo_policy_check %}
-  logger -s "Repo policy check is marked for deprecation. Consider using `allow_external_contributor` instead"
+  logger -s "Repo policy check is marked for deprecation. Consider using 'allow_external_contributor' instead"
 
     # Log common env variables.
     logger -s "GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}, \


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fix deprecation warning message formatting

### Rationale

an error is logged in the pre-job because `allow_external_contributor` is executed



### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

<!-- Explanation for any unchecked items above -->