### PR TITLE
fix: update queue duration calculation

### DIFF
--- a/github-runner-manager/src/github_runner_manager/github_client.py
+++ b/github-runner-manager/src/github_runner_manager/github_client.py
@@ -464,7 +464,18 @@ class GithubClient:
         # datetime strings should be in ISO 8601 format, but they can also use Z instead of +00:00,
         # which is not supported by datetime.fromisoformat
         created_at = datetime.fromisoformat(job["created_at"].replace("Z", "+00:00"))
-        started_at = datetime.fromisoformat(job["started_at"].replace("Z", "+00:00"))
+        queued_at_raw = job.get("queued_at")
+        queued_at = (
+            datetime.fromisoformat(queued_at_raw.replace("Z", "+00:00"))
+            if queued_at_raw
+            else None
+        )
+        started_at_raw = job.get("started_at")
+        started_at = (
+            datetime.fromisoformat(started_at_raw.replace("Z", "+00:00"))
+            if started_at_raw
+            else None
+        )
         # conclusion could be null or an empty dictionary per api schema, so we need to handle
         # that though we would assume that it should always be present, as the job should be
         # finished.
@@ -474,6 +485,7 @@ class GithubClient:
         job_id = job["id"]
         return JobInfo(
             job_id=job_id,
+            queued_at=queued_at,
             created_at=created_at,
             started_at=started_at,
             conclusion=conclusion,

--- a/github-runner-manager/src/github_runner_manager/metrics/github.py
+++ b/github-runner-manager/src/github_runner_manager/metrics/github.py
@@ -50,6 +50,7 @@ def job(
     except (JobNotFoundError, PlatformApiError) as exc:
         raise GithubMetricsError from exc
 
-    queue_duration = (job_info.started_at - job_info.created_at).total_seconds()
+    queued_or_created_at = job_info.queued_at or job_info.created_at
+    queue_duration = (job_info.started_at - queued_or_created_at).total_seconds()
 
     return GithubJobMetrics(queue_duration=queue_duration, conclusion=job_info.conclusion)

--- a/github-runner-manager/src/github_runner_manager/metrics/github.py
+++ b/github-runner-manager/src/github_runner_manager/metrics/github.py
@@ -51,6 +51,10 @@ def job(
         raise GithubMetricsError from exc
 
     queued_or_created_at = job_info.queued_at or job_info.created_at
-    queue_duration = (job_info.started_at - queued_or_created_at).total_seconds()
+    queue_duration = (
+        (job_info.started_at - queued_or_created_at).total_seconds()
+        if job_info.started_at
+        else None
+    )
 
     return GithubJobMetrics(queue_duration=queue_duration, conclusion=job_info.conclusion)

--- a/github-runner-manager/src/github_runner_manager/metrics/runner.py
+++ b/github-runner-manager/src/github_runner_manager/metrics/runner.py
@@ -550,7 +550,11 @@ def _issue_runner_start(
         else float("inf")
     )
     RUNNER_IDLE_DURATION_SECONDS.labels(flavor).observe(idle_duration)
-    queue_duration = job_metrics.queue_duration if job_metrics else float("inf")
+    queue_duration = (
+        job_metrics.queue_duration
+        if job_metrics and job_metrics.queue_duration is not None
+        else float("inf")
+    )
     RUNNER_QUEUE_DURATION_SECONDS.labels(flavor).observe(queue_duration)
     return metric_events.RunnerStart
 
@@ -614,14 +618,18 @@ def _create_runner_start(
         pre_job_metrics.timestamp - (runner_metrics.installation_end_timestamp or 0), 0
     )
 
-    # GitHub API returns started_at < created_at in some rare cases.
-    if job_metrics and job_metrics.queue_duration < 0:
+    # GitHub API returns started_at < queued_at in some rare cases.
+    if job_metrics and job_metrics.queue_duration is not None and job_metrics.queue_duration < 0:
         logger.warning(
             "Queue duration for runner %s is negative: %f. Setting it to zero.",
             runner_metrics.instance_id,
             job_metrics.queue_duration,
         )
-    queue_duration = max(job_metrics.queue_duration, 0) if job_metrics else None
+    queue_duration = (
+        max(job_metrics.queue_duration, 0)
+        if job_metrics and job_metrics.queue_duration is not None
+        else None
+    )
 
     return metric_events.RunnerStart(
         timestamp=pre_job_metrics.timestamp,

--- a/github-runner-manager/src/github_runner_manager/metrics/type.py
+++ b/github-runner-manager/src/github_runner_manager/metrics/type.py
@@ -19,5 +19,5 @@ class GithubJobMetrics(NamedTuple):
         conclusion: The conclusion of the job.
     """
 
-    queue_duration: float
+    queue_duration: Optional[float]
     conclusion: Optional[JobConclusion]

--- a/github-runner-manager/src/github_runner_manager/platform/github_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/github_provider.py
@@ -303,6 +303,7 @@ class GitHubRunnerPlatform(PlatformProvider):
             job_info,
         )
         return JobInfo(
+            queued_at=job_info.queued_at,
             created_at=job_info.created_at,
             started_at=job_info.started_at,
             conclusion=job_info.conclusion,

--- a/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
@@ -249,7 +249,7 @@ class JobInfo:
         conclusion: The end result of a job.
     """
 
-    queued_at: datetime
+    queued_at: datetime | None
     created_at: datetime
     started_at: datetime | None
     # A str until we realise a common pattern, use a simple str

--- a/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
+++ b/github-runner-manager/src/github_runner_manager/platform/platform_provider.py
@@ -243,12 +243,14 @@ class JobInfo:
     """Stats for a job on a platform.
 
     Attributes:
+        queued_at: The time the job entered the queue.
         created_at: The time the job was created.
         started_at: The time the job was started.
         conclusion: The end result of a job.
     """
 
+    queued_at: datetime
     created_at: datetime
-    started_at: datetime
+    started_at: datetime | None
     # A str until we realise a common pattern, use a simple str
     conclusion: str | None

--- a/github-runner-manager/src/github_runner_manager/types_/github.py
+++ b/github-runner-manager/src/github_runner_manager/types_/github.py
@@ -118,6 +118,7 @@ class JobInfo(BaseModel):
 
     Attributes:
         job_id: The ID of the job.
+        queued_at: The time the job entered the queue.
         created_at: The time the job was created.
         started_at: The time the job was started.
         conclusion: The end result of a job.
@@ -125,8 +126,9 @@ class JobInfo(BaseModel):
     """
 
     job_id: int
+    queued_at: datetime
     created_at: datetime
-    started_at: datetime
+    started_at: Optional[datetime]
     conclusion: Optional[JobConclusion]
     status: JobStatus
 

--- a/github-runner-manager/src/github_runner_manager/types_/github.py
+++ b/github-runner-manager/src/github_runner_manager/types_/github.py
@@ -126,7 +126,7 @@ class JobInfo(BaseModel):
     """
 
     job_id: int
-    queued_at: datetime
+    queued_at: Optional[datetime]
     created_at: datetime
     started_at: Optional[datetime]
     conclusion: Optional[JobConclusion]

--- a/github-runner-manager/tests/unit/metrics/test_github.py
+++ b/github-runner-manager/tests/unit/metrics/test_github.py
@@ -42,6 +42,7 @@ def test_job(pre_job_metrics: PreJobMetrics):
     created_at = datetime(2021, 10, 1, 0, 0, 0, tzinfo=timezone.utc)
     started_at = created_at + timedelta(seconds=3600)
     github_client.get_job_info_by_runner_name.return_value = JobInfo(
+        queued_at=created_at,
         created_at=created_at,
         started_at=started_at,
         conclusion=JobConclusion.SUCCESS,
@@ -60,6 +61,39 @@ def test_job(pre_job_metrics: PreJobMetrics):
     )
 
     assert job_metrics.queue_duration == 3600
+    assert job_metrics.conclusion == JobConclusion.SUCCESS
+
+
+def test_job_missing_started_at(pre_job_metrics: PreJobMetrics):
+    """
+    arrange: create a GithubClient mock with missing started_at.
+    act: Call job.
+    assert: queue_duration is None.
+    """
+    prefix = "app-0"
+    github_client = MagicMock(spec=GithubClient)
+    runner = InstanceID.build(prefix=prefix)
+    created_at = datetime(2021, 10, 1, 0, 0, 0, tzinfo=timezone.utc)
+    github_client.get_job_info_by_runner_name.return_value = JobInfo(
+        queued_at=created_at,
+        created_at=created_at,
+        started_at=None,
+        conclusion=JobConclusion.SUCCESS,
+        status=JobStatus.QUEUED,
+        job_id=randint(1, 1000),
+    )
+
+    github_provider = GitHubRunnerPlatform(
+        prefix=prefix, path="canonical", github_client=github_client
+    )
+    job_metrics = github_metrics.job(
+        platform_provider=github_provider,
+        pre_job_metrics=pre_job_metrics,
+        runner=runner,
+        metadata=RunnerMetadata(),
+    )
+
+    assert job_metrics.queue_duration is None
     assert job_metrics.conclusion == JobConclusion.SUCCESS
 
 

--- a/github-runner-manager/tests/unit/test_github_client.py
+++ b/github-runner-manager/tests/unit/test_github_client.py
@@ -28,7 +28,7 @@ from github_runner_manager.types_.github import (
 
 JobStatsRawData = namedtuple(
     "JobStatsRawData",
-    ["created_at", "started_at", "runner_name", "conclusion", "id", "status"],
+    ["created_at", "queued_at", "started_at", "runner_name", "conclusion", "id", "status"],
 )
 
 
@@ -38,6 +38,7 @@ def job_stats_fixture() -> JobStatsRawData:
     runner_name = secrets.token_hex(16)
     return JobStatsRawData(
         created_at="2021-10-01T00:00:00Z",
+        queued_at="2021-10-01T00:30:00Z",
         started_at="2021-10-01T01:00:00Z",
         conclusion="success",
         status="completed",
@@ -60,6 +61,7 @@ def github_client_fixture(job_stats_raw: JobStatsRawData) -> GithubClient:
             "jobs": [
                 {
                     "created_at": job_stats_raw.created_at,
+                    "queued_at": job_stats_raw.queued_at,
                     "started_at": job_stats_raw.started_at,
                     "runner_name": job_stats_raw.runner_name,
                     "conclusion": job_stats_raw.conclusion,
@@ -97,6 +99,7 @@ def _mock_multiple_pages_for_job_response(
                 "jobs": [
                     {
                         "created_at": job_stats_raw.created_at,
+                        "queued_at": job_stats_raw.queued_at,
                         "started_at": job_stats_raw.started_at,
                         "runner_name": runner_names[i * no_of_jobs_per_page + j],
                         "conclusion": job_stats_raw.conclusion,
@@ -128,6 +131,7 @@ def test_get_job_info_by_runner_name(github_client: GithubClient, job_stats_raw:
     )
     assert job_stats == JobInfo(
         created_at=datetime(2021, 10, 1, 0, 0, 0, tzinfo=timezone.utc),
+        queued_at=datetime(2021, 10, 1, 0, 30, 0, tzinfo=timezone.utc),
         started_at=datetime(2021, 10, 1, 1, 0, 0, tzinfo=timezone.utc),
         conclusion=JobConclusion.SUCCESS,
         status=JobStatus.COMPLETED,
@@ -150,6 +154,7 @@ def test_get_job_info_by_runner_name_no_conclusion(
             "jobs": [
                 {
                     "created_at": job_stats_raw.created_at,
+                    "queued_at": job_stats_raw.queued_at,
                     "started_at": job_stats_raw.started_at,
                     "runner_name": job_stats_raw.runner_name,
                     "conclusion": None,
@@ -167,6 +172,7 @@ def test_get_job_info_by_runner_name_no_conclusion(
     )
     assert job_stats == JobInfo(
         created_at=datetime(2021, 10, 1, 0, 0, 0, tzinfo=timezone.utc),
+        queued_at=datetime(2021, 10, 1, 0, 30, 0, tzinfo=timezone.utc),
         started_at=datetime(2021, 10, 1, 1, 0, 0, tzinfo=timezone.utc),
         conclusion=None,
         status=JobStatus.COMPLETED,
@@ -184,6 +190,7 @@ def test_get_job_info(github_client: GithubClient, job_stats_raw: JobStatsRawDat
         {},
         {
             "created_at": job_stats_raw.created_at,
+            "queued_at": job_stats_raw.queued_at,
             "started_at": job_stats_raw.started_at,
             "runner_name": job_stats_raw.runner_name,
             "conclusion": job_stats_raw.conclusion,
@@ -195,6 +202,7 @@ def test_get_job_info(github_client: GithubClient, job_stats_raw: JobStatsRawDat
     job_stats = github_client.get_job_info(path=github_repo, job_id=job_stats_raw.id)
     assert job_stats == JobInfo(
         created_at=datetime(2021, 10, 1, 0, 0, 0, tzinfo=timezone.utc),
+        queued_at=datetime(2021, 10, 1, 0, 30, 0, tzinfo=timezone.utc),
         started_at=datetime(2021, 10, 1, 1, 0, 0, tzinfo=timezone.utc),
         conclusion=JobConclusion.SUCCESS,
         status=JobStatus.COMPLETED,
@@ -223,6 +231,38 @@ def test_github_api_pagination_multiple_pages(
     )
     assert job_stats == JobInfo(
         created_at=datetime(2021, 10, 1, 0, 0, 0, tzinfo=timezone.utc),
+        queued_at=datetime(2021, 10, 1, 0, 30, 0, tzinfo=timezone.utc),
+        started_at=datetime(2021, 10, 1, 1, 0, 0, tzinfo=timezone.utc),
+        conclusion=JobConclusion.SUCCESS,
+        status=JobStatus.COMPLETED,
+        job_id=job_stats_raw.id,
+    )
+
+
+def test_get_job_info_without_queued_at(
+    github_client: GithubClient, job_stats_raw: JobStatsRawData
+):
+    """
+    arrange: A mocked Github Client with queued_at missing in the response.
+    act: Call get_job_info.
+    assert: The response is returned with queued_at set to None.
+    """
+    github_client._requester.requestJsonAndCheck.return_value = (
+        {},
+        {
+            "created_at": job_stats_raw.created_at,
+            "started_at": job_stats_raw.started_at,
+            "runner_name": job_stats_raw.runner_name,
+            "conclusion": job_stats_raw.conclusion,
+            "status": job_stats_raw.status,
+            "id": job_stats_raw.id,
+        },
+    )
+    github_repo = GitHubRepo(owner=secrets.token_hex(16), repo=secrets.token_hex(16))
+    job_stats = github_client.get_job_info(path=github_repo, job_id=job_stats_raw.id)
+    assert job_stats == JobInfo(
+        created_at=datetime(2021, 10, 1, 0, 0, 0, tzinfo=timezone.utc),
+        queued_at=None,
         started_at=datetime(2021, 10, 1, 1, 0, 0, tzinfo=timezone.utc),
         conclusion=JobConclusion.SUCCESS,
         status=JobStatus.COMPLETED,


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

<!-- Explanation for any unchecked items above -->