### PR TITLE
fix(charm): check image readiness before starting runner manager service

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 This changelog documents user-relevant changes to the GitHub runner charm.
 
+## 2026-04-03
+
+- Fixed charm not entering blocked/waiting status when the image integration has no image available. Previously, some event handlers (`upgrade-charm`, `planner-relation-changed`, `planner-relation-broken`) would start the runner manager service without checking image readiness, causing the service to error with "No runner combinations configured."
+
 ## 2026-03-30
 
 - Fixed stale `systemd` service files left behind when a unit is removed from a co-located machine. The service is now disabled, the service file removed, and the unit data cleaned up on stop.

--- a/src/charm.py
+++ b/src/charm.py
@@ -354,8 +354,6 @@ class GithubRunnerCharm(CharmBase):
             ]
             flush_runners = True
 
-        self._check_image_ready()
-
         self._reconcile(state)
 
         if flush_runners:
@@ -389,6 +387,7 @@ class GithubRunnerCharm(CharmBase):
         Args:
             state: The charm state.
         """
+        self._check_image_ready()
         self._setup_service(state)
         self._update_planner_flavor(state)
 
@@ -475,8 +474,6 @@ class GithubRunnerCharm(CharmBase):
     def _on_debug_ssh_relation_changed(self, _: ops.RelationChangedEvent) -> None:
         """Handle debug ssh relation changed event."""
         self.unit.status = MaintenanceStatus("Added debug-ssh relation")
-        self._check_image_ready()
-
         state = self._setup_state()
         self._reconcile(state)
 
@@ -498,8 +495,6 @@ class GithubRunnerCharm(CharmBase):
     def _on_image_relation_changed(self, _: ops.RelationChangedEvent) -> None:
         """Handle image relation changed event."""
         self.unit.status = MaintenanceStatus("Update image for runners")
-        self._check_image_ready()
-
         state = self._setup_state()
         self._reconcile(state)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -605,6 +605,42 @@ def test_on_config_changed_openstack_clouds_yaml(mock_side_effects):
     assert harness.charm.unit.status == BlockedStatus("Please provide image integration.")
 
 
+@pytest.mark.parametrize(
+    "handler_name, emit_event",
+    [
+        pytest.param(
+            "_on_upgrade_charm",
+            lambda h: h.charm.on.upgrade_charm.emit(),
+            id="upgrade-charm",
+        ),
+        pytest.param(
+            "_on_planner_relation_changed",
+            lambda h: h.charm._on_planner_relation_changed(MagicMock()),
+            id="planner-relation-changed",
+        ),
+    ],
+)
+def test_reconcile_blocks_when_image_not_ready(
+    harness: Harness, mock_side_effects, monkeypatch, handler_name, emit_event
+):
+    """
+    arrange: Set up charm with no image integration.
+    act: Fire an event that calls _reconcile without an explicit _check_image_ready call.
+    assert: Charm enters blocked/waiting status and the service is stopped.
+    """
+    harness.charm._setup_state = MagicMock()
+    manager_client_mock = MagicMock(spec=GitHubRunnerManagerClient)
+    harness.charm._manager_client = manager_client_mock
+    mock_mgr_service = MagicMock()
+    monkeypatch.setattr("charm.manager_service", mock_mgr_service)
+    monkeypatch.setattr("charm.execute_command", MagicMock(return_value=(0, "Mock_stdout")))
+    monkeypatch.setattr("charm.pathlib", MagicMock())
+
+    emit_event(harness)
+
+    assert harness.charm.unit.status.name == BlockedStatus.name
+
+
 def test_metric_log_ownership_for_upgrade(
     harness: Harness, mock_side_effects, tmp_path: Path, monkeypatch
 ):
@@ -686,6 +722,7 @@ def test_planner_relation_changed_writes_flavor(monkeypatch: pytest.MonkeyPatch)
     state_mock.runner_config.openstack_image.tags = ["x64", "noble"]
     harness.charm._setup_state = MagicMock(return_value=state_mock)
     harness.charm._setup_service = MagicMock()
+    harness.charm._check_image_ready = MagicMock()
 
     harness.update_relation_data(relation_id, "planner-app/0", {"endpoint": "http://example.com"})
 


### PR DESCRIPTION
###  Overview                                                                                                                                                                                                                                            

  Moved _check_image_ready() into _reconcile() so every code path that starts the runner manager service first verifies the image integration has an available image.                                                                                   
   
###  Rationale                                                                                                                                                                                                                                             
                            
  Several event handlers (_on_upgrade_charm, _on_planner_relation_changed, _on_planner_relation_broken) called _reconcile() without checking image readiness. This caused the service to start with combinations: [] and error with "No runner          
  combinations configured" instead of setting the charm to blocked/waiting status.
                                                                                                                                                                                                                                                        
 ### Juju Events Changes       

  No new events. Existing handlers _on_upgrade_charm, _on_planner_relation_changed, _on_planner_relation_broken, _on_config_changed, _on_image_relation_changed, and _on_debug_ssh_relation_changed now all go through _reconcile() for image readiness 
  checks. Redundant _check_image_ready() calls removed from the latter three.
                                                                                                                                                                                                                                                        
 ### Module Changes            

  - charm.py: _reconcile() now calls _check_image_ready() before _setup_service().

 ### Library Changes

  None.                                                                                                                                                                                                                                                 
   
  Checklist                                                                                                                                                                                                                                             
                            
  - [x] The charm style guide was applied.
  - [x] The contributing guide was applied.
  - [x] The changes are compliant with ISD054 - Managing Charm Complexity                                                                                                                                                                                   
  - [x] The documentation for charmhub is updated.
  - [x] The PR is tagged with appropriate label (urgent, trivial, complex).                                                                                                                                                                                 
  - [ ] The changelog is updated with changes that affects the users of the charm.
  - [ ] The application version number is updated in github-runner-manager/pyproject.toml.