### PR TITLE
fix(secret): use refresh=True to always use latest secret revision

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 This changelog documents user-relevant changes to the GitHub runner charm.
 
+## 2026-04-13
+
+- Fixed Juju secrets not picking up new revisions. The charm now uses `refresh=True` when reading secret contents, ensuring it always retrieves the latest revision instead of a cached one.
+
 ## 2026-04-07
 
 - Add GitHub App authentication support using Juju secrets for the private key, alongside the existing PAT-based authentication.

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -205,7 +205,7 @@ class GithubConfig:
         if private_key_secret_id:
             try:
                 private_key_secret = charm.model.get_secret(id=private_key_secret_id)
-                private_key = private_key_secret.get_content().get("private-key")
+                private_key = private_key_secret.get_content(refresh=True).get("private-key")
             except SecretNotFoundError as exc:
                 raise CharmConfigInvalidError(
                     f"GitHub App private key secret {private_key_secret_id} not found"
@@ -808,8 +808,7 @@ def _build_planner_config_from_charm(charm: CharmBase) -> PlannerConfig | None:
         return None
     try:
         token_secret = charm.model.get_secret(id=token_secret_id)
-        # no need for refresh - there shouldn't be multiple secret revisions
-        token_content = token_secret.get_content()
+        token_content = token_secret.get_content(refresh=True)
         token = token_content.get("token")
         if not token:
             logger.warning(

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -133,6 +133,7 @@ def test_github_config_from_charm_app_only():
     assert result.installation_id == 456
     assert result.private_key == "private-key-pem"
     mock_charm.model.get_secret.assert_called_once_with(id="secret:abc123")
+    secret_mock.get_content.assert_called_once_with(refresh=True)
 
 
 @pytest.mark.parametrize(
@@ -769,6 +770,7 @@ def test_planner_config_from_charm_extracts_endpoint_token():
         endpoint="http://planner.example.com", token="planner-token-value"
     )
     mock_charm.model.get_secret.assert_called_once_with(id="secret:abc123")
+    secret_mock.get_content.assert_called_once_with(refresh=True)
 
 
 def test_planner_config_from_charm_no_relation():


### PR DESCRIPTION
### Overview

Use refresh=True in get_content secret calls

### Rationale

otherwise a secret update will not be considered


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [x] The changelog is updated with changes that affects the users of the charm.
- [x] The application version number is updated in `github-runner-manager/pyproject.toml`.

<!-- Explanation for any unchecked items above -->