### PR TITLE
fix(tests): pin juju agent to 3.6.20

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -15,6 +15,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
+      bootstrap-options: "--agent-version=3.6.20"
       juju-channel: 3.6/stable
       provider: lxd
       test-tox-env: integration-juju3.6

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -17,6 +17,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
+      bootstrap-options: "--agent-version=3.6.20"
       juju-channel: 3.6/stable
       provider: lxd
       test-tox-env: integration-juju3.6
@@ -43,6 +44,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
+      bootstrap-options: "--agent-version=3.6.20"
       charmcraft-channel: latest/stable
       juju-channel: 3.6/stable
       pre-run-script: tests/integration/setup-integration-tests.sh
@@ -74,6 +76,7 @@ jobs:
       matrix:
         base: ["22.04", "24.04"]
     with:
+      bootstrap-options: "--agent-version=3.6.20"
       charmcraft-channel: latest/stable
       juju-channel: 3.6/stable
       provider: lxd


### PR DESCRIPTION
### Overview

Pin juju agent version to 3.6.20 in all integration and e2e test workflows to avoid CI flakiness from the recent 3.6.21 release.

### Rationale

CI has been flaky recently. Testing whether pinning to the previous juju agent version (3.6.20) resolves the instability introduced by 3.6.21 (released 2026-04-09).

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

<!-- No docs, changelog, or version bump needed — CI-only change, no user-facing impact -->