### PR TITLE
fix: set log=Fasle for jubilant deploy

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -561,6 +561,7 @@ def image_builder_fixture(
                 "virt-type": "virtual-machine",
                 "cores": "2",
             },
+            log=False,
         )
 
         yield image_builder_app_name
@@ -580,7 +581,8 @@ def image_builder_fixture(
     series = dep_ctx.series
 
     any_charm_src_overwrite = {
-        "any_charm.py": textwrap.dedent(f"""\
+        "any_charm.py": textwrap.dedent(
+            f"""\
             from any_charm_base import AnyCharmBase
 
             class AnyCharm(AnyCharmBase):
@@ -593,7 +595,8 @@ relation_changed, self._image_relation_changed)
                     # Provide mock image relation data
                     event.relation.data[self.unit]['id'] = '{openstack_config.test_image_id}'
                     event.relation.data[self.unit]['tags'] = '{series}, amd64'
-            """),
+            """
+        ),
     }
     logging.info(
         "Deploying fake image builder via any-charm for image ID %s",
@@ -919,7 +922,8 @@ def mock_planner_app(juju: jubilant.Juju, planner_token_secret: str) -> Iterator
     planner_name = "planner"
 
     any_charm_src_overwrite = {
-        "any_charm.py": textwrap.dedent(f"""\
+        "any_charm.py": textwrap.dedent(
+            f"""\
             from any_charm_base import AnyCharmBase
 
             class AnyCharm(AnyCharmBase):
@@ -933,7 +937,8 @@ def mock_planner_app(juju: jubilant.Juju, planner_token_secret: str) -> Iterator
                 def _on_planner_relation_changed(self, event):
                     event.relation.data[self.app]["endpoint"] = "http://mock:8080"
                     event.relation.data[self.app]["token"] = "{planner_token_secret}"
-            """),
+            """
+        ),
     }
 
     juju.deploy(

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -185,6 +185,7 @@ def deploy_github_runner_charm(
         base=base,
         config=default_config,
         constraints=constraints or DEFAULT_RUNNER_CONSTRAINTS,
+        log=False,
         **(deploy_kwargs or {}),
     )
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
- set jubilant deploy logs to False

### Rationale

- jubilant deploy may contain sensitive commands
<!-- The reason the change is needed -->

### Juju Events Changes

- None, only testing changes
<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied.
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied.
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated.
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`).
- [ ] The changelog is updated with changes that affects the users of the charm.
- [ ] The application version number is updated in `github-runner-manager/pyproject.toml`.

Testing code changes only.
<!-- Explanation for any unchecked items above -->