### PR TITLE
Disable jubilant logging for juju.deploy, juju.config and juju.exec

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -481,7 +481,7 @@ def app_no_runner(
     basic_app: str,
 ) -> Iterator[str]:
     """Application with no runner."""
-    juju.config(basic_app, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "0"})
+    juju.config(basic_app, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "0"}, log=False)
     juju.wait(
         lambda status: jubilant.all_active(status, basic_app),
         timeout=20 * 60,
@@ -581,8 +581,7 @@ def image_builder_fixture(
     series = dep_ctx.series
 
     any_charm_src_overwrite = {
-        "any_charm.py": textwrap.dedent(
-            f"""\
+        "any_charm.py": textwrap.dedent(f"""\
             from any_charm_base import AnyCharmBase
 
             class AnyCharm(AnyCharmBase):
@@ -595,8 +594,7 @@ relation_changed, self._image_relation_changed)
                     # Provide mock image relation data
                     event.relation.data[self.unit]['id'] = '{openstack_config.test_image_id}'
                     event.relation.data[self.unit]['tags'] = '{series}, amd64'
-            """
-        ),
+            """),
     }
     logging.info(
         "Deploying fake image builder via any-charm for image ID %s",
@@ -607,6 +605,7 @@ relation_changed, self._image_relation_changed)
         app=image_builder_app_name,
         channel="latest/beta",
         config={"src-overwrite": json.dumps(any_charm_src_overwrite)},
+        log=False,
     )
     yield image_builder_app_name
 
@@ -680,8 +679,8 @@ def app_scheduled_events_fixture(
     app_openstack_runner: str,
 ) -> str:
     """Application to check scheduled events."""
-    juju.config(app_openstack_runner, values={"reconcile-interval": "8"})
-    juju.config(app_openstack_runner, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "1"})
+    juju.config(app_openstack_runner, values={"reconcile-interval": "8"}, log=False)
+    juju.config(app_openstack_runner, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "1"}, log=False)
     juju.wait(
         lambda status: jubilant.all_active(status, app_openstack_runner),
         timeout=20 * 60,
@@ -730,7 +729,7 @@ def app_no_wait_fixture(
         base=deployment_context.base,
         wait_idle=False,
     )
-    juju.config(deployed_name, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "1"})
+    juju.config(deployed_name, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "1"}, log=False)
     return deployed_name
 
 
@@ -744,6 +743,7 @@ def tmate_ssh_server_app_fixture(juju: jubilant.Juju) -> str:
         # 2025-11-26: Set deployment type to virtual-machine due to bug with snapd. See:
         # https://github.com/canonical/snapd/pull/16131
         constraints={"virt-type": "virtual-machine"},
+        log=False,
     )
     return tmate_app_name
 
@@ -845,7 +845,9 @@ def app_with_forked_repo(
     Test should ensure it returns with the application in a good state and has
     one runner.
     """
-    juju.config(basic_app, values={PATH_CONFIG_NAME: forked_github_repository.full_name})
+    juju.config(
+        basic_app, values={PATH_CONFIG_NAME: forked_github_repository.full_name}, log=False
+    )
 
     return basic_app
 
@@ -922,8 +924,7 @@ def mock_planner_app(juju: jubilant.Juju, planner_token_secret: str) -> Iterator
     planner_name = "planner"
 
     any_charm_src_overwrite = {
-        "any_charm.py": textwrap.dedent(
-            f"""\
+        "any_charm.py": textwrap.dedent(f"""\
             from any_charm_base import AnyCharmBase
 
             class AnyCharm(AnyCharmBase):
@@ -937,8 +938,7 @@ def mock_planner_app(juju: jubilant.Juju, planner_token_secret: str) -> Iterator
                 def _on_planner_relation_changed(self, event):
                     event.relation.data[self.app]["endpoint"] = "http://mock:8080"
                     event.relation.data[self.app]["token"] = "{planner_token_secret}"
-            """
-        ),
+            """),
     }
 
     juju.deploy(
@@ -946,6 +946,7 @@ def mock_planner_app(juju: jubilant.Juju, planner_token_secret: str) -> Iterator
         app=planner_name,
         channel="latest/beta",
         config={"src-overwrite": json.dumps(any_charm_src_overwrite)},
+        log=False,
     )
 
     juju.wait(

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -75,7 +75,7 @@ def run_in_unit(
         Tuple of return code, stdout and stderr.
     """
     try:
-        task = juju.exec(command, unit=unit_name, wait=timeout)
+        task = juju.exec(command, unit=unit_name, wait=timeout, log=False)
         code, stdout, stderr = task.return_code, task.stdout, task.stderr
     except jubilant.TaskError as e:
         code, stdout, stderr = e.task.return_code, e.task.stdout, e.task.stderr

--- a/tests/integration/helpers/openstack.py
+++ b/tests/integration/helpers/openstack.py
@@ -156,7 +156,9 @@ class OpenStackInstanceHelper:
             app_name: The GitHub Runner Charm app name to create the runner for.
             num_runners: The number of runners.
         """
-        self.juju.config(app_name, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: f"{num_runners}"})
+        self.juju.config(
+            app_name, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: f"{num_runners}"}, log=False
+        )
         if num_runners == 0:
             return
         wait_for_runner_ready(self.juju, app_name, num_runners=num_runners)

--- a/tests/integration/test_charm_fork_path_change.py
+++ b/tests/integration/test_charm_fork_path_change.py
@@ -44,7 +44,7 @@ def test_path_config_change(
     logger.info("Ensure there is a runner (this calls reconcile)")
     instance_helper.ensure_charm_has_runner(app_with_forked_repo)
 
-    juju.config(app_with_forked_repo, values={PATH_CONFIG_NAME: github_config.path})
+    juju.config(app_with_forked_repo, values={PATH_CONFIG_NAME: github_config.path}, log=False)
 
     logger.info("Reconciling (again)")
     wait_for_runner_ready(juju, app_with_forked_repo)

--- a/tests/integration/test_charm_runner.py
+++ b/tests/integration/test_charm_runner.py
@@ -33,7 +33,7 @@ def app_fixture(
     """
     yield basic_app
 
-    juju.config(basic_app, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "0"})
+    juju.config(basic_app, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "0"}, log=False)
 
     unit_name = f"{basic_app}/0"
 
@@ -172,6 +172,7 @@ EOF
 logger -s "SSH config: $(cat ~/.ssh/config)"
     """,
         },
+        log=False,
     )
     wait_for_runner_ready(juju, app)
 

--- a/tests/integration/test_prometheus_metrics.py
+++ b/tests/integration/test_prometheus_metrics.py
@@ -43,7 +43,7 @@ def k8s_juju_fixture(request: pytest.FixtureRequest) -> Generator[jubilant.Juju,
 @pytest.fixture(scope="module", name="prometheus_app")
 def prometheus_app_fixture(k8s_juju: jubilant.Juju) -> AppStatus:
     """Deploy prometheus charm."""
-    k8s_juju.deploy("prometheus-k8s", channel="1/stable")
+    k8s_juju.deploy("prometheus-k8s", channel="1/stable", log=False)
     k8s_juju.wait(lambda status: jubilant.all_active(status, "prometheus-k8s"))
     assert k8s_juju.model is not None
     k8s_juju_model_name = k8s_juju.model.split(":", 1)[1]
@@ -58,7 +58,7 @@ def prometheus_app_fixture(k8s_juju: jubilant.Juju) -> AppStatus:
 @pytest.fixture(scope="module", name="grafana_app")
 def grafana_app_fixture(k8s_juju: jubilant.Juju, prometheus_app: AppStatus) -> AppStatus:
     """Deploy grafana charm."""
-    k8s_juju.deploy("grafana-k8s", channel="1/stable")
+    k8s_juju.deploy("grafana-k8s", channel="1/stable", log=False)
     k8s_juju.integrate("grafana-k8s:grafana-source", f"{prometheus_app.charm_name}:grafana-source")
     k8s_juju.wait(lambda status: jubilant.all_active(status, "grafana-k8s", "prometheus-k8s"))
     assert k8s_juju.model is not None
@@ -76,7 +76,7 @@ def traefik_ingress_fixture(
     k8s_juju: jubilant.Juju, prometheus_app: AppStatus, grafana_app: AppStatus
 ) -> None:
     """Ingress for cross controller communication."""
-    k8s_juju.deploy("traefik-k8s", channel="latest/stable")
+    k8s_juju.deploy("traefik-k8s", channel="latest/stable", log=False)
     k8s_juju.integrate("traefik-k8s", f"{prometheus_app.charm_name}:ingress")
     k8s_juju.integrate("traefik-k8s", f"{grafana_app.charm_name}:ingress")
 
@@ -94,10 +94,7 @@ def openstack_app_cos_agent_fixture(juju: jubilant.Juju, app_openstack_runner: s
     """Deploy cos-agent subordinate charm. Return the app name as a string."""
     app_name = app_openstack_runner
     juju.deploy(
-        COS_AGENT_CHARM,
-        channel="2/candidate",
-        base="ubuntu@22.04",
-        revision=149,
+        COS_AGENT_CHARM, channel="2/candidate", base="ubuntu@22.04", revision=149, log=False
     )
     juju.integrate(app_name, COS_AGENT_CHARM)
     juju.wait(lambda status: jubilant.all_agents_idle(status, app_name, COS_AGENT_CHARM))
@@ -144,7 +141,7 @@ def test_prometheus_metrics(
         grafana_ip=grafana_ip, grafana_password=grafana_password
     )
 
-    juju.config(app_name, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "1"})
+    juju.config(app_name, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "1"}, log=False)
     _wait_for_runner_ready(juju, app_name)
 
     dispatch_workflow(
@@ -156,7 +153,7 @@ def test_prometheus_metrics(
         dispatch_input={"runner": app_name},
     )
 
-    juju.config(app_name, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "0"})
+    juju.config(app_name, values={BASE_VIRTUAL_MACHINES_CONFIG_NAME: "0"}, log=False)
     _wait_for_no_runners(juju, app_name)
 
     prometheus_ip = prometheus_app.address


### PR DESCRIPTION
## Summary

Disable jubilant logging for all `juju.deploy()`, `juju.config()` and `juju.exec()` calls in integration tests by adding `log=False`.

## Changes

- `tests/integration/test_charm_fork_path_change.py`
- `tests/integration/test_charm_runner.py`
- `tests/integration/helpers/common.py`
- `tests/integration/helpers/openstack.py`
- `tests/integration/test_prometheus_metrics.py`
- `tests/integration/conftest.py`