### PR TITLE
Improve opentelemetry collector 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,11 @@
 
 This changelog documents user-relevant changes to the GitHub runner charm.
 
+## 2026-05-20
+
+- Enhanced OpenTelemetry Collector configuration in the pre-job script to expose local OTLP (gRPC/HTTP) and Loki endpoints for workflow to push observability data.
+- Enable system.cpu.logical.count and system.cpu.physical.count metrics.
+
 ## 2026-04-24
 
 - Exposed the configured GitHub path (org or repository) as a Terraform module output, allowing consumers to make decisions based on which path a runner is registered to.

--- a/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
@@ -234,7 +234,7 @@ processors:
   batch:
 exporters:
   otlp/self_hosted_runner:
-    endpoint: "$ACTION_OTEL_EXPORTER_OTLP_ENDPOINT"
+    endpoint: {{ otel_collector_endpoint }}
     tls:
       insecure: true
 service:

--- a/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
@@ -154,19 +154,12 @@ receivers:
       filesystem:
       network:
       load:
-  journald/self_hosted_runner_aproxy:
-    units:
-      - snap.aproxy.aproxy.service
   otlp:
     protocols:
       grpc:
         endpoint: 0.0.0.0:44317
       http:
         endpoint: 0.0.0.0:44318
-  prometheusremotewrite:
-    endpoint: 0.0.0.0:49090
-    default_external_labels:
-      source: github-runner
   loki:
     protocols:
       http:
@@ -196,39 +189,23 @@ processors:
       - key: github.run.attempt
         action: upsert
         value: "$GITHUB_RUN_ATTEMPT"
-  resource/self_hosted_runner_journald_attributes:
-    attributes:
-      - key: systemd.unit
-        from_attribute: systemd.unit
-        action: upsert
-  transform/self_hosted_runner_journald_loki_labels:
-    log_statements:
-      - context: resource
-        statements:
-          - >
-            set(attributes["loki.resource.labels"],
-            Concat([attributes["loki.resource.labels"], ", systemd.unit"], ""))
-            where attributes["loki.resource.labels"] != nil
-          - >
-            set(attributes["loki.resource.labels"], "systemd.unit")
-            where attributes["loki.resource.labels"] == nil
   transform/self_hosted_runner_loki_labels:
     log_statements:
       - context: resource
         statements:
           - >
-            set(attributes["loki.resource.labels"],
-            Concat([attributes["loki.resource.labels"],
+            set(resource.attributes["loki.resource.labels"],
+            Concat([resource.attributes["loki.resource.labels"],
             ", service.name, github.repository, github.runner, github.workflow, github.job, github.run.id, github.run.attempt"], ""))
-            where attributes["loki.resource.labels"] != nil
+            where resource.attributes["loki.resource.labels"] != nil
           - >
-            set(attributes["loki.resource.labels"],
+            set(resource.attributes["loki.resource.labels"],
             "service.name, github.repository, github.runner, github.workflow, github.job, github.run.id, github.run.attempt")
-            where attributes["loki.resource.labels"] == nil
+            where resource.attributes["loki.resource.labels"] == nil
   batch:
 exporters:
   otlp/self_hosted_runner:
-    endpoint: {{ otel_collector_endpoint }}
+    endpoint: "$ACTION_OTEL_EXPORTER_OTLP_ENDPOINT"
     tls:
       insecure: true
 service:
@@ -240,19 +217,6 @@ service:
     metrics/otlp:
       receivers: [otlp]
       processors: [resource/self_hosted_runner_github_labels, batch]
-      exporters: [otlp/self_hosted_runner]
-    metrics/prometheus:
-      receivers: [prometheusremotewrite]
-      processors: [resource/self_hosted_runner_github_labels, batch]
-      exporters: [otlp/self_hosted_runner]
-    logs:
-      receivers: [journald/self_hosted_runner_aproxy]
-      processors:
-        - resource/self_hosted_runner_journald_attributes
-        - transform/self_hosted_runner_journald_loki_labels
-        - resource/self_hosted_runner_github_labels
-        - transform/self_hosted_runner_loki_labels
-        - batch
       exporters: [otlp/self_hosted_runner]
     logs/otlp:
       receivers: [otlp]

--- a/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
@@ -165,7 +165,7 @@ receivers:
       http:
         endpoint: 0.0.0.0:43100
     use_incoming_timestamp: true
-  filelog/syslog:
+  filelog/aproxy:
     include:
       - /var/log/syslog
     operators:
@@ -267,8 +267,8 @@ service:
         - transform/self_hosted_runner_loki_labels
         - batch
       exporters: [otlp/self_hosted_runner]
-    logs/syslog:
-      receivers: [filelog/syslog]
+    logs/aproxy:
+      receivers: [filelog/aproxy]
       processors:
         - resource/self_hosted_runner_github_labels
         - transform/self_hosted_runner_loki_labels

--- a/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
@@ -157,6 +157,21 @@ receivers:
   journald/self_hosted_runner_aproxy:
     units:
       - snap.aproxy.aproxy.service
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:44317
+      http:
+        endpoint: 0.0.0.0:44318
+  prometheusremotewrite:
+    endpoint: 0.0.0.0:49090
+    default_external_labels:
+      source: github-runner
+  loki:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:43100
+    use_incoming_timestamp: true
 processors:
   resource/self_hosted_runner_github_labels:
     attributes:
@@ -222,6 +237,14 @@ service:
       receivers: [hostmetrics]
       processors: [resource/self_hosted_runner_github_labels, batch]
       exporters: [otlp/self_hosted_runner]
+    metrics/otlp:
+      receivers: [otlp]
+      processors: [resource/self_hosted_runner_github_labels, batch]
+      exporters: [otlp/self_hosted_runner]
+    metrics/prometheus:
+      receivers: [prometheusremotewrite]
+      processors: [resource/self_hosted_runner_github_labels, batch]
+      exporters: [otlp/self_hosted_runner]
     logs:
       receivers: [journald/self_hosted_runner_aproxy]
       processors:
@@ -230,6 +253,24 @@ service:
         - resource/self_hosted_runner_github_labels
         - transform/self_hosted_runner_loki_labels
         - batch
+      exporters: [otlp/self_hosted_runner]
+    logs/otlp:
+      receivers: [otlp]
+      processors:
+        - resource/self_hosted_runner_github_labels
+        - transform/self_hosted_runner_loki_labels
+        - batch
+      exporters: [otlp/self_hosted_runner]
+    logs/loki:
+      receivers: [loki]
+      processors:
+        - resource/self_hosted_runner_github_labels
+        - transform/self_hosted_runner_loki_labels
+        - batch
+      exporters: [otlp/self_hosted_runner]
+    traces:
+      receivers: [otlp]
+      processors: [resource/self_hosted_runner_github_labels, batch]
       exporters: [otlp/self_hosted_runner]
 EOF
 

--- a/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
@@ -144,29 +144,82 @@ receivers:
     collection_interval: 10s
     scrapers:
       cpu:
+        metrics:
+          system.cpu.logical.count:
+            enabled: true
+          system.cpu.physical.count:
+            enabled: true
       memory:
       disk:
       filesystem:
       network:
       load:
+  journald/self_hosted_runner_aproxy:
+    units:
+      - snap.aproxy.aproxy.service
 processors:
-  attributes/github_labels:
-    actions:
-      - key: github_runner
+  resource/self_hosted_runner_github_labels:
+    attributes:
+      - key: service.name
         action: upsert
-        value:  "$RUNNER_NAME"
-      - key: github_workflow
+        value: "self-hosted-runner"
+      - key: github.repository
         action: upsert
-        value:  "$GITHUB_WORKFLOW"
-      - key: github_job
+        value: "$GITHUB_REPOSITORY"
+      - key: github.runner
         action: upsert
-        value:  "$GITHUB_JOB"
-      - key: github_repository
+        value: "$RUNNER_NAME"
+      - key: github.workflow
         action: upsert
-        value:  "$GITHUB_REPOSITORY"
+        value: "$GITHUB_WORKFLOW"
+      - key: github.job
+        action: upsert
+        value: "$GITHUB_JOB"
+      - key: github.run.id
+        action: upsert
+        value: "$GITHUB_RUN_ID"
+      - key: github.run.attempt
+        action: upsert
+        value: "$GITHUB_RUN_ATTEMPT"
+  resource/self_hosted_runner_journald_attributes:
+    attributes:
+      - key: systemd.unit
+        from_attribute: systemd.unit
+        action: upsert
+  transform/self_hosted_runner_journald_loki_labels:
+    log_statements:
+      - context: resource
+        statements:
+          - >
+            set(attributes["loki.resource.labels"],
+            Concat([attributes["loki.resource.labels"], ", systemd.unit"], ""))
+            where attributes["loki.resource.labels"] != nil
+          - >
+            set(attributes["loki.resource.labels"], "systemd.unit")
+            where attributes["loki.resource.labels"] == nil
+  transform/self_hosted_runner_loki_labels:
+    log_statements:
+      - context: resource
+        statements:
+          - >
+            set(attributes["loki.resource.labels"],
+            Concat([attributes["loki.resource.labels"],
+            ", service.name, github.repository, github.runner, github.workflow, github.job, github.run.id, github.run.attempt"], ""))
+            where attributes["loki.resource.labels"] != nil
+          - >
+            set(attributes["loki.resource.labels"],
+            "service.name, github.repository, github.runner, github.workflow, github.job, github.run.id, github.run.attempt")
+            where attributes["loki.resource.labels"] == nil
+          - >
+            set(attributes["loki.attribute.labels"],
+            Concat([attributes["loki.attribute.labels"], ", service.name"], ""))
+            where attributes["loki.attribute.labels"] != nil
+          - >
+            set(attributes["loki.attribute.labels"], "service.name")
+            where attributes["loki.attribute.labels"] == nil
   batch:
 exporters:
-  otlp/mimir:
+  otlp/self_hosted_runner:
     endpoint: {{ otel_collector_endpoint }}
     tls:
       insecure: true
@@ -174,8 +227,17 @@ service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      processors: [attributes/github_labels, batch]
-      exporters: [otlp/mimir]
+      processors: [resource/self_hosted_runner_github_labels, batch]
+      exporters: [otlp/self_hosted_runner]
+    logs:
+      receivers: [journald/self_hosted_runner_aproxy]
+      processors:
+        - resource/self_hosted_runner_journald_attributes
+        - transform/self_hosted_runner_journald_loki_labels
+        - resource/self_hosted_runner_github_labels
+        - transform/self_hosted_runner_loki_labels
+        - batch
+      exporters: [otlp/self_hosted_runner]
 EOF
 
 /usr/bin/sudo /usr/bin/snap enable opentelemetry-collector

--- a/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
@@ -165,6 +165,12 @@ receivers:
       http:
         endpoint: 0.0.0.0:43100
     use_incoming_timestamp: true
+  filelog/syslog:
+    include:
+      - /var/log/syslog
+    operators:
+      - type: filter
+        expr: 'body not matches "aproxy.aproxy"'
 processors:
   attributes/self_hosted_runner_github_labels:
     actions:
@@ -256,6 +262,13 @@ service:
       exporters: [otlp/self_hosted_runner]
     logs/loki:
       receivers: [loki]
+      processors:
+        - resource/self_hosted_runner_github_labels
+        - transform/self_hosted_runner_loki_labels
+        - batch
+      exporters: [otlp/self_hosted_runner]
+    logs/syslog:
+      receivers: [filelog/syslog]
       processors:
         - resource/self_hosted_runner_github_labels
         - transform/self_hosted_runner_loki_labels

--- a/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
@@ -166,8 +166,8 @@ receivers:
         endpoint: 0.0.0.0:43100
     use_incoming_timestamp: true
 processors:
-  resource/self_hosted_runner_github_labels:
-    attributes:
+  attributes/self_hosted_runner_github_labels:
+    actions:
       - key: service.name
         action: upsert
         value: "self-hosted-runner"
@@ -189,6 +189,21 @@ processors:
       - key: github.run.attempt
         action: upsert
         value: "$GITHUB_RUN_ATTEMPT"
+      - key: host.arch
+        action: upsert
+        value: "$(uname -m)"
+  transform/self_hosted_runner_attributes_to_resource:
+    log_statements:
+      - context: log
+        statements:
+          - set(resource.attributes["service.name"], attributes["service.name"]) where attributes["service.name"] != nil
+          - set(resource.attributes["github.repository"], attributes["github.repository"]) where attributes["github.repository"] != nil
+          - set(resource.attributes["github.runner"], attributes["github.runner"]) where attributes["github.runner"] != nil
+          - set(resource.attributes["github.workflow"], attributes["github.workflow"]) where attributes["github.workflow"] != nil
+          - set(resource.attributes["github.job"], attributes["github.job"]) where attributes["github.job"] != nil
+          - set(resource.attributes["github.run.id"], attributes["github.run.id"]) where attributes["github.run.id"] != nil
+          - set(resource.attributes["github.run.attempt"], attributes["github.run.attempt"]) where attributes["github.run.attempt"] != nil
+          - set(resource.attributes["host.arch"], attributes["host.arch"]) where attributes["host.arch"] != nil
   transform/self_hosted_runner_loki_labels:
     log_statements:
       - context: resource
@@ -196,11 +211,11 @@ processors:
           - >
             set(resource.attributes["loki.resource.labels"],
             Concat([resource.attributes["loki.resource.labels"],
-            ", service.name, github.repository, github.runner, github.workflow, github.job, github.run.id, github.run.attempt"], ""))
+            ", service.name, github.repository, github.runner, github.workflow, github.job, github.run.id, github.run.attempt, host.arch"], ""))
             where resource.attributes["loki.resource.labels"] != nil
           - >
             set(resource.attributes["loki.resource.labels"],
-            "service.name, github.repository, github.runner, github.workflow, github.job, github.run.id, github.run.attempt")
+            "service.name, github.repository, github.runner, github.workflow, github.job, github.run.id, github.run.attempt, host.arch")
             where resource.attributes["loki.resource.labels"] == nil
   batch:
 exporters:
@@ -212,29 +227,31 @@ service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      processors: [resource/self_hosted_runner_github_labels, batch]
+      processors: [attributes/self_hosted_runner_github_labels, batch]
       exporters: [otlp/self_hosted_runner]
     metrics/otlp:
       receivers: [otlp]
-      processors: [resource/self_hosted_runner_github_labels, batch]
+      processors: [attributes/self_hosted_runner_github_labels, batch]
       exporters: [otlp/self_hosted_runner]
     logs/otlp:
       receivers: [otlp]
       processors:
-        - resource/self_hosted_runner_github_labels
+        - attributes/self_hosted_runner_github_labels
+        - transform/self_hosted_runner_attributes_to_resource
         - transform/self_hosted_runner_loki_labels
         - batch
       exporters: [otlp/self_hosted_runner]
     logs/loki:
       receivers: [loki]
       processors:
-        - resource/self_hosted_runner_github_labels
+        - attributes/self_hosted_runner_github_labels
+        - transform/self_hosted_runner_attributes_to_resource
         - transform/self_hosted_runner_loki_labels
         - batch
       exporters: [otlp/self_hosted_runner]
     traces:
       receivers: [otlp]
-      processors: [resource/self_hosted_runner_github_labels, batch]
+      processors: [attributes/self_hosted_runner_github_labels, batch]
       exporters: [otlp/self_hosted_runner]
 EOF
 

--- a/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
@@ -224,6 +224,11 @@ processors:
       - key: host.arch
         action: upsert
         value: "$(uname -m)"
+  resource/self_hosted_runner_github_aproxy_labels:
+    attributes:
+      - key: service.name
+        action: upsert
+        value: "aproxy"
   transform/self_hosted_runner_loki_labels:
     log_statements:
       - context: resource
@@ -271,6 +276,7 @@ service:
       receivers: [filelog/aproxy]
       processors:
         - resource/self_hosted_runner_github_labels
+        - resource/self_hosted_runner_github_aproxy_labels
         - transform/self_hosted_runner_loki_labels
         - batch
       exporters: [otlp/self_hosted_runner]

--- a/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
@@ -210,13 +210,6 @@ processors:
             set(attributes["loki.resource.labels"],
             "service.name, github.repository, github.runner, github.workflow, github.job, github.run.id, github.run.attempt")
             where attributes["loki.resource.labels"] == nil
-          - >
-            set(attributes["loki.attribute.labels"],
-            Concat([attributes["loki.attribute.labels"], ", service.name"], ""))
-            where attributes["loki.attribute.labels"] != nil
-          - >
-            set(attributes["loki.attribute.labels"], "service.name")
-            where attributes["loki.attribute.labels"] == nil
   batch:
 exporters:
   otlp/self_hosted_runner:

--- a/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/pre-job.j2
@@ -192,18 +192,32 @@ processors:
       - key: host.arch
         action: upsert
         value: "$(uname -m)"
-  transform/self_hosted_runner_attributes_to_resource:
-    log_statements:
-      - context: log
-        statements:
-          - set(resource.attributes["service.name"], attributes["service.name"]) where attributes["service.name"] != nil
-          - set(resource.attributes["github.repository"], attributes["github.repository"]) where attributes["github.repository"] != nil
-          - set(resource.attributes["github.runner"], attributes["github.runner"]) where attributes["github.runner"] != nil
-          - set(resource.attributes["github.workflow"], attributes["github.workflow"]) where attributes["github.workflow"] != nil
-          - set(resource.attributes["github.job"], attributes["github.job"]) where attributes["github.job"] != nil
-          - set(resource.attributes["github.run.id"], attributes["github.run.id"]) where attributes["github.run.id"] != nil
-          - set(resource.attributes["github.run.attempt"], attributes["github.run.attempt"]) where attributes["github.run.attempt"] != nil
-          - set(resource.attributes["host.arch"], attributes["host.arch"]) where attributes["host.arch"] != nil
+  resource/self_hosted_runner_github_labels:
+    attributes:
+      - key: service.name
+        action: upsert
+        value: "self-hosted-runner"
+      - key: github.repository
+        action: upsert
+        value: "$GITHUB_REPOSITORY"
+      - key: github.runner
+        action: upsert
+        value: "$RUNNER_NAME"
+      - key: github.workflow
+        action: upsert
+        value: "$GITHUB_WORKFLOW"
+      - key: github.job
+        action: upsert
+        value: "$GITHUB_JOB"
+      - key: github.run.id
+        action: upsert
+        value: "$GITHUB_RUN_ID"
+      - key: github.run.attempt
+        action: upsert
+        value: "$GITHUB_RUN_ATTEMPT"
+      - key: host.arch
+        action: upsert
+        value: "$(uname -m)"
   transform/self_hosted_runner_loki_labels:
     log_statements:
       - context: resource
@@ -236,22 +250,20 @@ service:
     logs/otlp:
       receivers: [otlp]
       processors:
-        - attributes/self_hosted_runner_github_labels
-        - transform/self_hosted_runner_attributes_to_resource
+        - resource/self_hosted_runner_github_labels
         - transform/self_hosted_runner_loki_labels
         - batch
       exporters: [otlp/self_hosted_runner]
     logs/loki:
       receivers: [loki]
       processors:
-        - attributes/self_hosted_runner_github_labels
-        - transform/self_hosted_runner_attributes_to_resource
+        - resource/self_hosted_runner_github_labels
         - transform/self_hosted_runner_loki_labels
         - batch
       exporters: [otlp/self_hosted_runner]
     traces:
       receivers: [otlp]
-      processors: [attributes/self_hosted_runner_github_labels, batch]
+      processors: [resource/self_hosted_runner_github_labels, batch]
       exporters: [otlp/self_hosted_runner]
 EOF
 

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
@@ -197,7 +197,7 @@ def test_create_runner_without_aproxy(
 
     runner_manager.create_runner(identity, runner_context)
     openstack_cloud.launch_instance.assert_called_once()
-    assert "aproxy" not in openstack_cloud.launch_instance.call_args.kwargs["cloud_init"]
+    assert "snap install aproxy" not in openstack_cloud.launch_instance.call_args.kwargs["cloud_init"]
 
 
 def test_delete_vms(runner_manager: OpenStackRunnerManager):

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
@@ -197,7 +197,9 @@ def test_create_runner_without_aproxy(
 
     runner_manager.create_runner(identity, runner_context)
     openstack_cloud.launch_instance.assert_called_once()
-    assert "snap install aproxy" not in openstack_cloud.launch_instance.call_args.kwargs["cloud_init"]
+    assert (
+        "snap install aproxy" not in openstack_cloud.launch_instance.call_args.kwargs["cloud_init"]
+    )
 
 
 def test_delete_vms(runner_manager: OpenStackRunnerManager):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -527,8 +527,6 @@ def image_builder_config_fixture(
         "build-interval": "12",
         "revision-history-limit": "2",
         "openstack-auth-url": openstack_config.auth_url,
-        # Bandit thinks this is a hardcoded password
-        "openstack-password": openstack_config.password,  # nosec: B105
         "openstack-project-domain-name": openstack_config.project_domain_name,
         "openstack-project-name": openstack_config.project_name,
         "openstack-user-domain-name": openstack_config.user_domain_name,
@@ -561,11 +559,20 @@ def image_builder_fixture(
 
     if not openstack_config.test_image_id:
         logging.info("Deploying image builder %s", image_builder_app_name)
+        password_secret_name = f"{image_builder_app_name}-openstack-password"
+        password_secret_id = juju.add_secret(
+            name=password_secret_name,
+            content={"password": openstack_config.password},
+        )
+        deploy_config = {
+            **image_builder_config,
+            "openstack-password-secret": str(password_secret_id),
+        }
         juju.deploy(
             "github-runner-image-builder",
             app=image_builder_app_name,
             channel="latest/edge",
-            config=image_builder_config,
+            config=deploy_config,
             constraints={
                 "root-disk": "20480M",
                 "mem": "2048M",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -582,6 +582,7 @@ def image_builder_fixture(
                 "cores": "2",
             },
         )
+        juju.grant_secret(password_secret_name, image_builder_app_name)
 
         yield image_builder_app_name
 


### PR DESCRIPTION
#### What this PR does

Enhanced OpenTelemetry Collector configuration in the pre-job script to properly expose local endpoints for metrics, logs, and traces collection with automatic GitHub workflow context labeling. Also adding `system.cpu.logical.count` and `system.cpu.physical.count` metrics.

#### Why we need it

This addition allows users to more easily upload workload custom metrics, logs, and traces to the action COS. Also, this will help us understand and plan the resource usage for self-hosted runners.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If this is a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this is Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If the github-runner-manager application has been changed:** The application version number is updated in `github-runner-manager/pyproject.toml`.
