### PR TITLE
Fix the publish workflow permission

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -10,3 +10,6 @@ jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
#### What this PR does

Fix the publish workflow permission.


#### Why we need it

The default organization causes the publish workflow to fail

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If this is a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this is Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If the github-runner-manager application has been changed:** The application version number is updated in `github-runner-manager/pyproject.toml`.
