### PR TITLE
fix(ci): generate coverage XML for manager app so TiCS can ingest it

### DIFF
--- a/github-runner-manager/tox.ini
+++ b/github-runner-manager/tox.ini
@@ -89,6 +89,7 @@ deps =
     pytest
     -r{toxinidir}/requirements.txt
 commands =
+    coverage xml -o coverage/coverage.xml
     coverage report
 
 [testenv:static]


### PR DESCRIPTION
#### What this PR does

Adds `coverage xml -o coverage/coverage.xml` to the `coverage-report` tox env in `github-runner-manager/tox.ini`.

The TiCS workflow runs coverage for both the charm (root `tox.ini`) and the manager app (`github-runner-manager/tox.ini`). The root env already produced an XML report, but the manager's `coverage-report` env only ran `coverage report` (a terminal summary) and never emitted XML.

#### Why we need it

TiCS scans the workspace for a coverage XML report to ingest unit-test coverage. With no XML produced for the manager app, TiCS was blocked. This change makes the manager env emit `coverage/coverage.xml`, matching the root `tox.ini` pattern.

Verified locally: `tox -e unit,coverage-report` in `github-runner-manager/` now writes a valid Cobertura XML report (86% coverage, above the `fail_under=73` threshold).

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable) — N/A, CI-only change
- [ ] I updated `docs/changelog.md` with user-relevant changes — N/A, no user-facing change
- [x] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration) — N/A, CI config change
- [ ] **If this is a Grafana dashboard:** I added a screenshot of the dashboard — N/A
- [ ] **If this is Terraform:** `terraform fmt` passes and `tflint` reports no errors — N/A
- [ ] **If the github-runner-manager application has been changed:** The application version number is updated in `github-runner-manager/pyproject.toml`. — N/A, no application code change (tox config only)