### PR TITLE
Limit aproxy nftables redirection to egress traffic only

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 This changelog documents user-relevant changes to the GitHub runner charm.
 
+## 2026-07-14
+
+- aproxy now only redirects traffic leaving the runner's default-route interface(s), so local traffic is no longer captured and private ranges no longer need to be added to `aproxy-exclude-addresses`.
+
 ## 2026-06-26
 
 - Fixed runners whose cloud VM entered an error state being kept until the creation timeout (~23 minutes) before cleanup. Such VMs are now cleaned up immediately, freeing the slot for a replacement runner.

--- a/github-runner-manager/pyproject.toml
+++ b/github-runner-manager/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "github-runner-manager"
-version = "0.18.2"
+version = "0.18.3"
 authors = [
     { name = "Canonical IS DevOps", email = "is-devops-team@canonical.com" },
 ]

--- a/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
+++ b/github-runner-manager/src/github_runner_manager/templates/openstack-userdata.sh.j2
@@ -15,6 +15,7 @@ snap install aproxy --edge
 snap set aproxy proxy={{ aproxy_address }} listen=:54969
 cat << EOF > /etc/nftables.conf
 define default-ipv4 = $(ip route get $(ip route show 0.0.0.0/0 | grep -oP 'via \K\S+') | grep -oP 'src \K\S+')
+define nics = { $(ip route show 0.0.0.0/0 | grep -oP 'dev \K\S+' | sort -u | sed 's/.*/"&"/' | paste -sd,) }
 table ip aproxy
 flush table ip aproxy
 table ip aproxy {
@@ -25,10 +26,12 @@ table ip aproxy {
       }
       chain prerouting {
               type nat hook prerouting priority dstnat; policy accept;
+              fib daddr oifname != \$nics return
               ip daddr != @exclude tcp dport { {{ aproxy_redirect_ports }} } counter dnat to \$default-ipv4:54969
       }
       chain output {
               type nat hook output priority -100; policy accept;
+              oifname != \$nics return
               ip daddr != @exclude tcp dport { {{ aproxy_redirect_ports }} } counter dnat to \$default-ipv4:54969
       }
 }

--- a/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
+++ b/github-runner-manager/tests/unit/openstack_cloud/test_openstack_runner_manager.py
@@ -100,10 +100,12 @@ def runner_metrics_mock_fixture(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
           }
           chain prerouting {
                   type nat hook prerouting priority dstnat; policy accept;
+                  fib daddr oifname != \\$nics return
                   ip daddr != @exclude tcp dport { 80, 443 } counter dnat to \\$default-ipv4:54969
           }
           chain output {
                   type nat hook output priority -100; policy accept;
+                  oifname != \\$nics return
                   ip daddr != @exclude tcp dport { 80, 443 } counter dnat to \\$default-ipv4:54969
           }
     }
@@ -123,10 +125,12 @@ def runner_metrics_mock_fixture(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
           }
           chain prerouting {
                   type nat hook prerouting priority dstnat; policy accept;
+                  fib daddr oifname != \\$nics return
                   ip daddr != @exclude tcp dport { 80, 443 } counter dnat to \\$default-ipv4:54969
           }
           chain output {
                   type nat hook output priority -100; policy accept;
+                  oifname != \\$nics return
                   ip daddr != @exclude tcp dport { 80, 443 } counter dnat to \\$default-ipv4:54969
           }
     }


### PR DESCRIPTION
#### What this PR does

Update the aproxy transparent proxy nftables rules  so they only redirect traffic leaving the runner's default-route ("physical") interfaces.

#### Why we need it

This can simplify the `aproxy-exclude-addresses` configuration, as we don't need to include the private IP ranges by default, and we only need to include the actual IP addresses that we need to exclude. Also, this would help reduce the chances of IP range conflicts between internal services, like MicroK8s, Docker, and LXD, and external services within the infrastructure using private IP addresses.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If this is a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this is Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If the github-runner-manager application has been changed:** The application version number is updated in `github-runner-manager/pyproject.toml`.
